### PR TITLE
Bugfix for mom6solo to be built

### DIFF
--- a/src/user/MOM_wave_interface.F90
+++ b/src/user/MOM_wave_interface.F90
@@ -452,7 +452,7 @@ subroutine Update_Surface_Waves(G, GV, US, Day, dt, CS, forces)
   type(unit_scale_type),   intent(in)  :: US   !< A dimensional unit scaling type
   type(time_type),         intent(in)  :: Day !< Current model time
   type(time_type),         intent(in)  :: dt  !< Timestep as a time-type
-  type(mech_forcing),      intent(in)  :: forces !< MOM_forcing_type
+  type(mech_forcing),      intent(in), optional  :: forces !< MOM_forcing_type
   ! Local variables
   integer :: ii, jj, kk, b
   type(time_type) :: Day_Center


### PR DESCRIPTION
This PR:
- fixes #41 

Currently, when `dev/emc` is checked out and used to build the mom6 solo executable, it encounters errors as documented in #41 

A patch is provided in this PR.

This should not be treated as a final solution.
A proper solution should be reached with GFDL so that the following files are not diverging from `main`

```
src/core/MOM_forcing_type.F90
src/user/MOM_wave_interface.F90
```