### PR TITLE
update to MOM6 main 20230206 commit 

### DIFF
--- a/.github/actions/ubuntu-setup/action.yml
+++ b/.github/actions/ubuntu-setup/action.yml
@@ -13,7 +13,7 @@ runs:
         sudo apt-get install netcdf-bin
         sudo apt-get install libnetcdf-dev
         sudo apt-get install libnetcdff-dev
-        sudo apt-get install mpich
-        sudo apt-get install libmpich-dev
+        sudo apt-get install openmpi-bin
+        sudo apt-get install libopenmpi-dev
         sudo apt-get install linux-tools-common
         echo "::endgroup::"


### PR DESCRIPTION
MOM6 main is updated on 20230206, this is based on EMC ungridded dimension of pstokes PR (https://github.com/mom-ocean/MOM6/pull/1591), but cherry-picked the fixing of CI commit from dev/gfdl.
Corresponding issue #110 
No code change being involved in this PR