### PR TITLE
Feature/debug mom6

### DIFF
--- a/src/user/MOM_wave_interface.F90
+++ b/src/user/MOM_wave_interface.F90
@@ -1022,6 +1022,8 @@ subroutine get_StokesSL_LiFoxKemper(ustar, hbl, GV, US, UStokes_SL, LA)
   real :: z0, z0i, r1, r2, r3, r4, tmp, lasl_sqr_i
   real :: u10
 
+  UStokes_sl = 0.0
+  LA=1.e8
   if (ustar > 0.0) then
     ! Computing u10 based on u_star and COARE 3.5 relationships
     call ust_2_u10_coare3p5(US%Z_to_m*US%s_to_T*ustar*sqrt(GV%Rho0/1.225), u10, GV, US)
@@ -1069,15 +1071,7 @@ subroutine get_StokesSL_LiFoxKemper(ustar, hbl, GV, US, UStokes_SL, LA)
          sqrt( 2.0 * PI *kstar * z0) * &
          erfc( sqrt( 2.0 * kstar * z0 ) )
     UStokes_sl = UStokes * (0.715 + r1 + r2 + r3 + r4)
-    if(UStokes_sl .ne. 0.0)then
-      LA = sqrt(US%Z_to_m*US%s_to_T*ustar / UStokes_sl)
-    else
-     UStokes_sl = 0.0
-     LA=1.e8
-    endif
-  else
-    UStokes_sl = 0.0
-    LA=1.e8
+    if(UStokes_sl .ne. 0.0)LA = sqrt(US%Z_to_m*US%s_to_T*ustar / UStokes_sl)
   endif
 
 end subroutine Get_StokesSL_LiFoxKemper

--- a/src/user/MOM_wave_interface.F90
+++ b/src/user/MOM_wave_interface.F90
@@ -1072,11 +1072,12 @@ subroutine get_StokesSL_LiFoxKemper(ustar, hbl, GV, US, UStokes_SL, LA)
     if(UStokes_sl .ne. 0.0)then
       LA = sqrt(US%Z_to_m*US%s_to_T*ustar / UStokes_sl)
     else
-      LA=1.e8
+     UStokes_sl = 0.0
+     LA=1.e8
     endif
-  !else
-  !  UStokes_sl = 0.0
-  !  LA=1.e8
+  else
+    UStokes_sl = 0.0
+    LA=1.e8
   endif
 
 end subroutine Get_StokesSL_LiFoxKemper

--- a/src/user/MOM_wave_interface.F90
+++ b/src/user/MOM_wave_interface.F90
@@ -1069,10 +1069,14 @@ subroutine get_StokesSL_LiFoxKemper(ustar, hbl, GV, US, UStokes_SL, LA)
          sqrt( 2.0 * PI *kstar * z0) * &
          erfc( sqrt( 2.0 * kstar * z0 ) )
     UStokes_sl = UStokes * (0.715 + r1 + r2 + r3 + r4)
-    LA = sqrt(US%Z_to_m*US%s_to_T*ustar / UStokes_sl)
-  else
-    UStokes_sl = 0.0
-    LA=1.e8
+    if(UStokes_sl .ne. 0.0)then
+      LA = sqrt(US%Z_to_m*US%s_to_T*ustar / UStokes_sl)
+    else
+      LA=1.e8
+    endif
+  !else
+  !  UStokes_sl = 0.0
+  !  LA=1.e8
   endif
 
 end subroutine Get_StokesSL_LiFoxKemper


### PR DESCRIPTION
Resolves issue #11 . All Regression tests on Hera pass current baselines [https://github.com/DeniseWorthen/ufs-s2s-model/tree/feature/rtmom6debug/log](https://github.com/DeniseWorthen/ufs-s2s-model/tree/feature/rtmom6debug/log)