### PR TITLE
Allow MOM6 to use a mesh optionally

### DIFF
--- a/config_src/nuopc_driver/mom_cap.F90
+++ b/config_src/nuopc_driver/mom_cap.F90
@@ -975,7 +975,7 @@ subroutine InitializeRealize(gcomp, importState, exportState, clock, rc)
                 "greater than parameter EPS_OMESH. n, lonMesh(n), lon(n), diff_lon, "//&
                 "EPS_OMESH= ',i8,2(f21.13,3x),2(d21.5))"
          write(err_msg, frmt)n,lonMesh(n),lon(n), diff_lon, eps_omesh
-         call MOM_error(FATAL, err_msg)
+         !call MOM_error(FATAL, err_msg)
        end if
        diff_lat = abs(latMesh(n) - lat(n))
        if (diff_lat > eps_omesh) then
@@ -983,13 +983,13 @@ subroutine InitializeRealize(gcomp, importState, exportState, clock, rc)
                 "greater than parameter EPS_OMESH. n, latMesh(n), lat(n), diff_lat, "//&
                 "EPS_OMESH= ',i8,2(f21.13,3x),2(d21.5))"
          write(err_msg, frmt)n,latMesh(n),lat(n), diff_lat, eps_omesh
-         call MOM_error(FATAL, err_msg)
+         !call MOM_error(FATAL, err_msg)
         end if
         if (abs(maskMesh(n) - mask(n)) > 0) then
           frmt = "('ERROR: ESMF mesh and MOM6 domain masks are inconsistent! - "//&
                  "MOM n, maskMesh(n), mask(n) = ',3(i8,2x))"
           write(err_msg, frmt)n,maskMesh(n),mask(n)
-          call MOM_error(FATAL, err_msg)
+          !call MOM_error(FATAL, err_msg)
         end if
      end do
 

--- a/config_src/nuopc_driver/mom_cap.F90
+++ b/config_src/nuopc_driver/mom_cap.F90
@@ -73,7 +73,8 @@ use ESMF,  only: ESMF_RC_FILE_OPEN, ESMF_RC_FILE_READ, ESMF_RC_FILE_WRITE
 use ESMF,  only: ESMF_VMBroadcast
 use ESMF,  only: ESMF_AlarmCreate, ESMF_ClockGetAlarmList, ESMF_AlarmList_Flag
 use ESMF,  only: ESMF_AlarmGet, ESMF_AlarmIsCreated, ESMF_ALARMLIST_ALL, ESMF_AlarmIsEnabled
-use ESMF,  only: ESMF_STATEITEM_NOTFOUND, ESMF_FieldWrite
+use ESMF,  only: ESMF_STATEITEM_NOTFOUND, ESMF_FieldWrite 
+use ESMF,  only: ESMF_END_ABORT, ESMF_Finalize
 use ESMF,  only: operator(==), operator(/=), operator(+), operator(-)
 
 ! TODO ESMF_GridCompGetInternalState does not have an explicit Fortran interface.
@@ -134,6 +135,7 @@ integer              :: logunit  !< stdout logging unit number
 logical              :: profile_memory = .true.
 logical              :: grid_attach_area = .false.
 logical              :: use_coldstart = .true.
+logical              :: use_mommesh = .false.
 character(len=128)   :: scalar_field_name = ''
 integer              :: scalar_field_count = 0
 integer              :: scalar_field_idx_grid_nx = 0
@@ -146,9 +148,11 @@ logical :: cesm_coupled = .true.
 type(ESMF_GeomType_Flag) :: geomtype = ESMF_GEOMTYPE_MESH
 #else
 logical :: cesm_coupled = .false.
-type(ESMF_GeomType_Flag) :: geomtype = ESMF_GEOMTYPE_GRID
+!type(ESMF_GeomType_Flag) :: geomtype = ESMF_GEOMTYPE_GRID
+!type(ESMF_GeomType_Flag) :: geomtype = ESMF_GEOMTYPE_MESH
 #endif
 character(len=8) :: restart_mode = 'alarms'
+type(ESMF_GeomType_Flag) :: geomtype
 
 contains
 
@@ -345,6 +349,25 @@ subroutine InitializeP0(gcomp, importState, exportState, clock, rc)
   if (isPresent .and. isSet) use_coldstart=(trim(value)=="true")
   write(logmsg,*) use_coldstart
   call ESMF_LogWrite('MOM_cap:use_coldstart = '//trim(logmsg), ESMF_LOGMSG_INFO)
+
+  use_mommesh = .false.
+  call NUOPC_CompAttributeGet(gcomp, name="use_mommesh", value=value, &
+       isPresent=isPresent, isSet=isSet, rc=rc)
+  if (ChkErr(rc,__LINE__,u_FILE_u)) return
+  if (isPresent .and. isSet) use_mommesh=(trim(value)=="true")
+  write(logmsg,*) use_mommesh
+  call ESMF_LogWrite('MOM_cap:use_mommesh = '//trim(logmsg), ESMF_LOGMSG_INFO)
+
+  if(use_mommesh)then
+    geomtype = ESMF_GEOMTYPE_MESH
+    call NUOPC_CompAttributeGet(gcomp, name='mesh_ocn', isPresent=isPresent, isSet=isSet, rc=rc)
+      if (.not. isPresent .and. .not. isSet) then
+        call ESMF_LogWrite('geomtype set to mesh but mesh_ocn is not specified', ESMF_LOGMSG_INFO)
+        call ESMF_Finalize(endflag=ESMF_END_ABORT)
+     endif
+  else
+    geomtype = ESMF_GEOMTYPE_GRID
+  endif
 
 end subroutine
 

--- a/config_src/nuopc_driver/mom_cap.F90
+++ b/config_src/nuopc_driver/mom_cap.F90
@@ -74,7 +74,7 @@ use ESMF,  only: ESMF_RC_FILE_OPEN, ESMF_RC_FILE_READ, ESMF_RC_FILE_WRITE
 use ESMF,  only: ESMF_VMBroadcast
 use ESMF,  only: ESMF_AlarmCreate, ESMF_ClockGetAlarmList, ESMF_AlarmList_Flag
 use ESMF,  only: ESMF_AlarmGet, ESMF_AlarmIsCreated, ESMF_ALARMLIST_ALL, ESMF_AlarmIsEnabled
-use ESMF,  only: ESMF_STATEITEM_NOTFOUND, ESMF_FieldWrite 
+use ESMF,  only: ESMF_STATEITEM_NOTFOUND, ESMF_FieldWrite
 use ESMF,  only: ESMF_END_ABORT, ESMF_Finalize
 use ESMF,  only: operator(==), operator(/=), operator(+), operator(-)
 
@@ -149,11 +149,9 @@ logical :: cesm_coupled = .true.
 type(ESMF_GeomType_Flag) :: geomtype = ESMF_GEOMTYPE_MESH
 #else
 logical :: cesm_coupled = .false.
-!type(ESMF_GeomType_Flag) :: geomtype = ESMF_GEOMTYPE_GRID
-!type(ESMF_GeomType_Flag) :: geomtype = ESMF_GEOMTYPE_MESH
+type(ESMF_GeomType_Flag) :: geomtype
 #endif
 character(len=8) :: restart_mode = 'alarms'
-type(ESMF_GeomType_Flag) :: geomtype
 
 contains
 
@@ -976,7 +974,7 @@ subroutine InitializeRealize(gcomp, importState, exportState, clock, rc)
                 "greater than parameter EPS_OMESH. n, lonMesh(n), lon(n), diff_lon, "//&
                 "EPS_OMESH= ',i8,2(f21.13,3x),2(d21.5))"
          write(err_msg, frmt)n,lonMesh(n),lon(n), diff_lon, eps_omesh
-         !call MOM_error(FATAL, err_msg)
+         call MOM_error(FATAL, err_msg)
        end if
        diff_lat = abs(latMesh(n) - lat(n))
        if (diff_lat > eps_omesh) then
@@ -984,13 +982,13 @@ subroutine InitializeRealize(gcomp, importState, exportState, clock, rc)
                 "greater than parameter EPS_OMESH. n, latMesh(n), lat(n), diff_lat, "//&
                 "EPS_OMESH= ',i8,2(f21.13,3x),2(d21.5))"
          write(err_msg, frmt)n,latMesh(n),lat(n), diff_lat, eps_omesh
-         !call MOM_error(FATAL, err_msg)
+         call MOM_error(FATAL, err_msg)
         end if
         if (abs(maskMesh(n) - mask(n)) > 0) then
           frmt = "('ERROR: ESMF mesh and MOM6 domain masks are inconsistent! - "//&
                  "MOM n, maskMesh(n), mask(n) = ',3(i8,2x))"
           write(err_msg, frmt)n,maskMesh(n),mask(n)
-          !call MOM_error(FATAL, err_msg)
+          call MOM_error(FATAL, err_msg)
         end if
      end do
 


### PR DESCRIPTION
Implements configurable settings which allow specifying that the MOM6 cap should use a mesh rather than a grid. The default is to use the grid, which is the current use in ufs-weather-model (both cpld and datm). Once MOM6 Issue #47 is resolved, we can switch the ufs-weather-model to use the Mesh by default.

See UFS issue [#398](https://github.com/ufs-community/ufs-weather-model/issues/398) for details and related PR [#399](https://github.com/ufs-community/ufs-weather-model/pull/399)