### PR TITLE
Add end of run restart functionality to MOM6

### DIFF
--- a/config_src/drivers/nuopc_cap/mom_cap.F90
+++ b/config_src/drivers/nuopc_cap/mom_cap.F90
@@ -1680,9 +1680,16 @@ subroutine ModelAdvance(gcomp, rc)
   !---------------
   ! Get the stop alarm
   !---------------
-  restart_eor = .true.
+  restart_eor = .false.
   call ESMF_ClockGetAlarm(clock, alarmname='stop_alarm', alarm=stop_alarm, rc=rc)
   if (ChkErr(rc,__LINE__,u_FILE_u)) return
+
+  ! Handle end of run restart
+  call NUOPC_CompAttributeGet(gcomp, name="write_restart_at_endofrun", value=cvalue, isPresent=isPresent, isSet=isSet, rc=rc)
+  if (ChkErr(rc,__LINE__,u_FILE_u)) return
+  if (isPresent .and. isSet) then
+     if (trim(cvalue) .eq. '.true.') restart_eor = .true.
+  end if
 
   !---------------
   ! If restart alarm exists and is ringing - write restart file

--- a/config_src/drivers/nuopc_cap/mom_cap.F90
+++ b/config_src/drivers/nuopc_cap/mom_cap.F90
@@ -1716,7 +1716,6 @@ subroutine ModelAdvance(gcomp, rc)
       if (ESMF_AlarmIsRinging(stop_alarm, rc=rc)) then
          if (ChkErr(rc,__LINE__,u_FILE_u)) return
          write_restart_eor = .true.
-         call ESMF_LogWrite("It's Working DPS", ESMF_LOGMSG_INFO)
          ! turn off the alarm
          call ESMF_AlarmRingerOff(restart_alarm, rc=rc )
          if (ChkErr(rc,__LINE__,u_FILE_u)) return

--- a/config_src/drivers/nuopc_cap/mom_cap.F90
+++ b/config_src/drivers/nuopc_cap/mom_cap.F90
@@ -382,6 +382,12 @@ subroutine InitializeP0(gcomp, importState, exportState, clock, rc)
     geomtype = ESMF_GEOMTYPE_GRID
   endif
 
+  ! Read end of run restart config option
+  call NUOPC_CompAttributeGet(gcomp, name="write_restart_at_endofrun", value=value, isPresent=isPresent, isSet=isSet, rc=rc)
+  if (ChkErr(rc,__LINE__,u_FILE_u)) return
+  if (isPresent .and. isSet) then
+     if (trim(value) .eq. '.true.') restart_eor = .true.
+  end if
 
 end subroutine
 
@@ -648,13 +654,6 @@ subroutine InitializeAdvertise(gcomp, importState, exportState, clock, rc)
     endif
 
   endif
-
-  ! Read end of run restart config option
-  call NUOPC_CompAttributeGet(gcomp, name="write_restart_at_endofrun", value=cvalue, isPresent=isPresent, isSet=isSet, rc=rc)
-  if (ChkErr(rc,__LINE__,u_FILE_u)) return
-  if (isPresent .and. isSet) then
-     if (trim(cvalue) .eq. '.true.') restart_eor = .true.
-  end if
 
   ocean_public%is_ocean_pe = .true.
   if (cesm_coupled .and. len_trim(inst_suffix)>0) then

--- a/config_src/drivers/nuopc_cap/mom_cap.F90
+++ b/config_src/drivers/nuopc_cap/mom_cap.F90
@@ -1822,7 +1822,7 @@ subroutine ModelAdvance(gcomp, rc)
          if (ChkErr(rc,__LINE__,u_FILE_u)) return
          write_restart_eor = .true.
          ! turn off the alarm
-         call ESMF_AlarmRingerOff(restart_alarm, rc=rc )
+         call ESMF_AlarmRingerOff(stop_alarm, rc=rc )
          if (ChkErr(rc,__LINE__,u_FILE_u)) return
        end if
     end if


### PR DESCRIPTION
This PR allows the user to create restart files at the end of a run in MOM using the **write_restart_at_endofrun** configuration option in CMEPS. This configuration option will control end of run restarts for MOM6, CICE, and CMEPS. This PR closes NOAA-EMC/CMEPS#118 and closes ufs-community/ufs-weather-model#2236. A similar PR was made in the CICE repository ([CICE PR#77](https://github.com/NOAA-EMC/CICE/pull/77)) that will completely resolve these issues.

The code was tested on Hera using the regression test **datm_cdeps_control_gefs**. This was tested using different combinations of restart setting to try and ensure expected functionality. 
If the setting is not set or set to _False_, a restart file will not be created at the end of the run. Setting the option to _true_ will create the file.
The end of file restarts for CMEPS, CICE, and MOM will all be controlled with this single configuration option.