### PR TITLE
switch to cesm-style field names in MOM6 cap

### DIFF
--- a/config_src/drivers/nuopc_cap/mom_cap.F90
+++ b/config_src/drivers/nuopc_cap/mom_cap.F90
@@ -724,40 +724,37 @@ subroutine InitializeAdvertise(gcomp, importState, exportState, clock, rc)
     call fld_list_add(fldsFrOcn_num, fldsFrOcn, trim(scalar_field_name), "will_provide")
   endif
 
-
   !--------- import fields -------------
-  call fld_list_add(fldsToOcn_num, fldsToOcn, "mean_salt_rate"             , "will provide") ! from ice
-  call fld_list_add(fldsToOcn_num, fldsToOcn, "mean_zonal_moment_flx"      , "will provide")
-  call fld_list_add(fldsToOcn_num, fldsToOcn, "mean_merid_moment_flx"      , "will provide")
-  call fld_list_add(fldsToOcn_num, fldsToOcn, "mean_sensi_heat_flx"        , "will provide")
-  call fld_list_add(fldsToOcn_num, fldsToOcn, "mean_evap_rate"             , "will provide")
-  call fld_list_add(fldsToOcn_num, fldsToOcn, "mean_net_lw_flx"            , "will provide")
-  call fld_list_add(fldsToOcn_num, fldsToOcn, "mean_net_sw_vis_dir_flx"    , "will provide")
-  call fld_list_add(fldsToOcn_num, fldsToOcn, "mean_net_sw_vis_dif_flx"    , "will provide")
-  call fld_list_add(fldsToOcn_num, fldsToOcn, "mean_net_sw_ir_dir_flx"     , "will provide")
-  call fld_list_add(fldsToOcn_num, fldsToOcn, "mean_net_sw_ir_dif_flx"     , "will provide")
-  call fld_list_add(fldsToOcn_num, fldsToOcn, "mean_prec_rate"             , "will provide")
-  call fld_list_add(fldsToOcn_num, fldsToOcn, "mean_fprec_rate"            , "will provide")
-  call fld_list_add(fldsToOcn_num, fldsToOcn, "inst_pres_height_surface"   , "will provide")
-  call fld_list_add(fldsToOcn_num, fldsToOcn, "Foxx_rofl"                  , "will provide") !-> liquid runoff
-  call fld_list_add(fldsToOcn_num, fldsToOcn, "Foxx_rofi"                  , "will provide") !-> ice runoff
-  call fld_list_add(fldsToOcn_num, fldsToOcn, "Si_ifrac"                   , "will provide") !-> ice fraction
-  call fld_list_add(fldsToOcn_num, fldsToOcn, "So_duu10n"                  , "will provide") !-> wind^2 at 10m
-  call fld_list_add(fldsToOcn_num, fldsToOcn, "mean_fresh_water_to_ocean_rate", "will provide")
-  call fld_list_add(fldsToOcn_num, fldsToOcn, "net_heat_flx_to_ocn"        , "will provide")
+  call fld_list_add(fldsToOcn_num, fldsToOcn, "Fioi_salt"      , "will provide") ! from ice
+  call fld_list_add(fldsToOcn_num, fldsToOcn, "Foxx_taux"      , "will provide")
+  call fld_list_add(fldsToOcn_num, fldsToOcn, "Foxx_tauy"      , "will provide")
+  call fld_list_add(fldsToOcn_num, fldsToOcn, "Foxx_sen"       , "will provide")
+  call fld_list_add(fldsToOcn_num, fldsToOcn, "Foxx_evap"      , "will provide")
+  call fld_list_add(fldsToOcn_num, fldsToOcn, "Foxx_lwnet"     , "will provide")
+  call fld_list_add(fldsToOcn_num, fldsToOcn, "Foxx_swnet_vdr" , "will provide")
+  call fld_list_add(fldsToOcn_num, fldsToOcn, "Foxx_swnet_vdf" , "will provide")
+  call fld_list_add(fldsToOcn_num, fldsToOcn, "Foxx_swnet_idr" , "will provide")
+  call fld_list_add(fldsToOcn_num, fldsToOcn, "Foxx_swnet_idf" , "will provide")
+  call fld_list_add(fldsToOcn_num, fldsToOcn, "Faxa_rain"      , "will provide")
+  call fld_list_add(fldsToOcn_num, fldsToOcn, "Faxa_snow"      , "will provide")
+  call fld_list_add(fldsToOcn_num, fldsToOcn, "Sa_pslv"        , "will provide")
+  call fld_list_add(fldsToOcn_num, fldsToOcn, "Foxx_rofl"      , "will provide") !-> liquid runoff
+  call fld_list_add(fldsToOcn_num, fldsToOcn, "Foxx_rofi"      , "will provide") !-> ice runoff
+  call fld_list_add(fldsToOcn_num, fldsToOcn, "Si_ifrac"       , "will provide") !-> ice fraction
+  call fld_list_add(fldsToOcn_num, fldsToOcn, "So_duu10n"      , "will provide") !-> wind^2 at 10m
+  call fld_list_add(fldsToOcn_num, fldsToOcn, "Fioi_meltw"     , "will provide")
+  call fld_list_add(fldsToOcn_num, fldsToOcn, "Fioi_melth"     , "will provide")
 
-  if (cesm_coupled) then
-    call fld_list_add(fldsToOcn_num, fldsToOcn, "heat_content_lprec", "will provide")
-    call fld_list_add(fldsToOcn_num, fldsToOcn, "heat_content_fprec", "will provide")
-    call fld_list_add(fldsToOcn_num, fldsToOcn, "heat_content_evap" , "will provide")
-    call fld_list_add(fldsToOcn_num, fldsToOcn, "heat_content_cond" , "will provide")
-    call fld_list_add(fldsToOcn_num, fldsToOcn, "heat_content_rofl" , "will provide")
-    call fld_list_add(fldsToOcn_num, fldsToOcn, "heat_content_rofi" , "will provide")
-  endif
+  call fld_list_add(fldsToOcn_num, fldsToOcn, "Foxx_hrain"     , "will provide")
+  call fld_list_add(fldsToOcn_num, fldsToOcn, "Foxx_hsnow"     , "will provide")
+  call fld_list_add(fldsToOcn_num, fldsToOcn, "Foxx_hevap"     , "will provide")
+  call fld_list_add(fldsToOcn_num, fldsToOcn, "Foxx_hcond"     , "will provide")
+  call fld_list_add(fldsToOcn_num, fldsToOcn, "Foxx_hrofl"     , "will provide")
+  call fld_list_add(fldsToOcn_num, fldsToOcn, "Foxx_hrofi"     , "will provide")
 
   if (use_waves) then
     if (wave_method == "EFACTOR") then
-      call fld_list_add(fldsToOcn_num, fldsToOcn, "Sw_lamult"                 , "will provide")
+      call fld_list_add(fldsToOcn_num, fldsToOcn, "Sw_lamult"   , "will provide")
     else if (wave_method == "SURFACE_BANDS") then
       call fld_list_add(fldsToOcn_num, fldsToOcn, "Sw_pstokes_x", "will provide", &
         ungridded_lbound=1, ungridded_ubound=Ice_ocean_boundary%num_stk_bands)
@@ -769,15 +766,15 @@ subroutine InitializeAdvertise(gcomp, importState, exportState, clock, rc)
   endif
 
   !--------- export fields -------------
-  call fld_list_add(fldsFrOcn_num, fldsFrOcn, "ocean_mask"                 , "will provide")
-  call fld_list_add(fldsFrOcn_num, fldsFrOcn, "sea_surface_temperature"    , "will provide")
-  call fld_list_add(fldsFrOcn_num, fldsFrOcn, "s_surf"                     , "will provide")
-  call fld_list_add(fldsFrOcn_num, fldsFrOcn, "ocn_current_zonal"          , "will provide")
-  call fld_list_add(fldsFrOcn_num, fldsFrOcn, "ocn_current_merid"          , "will provide")
-  call fld_list_add(fldsFrOcn_num, fldsFrOcn, "sea_surface_slope_zonal"    , "will provide")
-  call fld_list_add(fldsFrOcn_num, fldsFrOcn, "sea_surface_slope_merid"    , "will provide")
-  call fld_list_add(fldsFrOcn_num, fldsFrOcn, "freezing_melting_potential" , "will provide")
-  call fld_list_add(fldsFrOcn_num, fldsFrOcn, "So_bldepth"                 , "will provide")
+  call fld_list_add(fldsFrOcn_num, fldsFrOcn, "So_omask"   , "will provide")
+  call fld_list_add(fldsFrOcn_num, fldsFrOcn, "So_t"       , "will provide")
+  call fld_list_add(fldsFrOcn_num, fldsFrOcn, "So_s"       , "will provide")
+  call fld_list_add(fldsFrOcn_num, fldsFrOcn, "So_u"       , "will provide")
+  call fld_list_add(fldsFrOcn_num, fldsFrOcn, "So_v"       , "will provide")
+  call fld_list_add(fldsFrOcn_num, fldsFrOcn, "So_dhdx"    , "will provide")
+  call fld_list_add(fldsFrOcn_num, fldsFrOcn, "So_dhdy"    , "will provide")
+  call fld_list_add(fldsFrOcn_num, fldsFrOcn, "Fioo_q"     , "will provide")
+  call fld_list_add(fldsFrOcn_num, fldsFrOcn, "So_bldepth" , "will provide")
 
   do n = 1,fldsToOcn_num
     call NUOPC_Advertise(importState, standardName=fldsToOcn(n)%stdname, name=fldsToOcn(n)%shortname, rc=rc)
@@ -1627,7 +1624,7 @@ subroutine ModelAdvance(gcomp, rc)
     ! Import data
     !---------------
 
-    call mom_import(ocean_public, ocean_grid, importState, ice_ocean_boundary, cesm_coupled, rc=rc)
+    call mom_import(ocean_public, ocean_grid, importState, ice_ocean_boundary, rc=rc)
     if (ChkErr(rc,__LINE__,u_FILE_u)) return
 
     !---------------
@@ -2433,7 +2430,7 @@ end subroutine shr_log_setLogUnit
 !!     <th>Description</td>
 !!     <th>Notes</td>
 !! <tr>
-!!     <td>inst_pres_height_surface</td>
+!!     <td>Sa_pslv</td>
 !!     <td>Pa</td>
 !!     <td>p</td>
 !!     <td>pressure of overlying sea ice and atmosphere</td>
@@ -2447,14 +2444,14 @@ end subroutine shr_log_setLogUnit
 !!     <td></td>
 !! </tr>
 !! <tr>
-!!     <td>seaice_melt_heat</td>
+!!     <td>Fioi_melth</td>
 !!     <td>W m-2</td>
 !!     <td>seaice_melt_heat</td>
 !!     <td>sea ice and snow melt heat flux</td>
 !!     <td></td>
 !! </tr>
 !! <tr>
-!!     <td>seaice_melt</td>
+!!     <td>Fioi_meltw</td>
 !!     <td>kg m-2 s-1</td>
 !!     <td>seaice_melt</td>
 !!     <td>water flux due to sea ice and snow melting</td>
@@ -2468,136 +2465,143 @@ end subroutine shr_log_setLogUnit
 !!     <td></td>
 !! </tr>
 !! <tr>
-!!     <td>mean_evap_rate</td>
+!!     <td>Foxx_evap</td>
 !!     <td>kg m-2 s-1</td>
 !!     <td>q_flux</td>
 !!     <td>specific humidity flux</td>
 !!     <td></td>
 !! </tr>
 !! <tr>
-!!     <td>mean_fprec_rate</td>
+!!     <td>Faxa_snow</td>
 !!     <td>kg m-2 s-1</td>
 !!     <td>fprec</td>
 !!     <td>mass flux of frozen precip</td>
 !!     <td></td>
 !! </tr>
 !! <tr>
-!!     <td>mean_merid_moment_flx</td>
-!!     <td>Pa</td>
-!!     <td>v_flux</td>
-!!     <td>j-directed wind stress into ocean</td>
-!!     <td>[vector rotation] (@ref VectorRotations) applied - lat-lon to tripolar</td>
-!! </tr>
-!! <tr>
-!!     <td>mean_net_lw_flx</td>
+!!     <td>Foxx_lwnet</td>
 !!     <td>W m-2</td>
 !!     <td>lw_flux</td>
 !!     <td>long wave radiation</td>
 !!     <td></td>
 !! </tr>
 !! <tr>
-!!     <td>mean_net_sw_ir_dif_flx</td>
+!!     <td>Foxx_swnet_idf</td>
 !!     <td>W m-2</td>
 !!     <td>sw_flux_nir_dif</td>
 !!     <td>diffuse near IR shortwave radiation</td>
 !!     <td></td>
 !! </tr>
 !! <tr>
-!!     <td>mean_net_sw_ir_dir_flx</td>
+!!     <td>Foxx_swnet_idr</td>
 !!     <td>W m-2</td>
 !!     <td>sw_flux_nir_dir</td>
 !!     <td>direct near IR shortwave radiation</td>
 !!     <td></td>
 !! </tr>
 !! <tr>
-!!     <td>mean_net_sw_vis_dif_flx</td>
+!!     <td>Foxx_swnet_vdf</td>
 !!     <td>W m-2</td>
 !!     <td>sw_flux_vis_dif</td>
 !!     <td>diffuse visible shortware radiation</td>
 !!     <td></td>
 !! </tr>
 !! <tr>
-!!     <td>mean_net_sw_vis_dir_flx</td>
+!!     <td>Foxx_swnet_idr</td>
 !!     <td>W m-2</td>
 !!     <td>sw_flux_vis_dir</td>
 !!     <td>direct visible shortware radiation</td>
 !!     <td></td>
 !! </tr>
 !! <tr>
-!!     <td>mean_prec_rate</td>
+!!     <td>Faxa_rain</td>
 !!     <td>kg m-2 s-1</td>
 !!     <td>lprec</td>
 !!     <td>mass flux of liquid precip</td>
 !!     <td></td>
 !! </tr>
 !! <tr>
-!!     <td>heat_content_lprec</td>
+!!     <td>Foxx_hrain</td>
 !!     <td>W m-2</td>
 !!     <td>hrain</td>
 !!     <td>heat content (enthalpy) of liquid water entering the ocean</td>
 !!     <td></td>
 !! </tr>
 !! <tr>
-!!     <td>heat_content_fprec</td>
+!!     <td>Foxx_hsnow</td>
 !!     <td>W m-2</td>
 !!     <td>hsnow</td>
 !!     <td>heat content (enthalpy) of frozen water entering the ocean</td>
 !!     <td></td>
 !! </tr>
 !! <tr>
-!!     <td>heat_content_evap</td>
+!!     <td>Foxx_hevap</td>
 !!     <td>W m-2</td>
 !!     <td>hevap</td>
 !!     <td>heat content (enthalpy) of water leaving the ocean</td>
 !!     <td></td>
 !! </tr>
 !! <tr>
-!!     <td>heat_content_cond</td>
+!!     <td>Foxx_hcond</td>
 !!     <td>W m-2</td>
 !!     <td>hcond</td>
 !!     <td>heat content (enthalpy) of liquid water entering the ocean due to condensation</td>
 !!     <td></td>
 !! </tr>
 !! <tr>
-!!     <td>heat_content_rofl</td>
+!!     <td>Foxx_hrofl</td>
 !!     <td>W m-2</td>
 !!     <td>hrofl</td>
 !!     <td>heat content (enthalpy) of liquid runoff</td>
 !!     <td></td>
 !! </tr>
 !! <tr>
-!!     <td>heat_content_rofi</td>
+!!     <td>Foxx_hrofi</td>
 !!     <td>W m-2</td>
 !!     <td>hrofi</td>
 !!     <td>heat content (enthalpy) of frozen runoff</td>
 !!     <td></td>
 !! </tr>
 !! <tr>
-!!     <td>mean_runoff_rate</td>
+!!     <td>Foxx_rofl</td>
 !!     <td>kg m-2 s-1</td>
 !!     <td>runoff</td>
 !!     <td>mass flux of liquid runoff</td>
 !!     <td></td>
 !! </tr>
 !! <tr>
-!!     <td>mean_salt_rate</td>
+!!     <td>Foxx_rofi</td>
+!!     <td>kg m-2 s-1</td>
+!!     <td>runoff</td>
+!!     <td>mass flux of frozen runoff</td>
+!!     <td></td>
+!! </tr>
+!! <tr>
+!!     <td>Fioi_salt</td>
 !!     <td>kg m-2 s-1</td>
 !!     <td>salt_flux</td>
 !!     <td>salt flux</td>
 !!     <td></td>
 !! </tr>
 !! <tr>
-!!     <td>mean_sensi_heat_flx</td>
+!!     <td>Foxx_sen</td>
 !!     <td>W m-2</td>
 !!     <td>t_flux</td>
 !!     <td>sensible heat flux into ocean</td>
 !!     <td></td>
 !! </tr>
 !! <tr>
-!!     <td>mean_zonal_moment_flx</td>
+!!     <td>Foxx_taux</td>
 !!     <td>Pa</td>
 !!     <td>u_flux</td>
 !!     <td>i-directed wind stress into ocean</td>
+!!     <td>[vector rotation] (@ref VectorRotations) applied - lat-lon to tripolar</td>
+!! </tr>
+!! <tr>
+!!     <td>Foxx_tauy</td>
+!!     <td>Pa</td>
+!!     <td>v_flux</td>
+!!     <td>j-directed wind stress into ocean</td>
 !!     <td>[vector rotation] (@ref VectorRotations) applied - lat-lon to tripolar</td>
 !! </tr>
 !! </table>
@@ -2616,63 +2620,63 @@ end subroutine shr_log_setLogUnit
 !!       <th>Notes</th>
 !!   </tr>
 !!   <tr>
-!!       <td>freezing_melting_potential</td>
+!!       <td>Fioo_q</td>
 !!       <td>W m-2</td>
 !!       <td>combination of frazil and melt_potential</td>
 !!       <td>cap converts model units (J m-2) to (W m-2) for export</td>
 !!       <td></td>
 !!   </tr>
 !!   <tr>
-!!       <td>ocean_mask</td>
+!!       <td>So_omask</td>
 !!       <td></td>
 !!       <td></td>
 !!       <td>ocean mask</td>
 !!       <td></td>
 !!   </tr>
 !!   <tr>
-!!       <td>ocn_current_merid</td>
+!!       <td>So_v</td>
 !!       <td>m s-1</td>
 !!       <td>v_surf</td>
 !!       <td>j-directed surface velocity on u-cell</td>
 !!       <td>[vector rotation] (@ref VectorRotations) applied - tripolar to lat-lon</td>
 !!   </tr>
 !!   <tr>
-!!       <td>ocn_current_zonal</td>
+!!       <td>So_u</td>
 !!       <td>m s-1</td>
 !!       <td>u_surf</td>
 !!       <td>i-directed surface velocity on u-cell</td>
 !!       <td>[vector rotation] (@ref VectorRotations) applied - tripolar to lat-lon</td>
 !!   </tr>
 !!   <tr>
-!!       <td>s_surf</td>
+!!       <td>So_s</td>
 !!       <td>psu</td>
 !!       <td>s_surf</td>
 !!       <td>sea surface salinity on t-cell</td>
 !!       <td></td>
 !!   </tr>
 !!   <tr>
-!!       <td>sea_surface_temperature</td>
+!!       <td>So_t</td>
 !!       <td>K</td>
 !!       <td>t_surf</td>
 !!       <td>sea surface temperature on t-cell</td>
 !!       <td></td>
 !!   </tr>
 !!   <tr>
-!!       <td>sea_surface_slope_zonal</td>
+!!       <td>So_dhdx</td>
 !!       <td>unitless</td>
 !!       <td>created from ssh</td>
 !!       <td>sea surface zonal slope</td>
 !!       <td></td>
 !!   </tr>
 !!   <tr>
-!!       <td>sea_surface_slope_merid</td>
+!!       <td>So_dhy</td>
 !!       <td>unitless</td>
 !!       <td>created from ssh</td>
 !!       <td>sea surface meridional slope</td>
 !!       <td></td>
 !!   </tr>
 !!   <tr>
-!!       <td>so_bldepth</td>
+!!       <td>So_bldepth</td>
 !!       <td>m</td>
 !!       <td>obld</td>
 !!       <td>ocean surface boundary layer depth</td>

--- a/config_src/drivers/nuopc_cap/mom_cap_methods.F90
+++ b/config_src/drivers/nuopc_cap/mom_cap_methods.F90
@@ -72,12 +72,11 @@ end subroutine mom_set_geomtype
 !> This function has a few purposes:
 !! (1) it imports surface fluxes using data from the mediator; and
 !! (2) it can apply restoring in SST and SSS.
-subroutine mom_import(ocean_public, ocean_grid, importState, ice_ocean_boundary, cesm_coupled, rc)
+subroutine mom_import(ocean_public, ocean_grid, importState, ice_ocean_boundary, rc)
   type(ocean_public_type)       , intent(in)    :: ocean_public       !< Ocean surface state
   type(ocean_grid_type)         , intent(in)    :: ocean_grid         !< Ocean model grid
   type(ESMF_State)              , intent(inout) :: importState        !< incoming data from mediator
   type(ice_ocean_boundary_type) , intent(inout) :: ice_ocean_boundary !< Ocean boundary forcing
-  logical                       , intent(in)    :: cesm_coupled       !< Flag to check if coupled with cesm
   integer                       , intent(inout) :: rc                 !< Return code
 
   ! Local Variables
@@ -103,43 +102,42 @@ subroutine mom_import(ocean_public, ocean_grid, importState, ice_ocean_boundary,
   !----
   ! surface height pressure
   !----
-  call state_getimport(importState, 'inst_pres_height_surface', &
-       isc, iec, jsc, jec, ice_ocean_boundary%p, rc=rc)
+  call state_getimport(importState, 'Sa_pslv', isc, iec, jsc, jec, ice_ocean_boundary%p, rc=rc)
   if (ChkErr(rc,__LINE__,u_FILE_u)) return
 
   !----
   ! near-IR, direct shortwave  (W/m2)
   !----
-  call state_getimport(importState, 'mean_net_sw_ir_dir_flx', &
-       isc, iec, jsc, jec, ice_ocean_boundary%sw_flux_nir_dir, areacor=med2mod_areacor, rc=rc)
+  call state_getimport(importState, 'Foxx_swnet_idr', isc, iec, jsc, jec, &
+       ice_ocean_boundary%sw_flux_nir_dir, areacor=med2mod_areacor, rc=rc)
   if (ChkErr(rc,__LINE__,u_FILE_u)) return
 
   !----
   ! near-IR, diffuse shortwave  (W/m2)
   !----
-  call state_getimport(importState, 'mean_net_sw_ir_dif_flx', &
-       isc, iec, jsc, jec, ice_ocean_boundary%sw_flux_nir_dif, areacor=med2mod_areacor, rc=rc)
+  call state_getimport(importState, 'Foxx_swnet_idf', isc, iec, jsc, jec, &
+       ice_ocean_boundary%sw_flux_nir_dif, areacor=med2mod_areacor, rc=rc)
   if (ChkErr(rc,__LINE__,u_FILE_u)) return
 
   !----
   ! visible, direct shortwave  (W/m2)
   !----
-  call state_getimport(importState, 'mean_net_sw_vis_dir_flx', &
-       isc, iec, jsc, jec, ice_ocean_boundary%sw_flux_vis_dir, areacor=med2mod_areacor, rc=rc)
+  call state_getimport(importState, 'Foxx_swnet_vdr', isc, iec, jsc, jec, &
+       ice_ocean_boundary%sw_flux_vis_dir, areacor=med2mod_areacor, rc=rc)
   if (ChkErr(rc,__LINE__,u_FILE_u)) return
 
   !----
   ! visible, diffuse shortwave (W/m2)
   !----
-  call state_getimport(importState, 'mean_net_sw_vis_dif_flx', &
-       isc, iec, jsc, jec, ice_ocean_boundary%sw_flux_vis_dif, areacor=med2mod_areacor, rc=rc)
+  call state_getimport(importState, 'Foxx_swnet_vdf', isc, iec, jsc, jec, &
+       ice_ocean_boundary%sw_flux_vis_dif, areacor=med2mod_areacor, rc=rc)
   if (ChkErr(rc,__LINE__,u_FILE_u)) return
 
   ! -------
   ! Net longwave radiation (W/m2)
   ! -------
-  call state_getimport(importState, 'mean_net_lw_flx',  &
-       isc, iec, jsc, jec, ice_ocean_boundary%lw_flux, areacor=med2mod_areacor, rc=rc)
+  call state_getimport(importState, 'Foxx_lwnet', isc, iec, jsc, jec, &
+       ice_ocean_boundary%lw_flux, areacor=med2mod_areacor, rc=rc)
   if (ChkErr(rc,__LINE__,u_FILE_u)) return
 
   !----
@@ -148,10 +146,10 @@ subroutine mom_import(ocean_public, ocean_grid, importState, ice_ocean_boundary,
   allocate (taux(isc:iec,jsc:jec))
   allocate (tauy(isc:iec,jsc:jec))
 
-  call state_getimport(importState, 'mean_zonal_moment_flx', isc, iec, jsc, jec, taux, &
+  call state_getimport(importState, 'Foxx_taux', isc, iec, jsc, jec, taux, &
        areacor=med2mod_areacor, rc=rc)
   if (ChkErr(rc,__LINE__,u_FILE_u)) return
-  call state_getimport(importState, 'mean_merid_moment_flx', isc, iec, jsc, jec, tauy, &
+  call state_getimport(importState, 'Foxx_tauy', isc, iec, jsc, jec, tauy, &
        areacor=med2mod_areacor, rc=rc)
   if (ChkErr(rc,__LINE__,u_FILE_u)) return
 
@@ -172,29 +170,29 @@ subroutine mom_import(ocean_public, ocean_grid, importState, ice_ocean_boundary,
   !----
   ! sensible heat flux (W/m2)
   !----
-  call state_getimport(importState, 'mean_sensi_heat_flx', &
-       isc, iec, jsc, jec, ice_ocean_boundary%t_flux, areacor=med2mod_areacor, rc=rc)
+  call state_getimport(importState, 'Foxx_sen', isc, iec, jsc, jec, &
+       ice_ocean_boundary%t_flux, areacor=med2mod_areacor, rc=rc)
   if (ChkErr(rc,__LINE__,u_FILE_u)) return
 
   !----
   ! evaporation flux (W/m2)
   !----
-  call state_getimport(importState, 'mean_evap_rate', &
-       isc, iec, jsc, jec, ice_ocean_boundary%q_flux, areacor=med2mod_areacor, rc=rc)
+  call state_getimport(importState, 'Foxx_evap', isc, iec, jsc, jec, &
+       ice_ocean_boundary%q_flux, areacor=med2mod_areacor, rc=rc)
   if (ChkErr(rc,__LINE__,u_FILE_u)) return
 
   !----
   ! liquid precipitation (rain)
   !----
-  call state_getimport(importState, 'mean_prec_rate', &
-       isc, iec, jsc, jec, ice_ocean_boundary%lprec, areacor=med2mod_areacor, rc=rc)
+  call state_getimport(importState, 'Faxa_rain', isc, iec, jsc, jec, &
+       ice_ocean_boundary%lprec, areacor=med2mod_areacor, rc=rc)
   if (ChkErr(rc,__LINE__,u_FILE_u)) return
 
   !----
   ! frozen precipitation (snow)
   !----
-  call state_getimport(importState, 'mean_fprec_rate', &
-       isc, iec, jsc, jec, ice_ocean_boundary%fprec, areacor=med2mod_areacor, rc=rc)
+  call state_getimport(importState, 'Faxa_snow', isc, iec, jsc, jec, &
+       ice_ocean_boundary%fprec, areacor=med2mod_areacor, rc=rc)
   if (ChkErr(rc,__LINE__,u_FILE_u)) return
 
   !----
@@ -216,75 +214,85 @@ subroutine mom_import(ocean_public, ocean_grid, importState, ice_ocean_boundary,
   if (ChkErr(rc,__LINE__,u_FILE_u)) return
 
   !----
-  ! Enthalpy terms (only in CESM)
+  ! Enthalpy terms
   !----
-  if (cesm_coupled) then
-    !----
-    ! enthalpy from liquid precipitation (hrain)
-    !----
-    call state_getimport(importState, 'heat_content_lprec', &
-         isc, iec, jsc, jec, ice_ocean_boundary%hrain, areacor=med2mod_areacor, rc=rc)
-    if (ChkErr(rc,__LINE__,u_FILE_u)) return
 
-    !----
-    ! enthalpy from frozen precipitation (hsnow)
-    !----
-    call state_getimport(importState, 'heat_content_fprec', &
-         isc, iec, jsc, jec, ice_ocean_boundary%hsnow, areacor=med2mod_areacor, rc=rc)
+  !----
+  ! enthalpy from liquid precipitation (hrain)
+  !----
+  if ( associated(ice_ocean_boundary%hrain) ) then
+    call state_getimport(importState, 'Foxx_hrain', isc, iec, jsc, jec, &
+         ice_ocean_boundary%hrain, areacor=med2mod_areacor, rc=rc)
     if (ChkErr(rc,__LINE__,u_FILE_u)) return
+  end if
 
-    !----
-    ! enthalpy from liquid runoff (hrofl)
-    !----
-    call state_getimport(importState, 'heat_content_rofl', &
-         isc, iec, jsc, jec, ice_ocean_boundary%hrofl, areacor=med2mod_areacor, rc=rc)
+  !----
+  ! enthalpy from frozen precipitation (hsnow)
+  !----
+  if ( associated(ice_ocean_boundary%hsnow) ) then
+    call state_getimport(importState, 'Foxx_hsnow', isc, iec, jsc, jec, &
+         ice_ocean_boundary%hsnow, areacor=med2mod_areacor, rc=rc)
     if (ChkErr(rc,__LINE__,u_FILE_u)) return
+  end if
 
-    !----
-    ! enthalpy from frozen runoff (hrofi)
-    !----
-    call state_getimport(importState, 'heat_content_rofi', &
-         isc, iec, jsc, jec, ice_ocean_boundary%hrofi, areacor=med2mod_areacor, rc=rc)
+  !----
+  ! enthalpy from liquid runoff (hrofl)
+  !----
+  if ( associated(ice_ocean_boundary%hrofl) ) then
+    call state_getimport(importState, 'Foxx_hrofl', isc, iec, jsc, jec, &
+         ice_ocean_boundary%hrofl, areacor=med2mod_areacor, rc=rc)
     if (ChkErr(rc,__LINE__,u_FILE_u)) return
+  end if
 
-    !----
-    ! enthalpy from evaporation (hevap)
-    !----
-    call state_getimport(importState, 'heat_content_evap', &
-         isc, iec, jsc, jec, ice_ocean_boundary%hevap, areacor=med2mod_areacor, rc=rc)
+  !----
+  ! enthalpy from frozen runoff (hrofi)
+  !----
+  if ( associated(ice_ocean_boundary%hrofi) ) then
+    call state_getimport(importState, 'Foxx_hrofi', isc, iec, jsc, jec, &
+         ice_ocean_boundary%hrofi, areacor=med2mod_areacor, rc=rc)
     if (ChkErr(rc,__LINE__,u_FILE_u)) return
+  end if
 
-    !----
-    ! enthalpy from condensation (hcond)
-    !----
-    call state_getimport(importState, 'heat_content_cond', &
-         isc, iec, jsc, jec, ice_ocean_boundary%hcond, areacor=med2mod_areacor, rc=rc)
+  !----
+  ! enthalpy from evaporation (hevap)
+  !----
+  if ( associated(ice_ocean_boundary%hevap) ) then
+    call state_getimport(importState, 'Foxx_hevap', isc, iec, jsc, jec, &
+         ice_ocean_boundary%hevap, areacor=med2mod_areacor, rc=rc)
     if (ChkErr(rc,__LINE__,u_FILE_u)) return
+  end if
 
+  !----
+  ! enthalpy from condensation (hcond)
+  !----
+  if ( associated(ice_ocean_boundary%hcond) ) then
+    call state_getimport(importState, 'Foxx_hcond', isc, iec, jsc, jec, &
+         ice_ocean_boundary%hcond, areacor=med2mod_areacor, rc=rc)
+    if (ChkErr(rc,__LINE__,u_FILE_u)) return
   endif
 
   !----
   ! salt flux from ice
   !----
   ice_ocean_boundary%salt_flux(:,:) = 0._ESMF_KIND_R8
-  call state_getimport(importState, 'mean_salt_rate',  &
-       isc, iec, jsc, jec, ice_ocean_boundary%salt_flux, areacor=med2mod_areacor, rc=rc)
+  call state_getimport(importState, 'Fioi_salt', isc, iec, jsc, jec, &
+       ice_ocean_boundary%salt_flux, areacor=med2mod_areacor, rc=rc)
   if (ChkErr(rc,__LINE__,u_FILE_u)) return
 
   !----
   ! snow&ice melt heat flux  (W/m^2)
   !----
   ice_ocean_boundary%seaice_melt_heat(:,:) = 0._ESMF_KIND_R8
-  call state_getimport(importState, 'net_heat_flx_to_ocn',  &
-       isc, iec, jsc, jec, ice_ocean_boundary%seaice_melt_heat, areacor=med2mod_areacor, rc=rc)
+  call state_getimport(importState, 'Fioi_melth', isc, iec, jsc, jec, &
+       ice_ocean_boundary%seaice_melt_heat, areacor=med2mod_areacor, rc=rc)
   if (ChkErr(rc,__LINE__,u_FILE_u)) return
 
   !----
   ! snow&ice melt water flux  (W/m^2)
   !----
   ice_ocean_boundary%seaice_melt(:,:) = 0._ESMF_KIND_R8
-  call state_getimport(importState, 'mean_fresh_water_to_ocean_rate',  &
-       isc, iec, jsc, jec, ice_ocean_boundary%seaice_melt, areacor=med2mod_areacor, rc=rc)
+  call state_getimport(importState, 'Fioi_meltw', isc, iec, jsc, jec, &
+       ice_ocean_boundary%seaice_melt, areacor=med2mod_areacor, rc=rc)
   if (ChkErr(rc,__LINE__,u_FILE_u)) return
 
   !----
@@ -293,24 +301,24 @@ subroutine mom_import(ocean_public, ocean_grid, importState, ice_ocean_boundary,
   ! Note - preset values to 0, if field does not exist in importState, then will simply return
   ! and preset value will be used
   ice_ocean_boundary%mi(:,:) = 0._ESMF_KIND_R8
-  call state_getimport(importState, 'mass_of_overlying_ice',  &
-       isc, iec, jsc, jec, ice_ocean_boundary%mi,rc=rc)
+  call state_getimport(importState, 'mass_of_overlying_ice', isc, iec, jsc, jec, &
+       ice_ocean_boundary%mi,rc=rc)
   if (ChkErr(rc,__LINE__,u_FILE_u)) return
 
   !----
   ! sea-ice fraction
   !----
   ice_ocean_boundary%ice_fraction(:,:) = 0._ESMF_KIND_R8
-  call state_getimport(importState, 'Si_ifrac',  &
-       isc, iec, jsc, jec, ice_ocean_boundary%ice_fraction, rc=rc)
+  call state_getimport(importState, 'Si_ifrac', isc, iec, jsc, jec, &
+       ice_ocean_boundary%ice_fraction, rc=rc)
   if (ChkErr(rc,__LINE__,u_FILE_u)) return
 
   !----
   ! 10m wind squared
   !----
   ice_ocean_boundary%u10_sqr(:,:) = 0._ESMF_KIND_R8
-  call state_getimport(importState, 'So_duu10n',  &
-       isc, iec, jsc, jec, ice_ocean_boundary%u10_sqr, rc=rc)
+  call state_getimport(importState, 'So_duu10n', isc, iec, jsc, jec, &
+       ice_ocean_boundary%u10_sqr, rc=rc)
   if (ChkErr(rc,__LINE__,u_FILE_u)) return
 
   !----
@@ -318,8 +326,8 @@ subroutine mom_import(ocean_public, ocean_grid, importState, ice_ocean_boundary,
   !----
   if ( associated(ice_ocean_boundary%lamult) ) then
     ice_ocean_boundary%lamult (:,:) = 0._ESMF_KIND_R8
-    call state_getimport(importState, 'Sw_lamult',  &
-         isc, iec, jsc, jec, ice_ocean_boundary%lamult, rc=rc)
+    call state_getimport(importState, 'Sw_lamult', isc, iec, jsc, jec, &
+         ice_ocean_boundary%lamult, rc=rc)
     if (ChkErr(rc,__LINE__,u_FILE_u)) return
   endif
 
@@ -424,8 +432,7 @@ subroutine mom_export(ocean_public, ocean_grid, ocean_state, exportState, clock,
     enddo
   enddo
 
-  call State_SetExport(exportState, 'ocean_mask', &
-       isc, iec, jsc, jec, omask, ocean_grid, rc=rc)
+  call State_SetExport(exportState, 'So_omask', isc, iec, jsc, jec, omask, ocean_grid, rc=rc)
   if (ChkErr(rc,__LINE__,u_FILE_u)) return
 
   deallocate(omask)
@@ -433,15 +440,13 @@ subroutine mom_export(ocean_public, ocean_grid, ocean_state, exportState, clock,
   ! -------
   ! Sea surface temperature
   ! -------
-  call State_SetExport(exportState, 'sea_surface_temperature', &
-       isc, iec, jsc, jec, ocean_public%t_surf, ocean_grid, rc=rc)
+  call State_SetExport(exportState, 'So_t', isc, iec, jsc, jec, ocean_public%t_surf, ocean_grid, rc=rc)
   if (ChkErr(rc,__LINE__,u_FILE_u)) return
 
   ! -------
   ! Sea surface salinity
   ! -------
-  call State_SetExport(exportState, 's_surf', &
-       isc, iec, jsc, jec, ocean_public%s_surf, ocean_grid, rc=rc)
+  call State_SetExport(exportState, 'So_s', isc, iec, jsc, jec, ocean_public%s_surf, ocean_grid, rc=rc)
   if (ChkErr(rc,__LINE__,u_FILE_u)) return
 
   ! -------
@@ -467,12 +472,10 @@ subroutine mom_export(ocean_public, ocean_grid, ocean_state, exportState, clock,
     enddo
   enddo
 
-  call State_SetExport(exportState, 'ocn_current_zonal', &
-       isc, iec, jsc, jec, ocz_rot, ocean_grid, rc=rc)
+  call State_SetExport(exportState, 'So_u', isc, iec, jsc, jec, ocz_rot, ocean_grid, rc=rc)
   if (ChkErr(rc,__LINE__,u_FILE_u)) return
 
-  call State_SetExport(exportState, 'ocn_current_merid', &
-       isc, iec, jsc, jec, ocm_rot, ocean_grid, rc=rc)
+  call State_SetExport(exportState, 'So_v', isc, iec, jsc, jec, ocm_rot, ocean_grid, rc=rc)
   if (ChkErr(rc,__LINE__,u_FILE_u)) return
 
   deallocate(ocz, ocm, ocz_rot, ocm_rot)
@@ -482,8 +485,8 @@ subroutine mom_export(ocean_public, ocean_grid, ocean_state, exportState, clock,
   ! -------
   call ESMF_StateGet(exportState, 'So_bldepth', itemFlag, rc=rc)
   if (itemFlag /= ESMF_STATEITEM_NOTFOUND) then
-    call State_SetExport(exportState, 'So_bldepth', &
-         isc, iec, jsc, jec, ocean_public%obld, ocean_grid, rc=rc)
+    call State_SetExport(exportState, 'So_bldepth', isc, iec, jsc, jec, &
+         ocean_public%obld, ocean_grid, rc=rc)
     if (ChkErr(rc,__LINE__,u_FILE_u)) return
   endif
 
@@ -506,8 +509,8 @@ subroutine mom_export(ocean_public, ocean_grid, ocean_state, exportState, clock,
     enddo
   enddo
 
-  call State_SetExport(exportState, 'freezing_melting_potential', &
-       isc, iec, jsc, jec, melt_potential, ocean_grid, areacor=mod2med_areacor, rc=rc)
+  call State_SetExport(exportState, 'Fioo_q', isc, iec, jsc, jec, &
+       melt_potential, ocean_grid, areacor=mod2med_areacor, rc=rc)
   if (ChkErr(rc,__LINE__,u_FILE_u)) return
 
   deallocate(melt_potential)
@@ -620,12 +623,10 @@ subroutine mom_export(ocean_public, ocean_grid, ocean_state, exportState, clock,
     enddo
   enddo
 
-  call State_SetExport(exportState, 'sea_surface_slope_zonal', &
-       isc, iec, jsc, jec, dhdx_rot, ocean_grid, rc=rc)
+  call State_SetExport(exportState, 'So_dhdx', isc, iec, jsc, jec, dhdx_rot, ocean_grid, rc=rc)
   if (ChkErr(rc,__LINE__,u_FILE_u)) return
 
-  call State_SetExport(exportState, 'sea_surface_slope_merid', &
-       isc, iec, jsc, jec, dhdy_rot, ocean_grid, rc=rc)
+  call State_SetExport(exportState, 'So_dhdy', isc, iec, jsc, jec, dhdy_rot, ocean_grid, rc=rc)
   if (ChkErr(rc,__LINE__,u_FILE_u)) return
 
   deallocate(ssh, dhdx, dhdy, dhdx_rot, dhdy_rot)


### PR DESCRIPTION
* modify field names to use CESM-style field names. Field names were aligned with those in https://github.com/ESCOMP/CMEPS/blob/main/mediator/fd_cesm.yaml
* removes cesm_coupled restriction on enthalpy fields (fields are added to ufs field dictionary)
* two fields remain unresolved, sea_level and mass_overlying_ice, currently unused