### PR TITLE
update to main 20240729 commit (gfdl-to-main-2024-05-31)

### DIFF
--- a/.github/actions/testing-setup/action.yml
+++ b/.github/actions/testing-setup/action.yml
@@ -28,7 +28,7 @@ runs:
       run: |
         echo "::group::Compile FMS library"
         cd .testing
-        REPORT_ERROR_LOGS=true make deps/lib/libFMS.a -s -j
+        REPORT_ERROR_LOGS=true make build/deps/lib/libFMS.a -s -j
         echo "::endgroup::"
 
     - name: Compile MOM6 in symmetric memory mode

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -31,14 +31,7 @@ jobs:
     - name: Run (single processor) unit tests
       run: make run.unit
 
-    - name: Report unit test coverage to CI (PR)
-      if: github.event_name == 'pull_request'
-      run: make report.cov.unit REQUIRE_COVERAGE_UPLOAD=true
-      env:
-        CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
-
-    - name: Report unit test coverage to CI (Push)
-      if: github.event_name != 'pull_request'
+    - name: Report unit test coverage to CI
       run: make report.cov.unit
       env:
         CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
@@ -49,14 +42,7 @@ jobs:
     - name: Run coverage tests
       run: make -j -k run.cov
 
-    - name: Report coverage to CI (PR)
-      if: github.event_name == 'pull_request'
-      run: make report.cov REQUIRE_COVERAGE_UPLOAD=true
-      env:
-        CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
-
-    - name: Report coverage to CI (Push)
-      if: github.event_name != 'pull_request'
+    - name: Report coverage to CI
       run: make report.cov
       env:
         CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}

--- a/.github/workflows/macos-regression.yml
+++ b/.github/workflows/macos-regression.yml
@@ -11,7 +11,6 @@ jobs:
       CC: gcc
       FC: gfortran
       FMS_COMMIT: 2019.01.03
-      FRAMEWORK: fms1
 
     defaults:
       run:

--- a/.github/workflows/macos-regression.yml
+++ b/.github/workflows/macos-regression.yml
@@ -10,6 +10,8 @@ jobs:
     env:
       CC: gcc
       FC: gfortran
+      FMS_COMMIT: 2019.01.03
+      FRAMEWORK: fms1
 
     defaults:
       run:

--- a/.github/workflows/macos-stencil.yml
+++ b/.github/workflows/macos-stencil.yml
@@ -11,7 +11,6 @@ jobs:
       CC: gcc
       FC: gfortran
       FMS_COMMIT: 2019.01.03
-      FRAMEWORK: fms1
 
     defaults:
       run:

--- a/.github/workflows/macos-stencil.yml
+++ b/.github/workflows/macos-stencil.yml
@@ -10,6 +10,8 @@ jobs:
     env:
       CC: gcc
       FC: gfortran
+      FMS_COMMIT: 2019.01.03
+      FRAMEWORK: fms1
 
     defaults:
       run:

--- a/.github/workflows/perfmon.yml
+++ b/.github/workflows/perfmon.yml
@@ -40,9 +40,25 @@ jobs:
         sudo sysctl -w kernel.perf_event_paranoid=2
         make perf DO_REGRESSION_TESTS=true
 
+    # This job assumes that build/target_codebase was cloned above
+    - name: Compile timing tests for reference code
+      if: ${{ github.event_name == 'pull_request' }}
+      run: >-
+        make -j build.timing_target
+        MOM_TARGET_SLUG=$GITHUB_REPOSITORY
+        MOM_TARGET_LOCAL_BRANCH=$GITHUB_BASE_REF
+        DO_REGRESSION_TESTS=true
+
     - name: Compile timing tests
       run: |
         make -j build.timing
+
+    # DO_REGERESSION_TESTS=true is needed here to set the internal macro TARGET_CODEBASE
+    - name: Run timing tests for reference code
+      if: ${{ github.event_name == 'pull_request' }}
+      run: >-
+        make -j run.timing_target
+        DO_REGRESSION_TESTS=true
 
     - name: Run timing tests
       run: |
@@ -51,3 +67,9 @@ jobs:
     - name: Display timing results
       run: |
         make -j show.timing
+
+    - name: Display comparison of timing results
+      if: ${{ github.event_name == 'pull_request' }}
+      run: >-
+        make -j compare.timing
+        DO_REGRESSION_TESTS=true

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -32,6 +32,8 @@ p:clone:
   tags:
     - ncrc5
   script:
+    # NOTE: We could sweep any builds older than 3 days here if needed
+    #- find $HOME/ci/[0-9]* -mtime +3 -delete 2> /dev/null || true
     - .gitlab/pipeline-ci-tool.sh create-job-dir
 #.gitlab/pipeline-ci-tool.sh clean-job-dir
 
@@ -353,4 +355,5 @@ cleanup:
   before_script:
     - echo Skipping usual preamble
   script:
+    - rm -rf $HOME/ci/$CI_PIPELINE_ID
     - rm -rf $JOB_DIR

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -9,7 +9,7 @@ stages:
 # that is unique to this pipeline.
 # We use the "fetch" strategy to speed up the startup of stages
 variables:
-  JOB_DIR: "/lustre/f2/scratch/oar.gfdl.ogrp-account/runner/builds/$CI_PIPELINE_ID"
+  JOB_DIR: "/gpfs/f5/gfdl_o/scratch/oar.gfdl.ogrp-account/runner/builds/$CI_PIPELINE_ID"
   GIT_STRATEGY: fetch
 
 # Always eport value of $JOB_DIR

--- a/.gitlab/pipeline-ci-tool.sh
+++ b/.gitlab/pipeline-ci-tool.sh
@@ -94,6 +94,13 @@ create-job-dir () {
     make -f tools/MRS/Makefile.clone clone_gfdl -j # Extras and link to datasets
     bash tools/MRS/generate_manifest.sh . tools/MRS/excluded-expts.txt > manifest.mk
     mkdir -p results
+    # Temporarily move build directory to $HOME to circumvent poor F5 performance
+    mkdir -p $HOME/ci/$CI_PIPELINE_ID/build
+    ln -s $HOME/ci/$CI_PIPELINE_ID/build build
+    # Builds need non-mangled access to src/.
+    ln -s "$(pwd)"/src $HOME/ci/$CI_PIPELINE_ID/src
+    # Static builds need access to ocean_only/
+    ln -s "$(pwd)"/ocean_only $HOME/ci/$CI_PIPELINE_ID/ocean_only
   fi
   section-end create-job-dir
 }

--- a/.testing/Makefile
+++ b/.testing/Makefile
@@ -217,7 +217,6 @@ endif
 
 FMS_SOURCE = $(call SOURCE,deps/fms/src)
 
-
 #---
 # Rules
 
@@ -683,6 +682,24 @@ run.timing: $(foreach f, $(TIMING_EXECS), work/timing/$(f).out)
 show.timing: $(foreach f, $(TIMING_EXECS), work/timing/$(f).show)
 $(WORKSPACE)/work/timing/%.show:
 	./tools/disp_timing.py $(@:.show=.out)
+
+# Invoke the above unit/timing rules for a "target" code
+# Invoke with appropriate macros defines, i.e.
+#   make build.timing_target MOM_TARGET_URL=... MOM_TARGET_BRANCH=... TARGET_CODEBASE=build/target_codebase
+#   make run.timing_target TARGET_CODEBASE=build/target_codebase
+
+TIMING_TARGET_EXECS ?= $(basename $(notdir $(wildcard $(TARGET_CODEBASE)/config_src/drivers/timing_tests/*.F90) ) )
+
+.PHONY: build.timing_target
+build.timing_target: $(foreach f, $(TIMING_TARGET_EXECS), $(TARGET_CODEBASE)/.testing/build/timing/$(f))
+.PHONY: run.timing_target
+run.timing_target: $(foreach f, $(TIMING_TARGET_EXECS), $(TARGET_CODEBASE)/.testing/work/timing/$(f).out)
+.PHONY: compare.timing
+compare.timing: $(foreach f, $(filter $(TIMING_EXECS),$(TIMING_TARGET_EXECS)), work/timing/$(f).compare)
+$(WORKSPACE)/work/timing/%.compare: $(TARGET_CODEBASE)
+	./tools/disp_timing.py -r $(TARGET_CODEBASE)/.testing/$(@:.compare=.out) $(@:.compare=.out)
+$(TARGET_CODEBASE)/.testing/%: | $(TARGET_CODEBASE)
+	cd $(TARGET_CODEBASE)/.testing && make $*
 
 # General rule to run a unit test executable
 # Pattern is to run build/unit/executable and direct output to executable.out

--- a/.testing/Makefile
+++ b/.testing/Makefile
@@ -286,7 +286,6 @@ $(BUILD)/unit/Makefile: MOM_ENV += $(COV_FCFLAGS) $(COV_LDFLAGS)
 $(BUILD)/timing/Makefile: MOM_ENV += $(OPT_FCFLAGS) $(MOM_LDFLAGS)
 
 # Configure script flags
-MOM_ACFLAGS := --with-framework=$(FRAMEWORK)
 $(BUILD)/openmp/Makefile: MOM_ACFLAGS += --enable-openmp
 $(BUILD)/coupled/Makefile: MOM_ACFLAGS += --with-driver=FMS_cap
 $(BUILD)/nuopc/Makefile: MOM_ACFLAGS += --with-driver=nuopc_cap

--- a/.testing/Makefile
+++ b/.testing/Makefile
@@ -46,10 +46,10 @@
 #   LDFLAGS_USER        User-defined linker flags (used for all MOM/FMS builds)
 #
 # Experiment Configuration:
-#   BUILDS  Executables to be built by `make` or `make all`
+#   EXECS   Executables to be built by `make` or `make all`
 #   CONFIGS Model configurations to test (default: `tc*`)
-#   TESTS   Tests to run
 #   DIMS    Dimensional scaling tests
+#   TESTS   Tests to run
 #
 # Regression repository ("target") configuration:
 #   MOM_TARGET_SLUG             URL slug (minus domain) of the target repo
@@ -57,19 +57,19 @@
 #   MOM_TARGET_LOCAL_BRANCH     Target branch name
 # (NOTE: These would typically be configured by a CI.)
 #
-# Paths for stages:
-#   WORKSPACE   Location to place work/ and results/ directories (i.e. where to run the model)
-#
-#----
+# Output paths:
+#   BUILD   Compiled executables and libraries
+#   DEPS    Compiled dependencies
+#   WORK    Test model output
 
 # TODO: POSIX shell compatibility
 SHELL = bash
 
-# No implicit rules
-.SUFFIXES:
+# No implicit rules, suffixes, or variables
+MAKEFLAGS += -rR
 
-# No implicit variables
-MAKEFLAGS += -R
+# Determine the MOM6 autoconf srcdir
+AC_SRCDIR := $(dir $(abspath $(lastword $(MAKEFILE_LIST))))../ac
 
 # User-defined configuration
 -include config.mk
@@ -104,10 +104,7 @@ FCFLAGS_FMS ?= $(FCFLAGS_DEBUG)
 LDFLAGS_COVERAGE ?= --coverage
 LDFLAGS_USER ?=
 
-# Set to `true` to require identical results from DEBUG and REPRO builds
-# NOTE: Many compilers (Intel, GCC on ARM64) do not produce identical results
-#   across DEBUG and REPRO builds (as defined below), so we disable on
-#   default.
+# Set to verify identical DEBUG and REPRO results
 DO_REPRO_TESTS ?=
 
 # Enable profiling
@@ -116,8 +113,11 @@ DO_PROFILE ?=
 # Enable code coverage runs
 DO_COVERAGE ?=
 
-# Enable code coverage runs
+# Enable unit tests
 DO_UNIT_TESTS ?=
+
+# Check for regressions with target branch
+DO_REGRESSION_TESTS ?=
 
 # Report failure if coverage report is not uploaded
 REQUIRE_COVERAGE_UPLOAD ?=
@@ -128,52 +128,69 @@ REPORT_ERROR_LOGS ?=
 # Time measurement (configurable by the CI)
 TIME ?= time
 
+# Legacy external work directory
+#WORKSPACE ?=
+WORKSPACE ?= .
+
+# Set directories for build/ and work/
+#BUILD ?= $(WORKSPACE)build
+#DEPS ?= $(BUILD)/deps
+#WORK ?= $(WORKSPACE)work
+BUILD ?= $(WORKSPACE)/build
+DEPS ?= $(BUILD)/deps
+WORK ?= $(WORKSPACE)/work
 
 # Experiment configuration
-BUILDS ?= symmetric/MOM6 asymmetric/MOM6 openmp/MOM6
+EXECS ?= symmetric/MOM6 asymmetric/MOM6 openmp/MOM6
 CONFIGS ?= $(wildcard tc*)
-TESTS ?= grid layout rotate restart openmp nan $(foreach d,$(DIMS),dim.$(d))
 DIMS ?= t l h z q r
+TESTS ?= grid layout rotate restart openmp nan $(foreach d,$(DIMS),dim.$(d))
 
-# Default is to place work/ and results/ in current directory
-WORKSPACE ?= .
+# Unit test executables
+UNIT_EXECS ?= \
+  $(basename $(notdir $(wildcard ../config_src/drivers/unit_tests/*.F90)))
+
+# Timing test executables
+TIMING_EXECS ?= \
+  $(basename $(notdir $(wildcard ../config_src/drivers/timing_tests/*.F90)))
+
 
 #---
 # Test configuration
 
-# REPRO tests enable reproducibility with optimization, and often do not match
-# the DEBUG results in older GCCs and vendor compilers, so we can optionally
-# disable them.
-ifeq ($(DO_REPRO_TESTS), true)
-  BUILDS += repro/MOM6
+# Set if either DO_COVERAGE or DO_UNIT_TESTS is set
+run_unit_tests =
+
+# REPRO and DEBUG equivalence
+ifdef DO_REPRO_TESTS
+  EXECS += repro/MOM6
   TESTS += repro
 endif
 
 # Profiling
-ifeq ($(DO_PROFILE), true)
-  BUILDS += opt/MOM6 opt_target/MOM6
+ifdef DO_PROFILE
+  EXECS += opt/MOM6 opt_target/MOM6
 endif
 
 # Coverage
-ifeq ($(DO_COVERAGE), true)
-  BUILDS += cov/MOM6
+ifdef DO_COVERAGE
+  EXECS += cov/MOM6
+  run_unit_execs = yes
 endif
 
-# Unit testing (or coverage)
-UNIT_EXECS ?= $(basename $(notdir $(wildcard ../config_src/drivers/unit_tests/*.F90) ) )
-TIMING_EXECS ?= $(basename $(notdir $(wildcard ../config_src/drivers/timing_tests/*.F90) ) )
-ifneq (X$(DO_COVERAGE)$(DO_UNIT_TESTS)X, XX)
-  BUILDS += $(foreach e, $(UNIT_EXECS), unit/$(e))
+# Unit test executables
+ifdef DO_UNIT_TESTS
+  run_unit_tests = yes
 endif
 
-ifeq ($(DO_PROFILE), false)
-  BUILDS += opt/MOM6 opt_target/MOM6
+# If either coverage or unit tests are enabled, build the unit test execs
+ifdef run_unit_tests
+  EXECS += $(foreach e, $(UNIT_EXECS), unit/$(e))
 endif
 
-
-DO_REGRESSION_TESTS ?=
-ifeq ($(DO_REGRESSION_TESTS), true)
-  BUILDS += target/MOM6
+# Regression testing
+ifdef DO_REGRESSION_TESTS
+  EXECS += target/MOM6
   TESTS += regression
 
   MOM_TARGET_SLUG ?= NOAA-GFDL/MOM6
@@ -182,12 +199,13 @@ ifeq ($(DO_REGRESSION_TESTS), true)
   MOM_TARGET_LOCAL_BRANCH ?= dev/gfdl
   MOM_TARGET_BRANCH := origin/$(MOM_TARGET_LOCAL_BRANCH)
 
-  TARGET_CODEBASE = build/target_codebase
+  TARGET_CODEBASE = $(BUILD)/target_codebase
 else
   MOM_TARGET_URL =
   MOM_TARGET_BRANCH =
   TARGET_CODEBASE =
 endif
+
 
 # List of source files to link this Makefile's dependencies to model Makefiles
 # Assumes a depth of two, and the following extensions: F90 inc c h
@@ -202,31 +220,30 @@ MOM_SOURCE = \
   $(wildcard ../config_src/ext*/*/*.F90)
 
 TARGET_SOURCE = \
-  $(call SOURCE,build/target_codebase/src) \
-  $(wildcard build/target_codebase/config_src/drivers/solo_driver/*.F90) \
-  $(wildcard build/target_codebase/config_src/ext*/*.F90)
+  $(call SOURCE,$(BUILD)/target_codebase/src) \
+  $(wildcard $(BUILD)/target_codebase/config_src/drivers/solo_driver/*.F90) \
+  $(wildcard $(BUILD)target_codebase/config_src/ext*/*.F90)
 
-# NOTE: Current default framework is FMS1, but this could change.
-ifeq ($(FRAMEWORK), fms2)
-  MOM_SOURCE +=$(wildcard ../config_src/infra/FMS2/*.F90)
-  TARGET_SOURCE += $(wildcard build/target_codebase/config_src/infra/FMS2/*.F90)
-else
+ifeq ($(FRAMEWORK), fms1)
   MOM_SOURCE += $(wildcard ../config_src/infra/FMS1/*.F90)
-  TARGET_SOURCE += $(wildcard build/target_codebase/config_src/infra/FMS1/*.F90)
+  TARGET_SOURCE += $(wildcard $(BUILD)/target_codebase/config_src/infra/FMS1/*.F90)
+else
+  MOM_SOURCE +=$(wildcard ../config_src/infra/FMS2/*.F90)
+  TARGET_SOURCE += $(wildcard $(BUILD)/target_codebase/config_src/infra/FMS2/*.F90)
 endif
 
-FMS_SOURCE = $(call SOURCE,deps/fms/src)
+FMS_SOURCE = $(call SOURCE,$(DEPS)/fms/src)
 
-#---
-# Rules
+
+## Rules
 
 .PHONY: all build.regressions build.prof
-all: $(foreach b,$(BUILDS),build/$(b))
-build.regressions: $(foreach b,symmetric target,build/$(b)/MOM6)
-build.prof: $(foreach b,opt opt_target,build/$(b)/MOM6)
+all: $(foreach b,$(EXECS),$(BUILD)/$(b))
+build.regressions: $(foreach b,symmetric target,$(BUILD)/$(b)/MOM6)
+build.prof: $(foreach b,opt opt_target,$(BUILD)/$(b)/MOM6)
 
 # Executable
-.PRECIOUS: $(foreach b,$(BUILDS),build/$(b))
+.PRECIOUS: $(foreach b,$(EXECS),$(BUILD)/$(b))
 
 
 # Compiler flags
@@ -234,9 +251,9 @@ build.prof: $(foreach b,opt opt_target,build/$(b)/MOM6)
 # .testing dependencies
 # TODO: We should probably build TARGET with the FMS that it was configured
 #   to use.  But for now we use the same FMS over all builds.
-FCFLAGS_DEPS = -I../../deps/include
-LDFLAGS_DEPS = -L../../deps/lib
-PATH_DEPS = PATH="${PATH}:../../deps/bin"
+FCFLAGS_DEPS = -I$(abspath $(DEPS)/include)
+LDFLAGS_DEPS = -L$(abspath $(DEPS)/lib)
+PATH_DEPS = PATH="${PATH}:$(abspath $(DEPS)/bin)"
 
 
 # Define the build targets in terms of the traditional DEBUG/REPRO/etc labels
@@ -254,82 +271,96 @@ COV_LDFLAGS := LDFLAGS="$(LDFLAGS_COVERAGE) $(LDFLAGS_DEPS) $(LDFLAGS_USER)"
 
 # Environment variable configuration
 MOM_ENV := $(PATH_FMS)
-build/symmetric/Makefile: MOM_ENV += $(SYMMETRIC_FCFLAGS) $(MOM_LDFLAGS)
-build/asymmetric/Makefile: MOM_ENV += $(ASYMMETRIC_FCFLAGS) $(MOM_LDFLAGS) \
-  MOM_MEMORY=../../../config_src/memory/dynamic_nonsymmetric/MOM_memory.h
-build/repro/Makefile: MOM_ENV += $(REPRO_FCFLAGS) $(MOM_LDFLAGS)
-build/openmp/Makefile: MOM_ENV += $(OPENMP_FCFLAGS) $(MOM_LDFLAGS)
-build/target/Makefile: MOM_ENV += $(TARGET_FCFLAGS) $(MOM_LDFLAGS)
-build/opt/Makefile: MOM_ENV += $(OPT_FCFLAGS) $(MOM_LDFLAGS)
-build/opt_target/Makefile: MOM_ENV += $(OPT_FCFLAGS) $(MOM_LDFLAGS)
-build/coupled/Makefile: MOM_ENV += $(SYMMETRIC_FCFLAGS) $(MOM_LDFLAGS)
-build/nuopc/Makefile: MOM_ENV += $(SYMMETRIC_FCFLAGS) $(MOM_LDFLAGS)
-build/cov/Makefile: MOM_ENV += $(COV_FCFLAGS) $(COV_LDFLAGS)
-build/unit/Makefile: MOM_ENV += $(COV_FCFLAGS) $(COV_LDFLAGS)
-build/timing/Makefile: MOM_ENV += $(OPT_FCFLAGS) $(MOM_LDFLAGS)
+$(BUILD)/symmetric/Makefile: MOM_ENV += $(SYMMETRIC_FCFLAGS) $(MOM_LDFLAGS)
+$(BUILD)/asymmetric/Makefile: MOM_ENV += $(ASYMMETRIC_FCFLAGS) $(MOM_LDFLAGS) \
+  MOM_MEMORY=$(AC_SRCDIR)/../config_src/memory/dynamic_nonsymmetric/MOM_memory.h
+$(BUILD)/repro/Makefile: MOM_ENV += $(REPRO_FCFLAGS) $(MOM_LDFLAGS)
+$(BUILD)/openmp/Makefile: MOM_ENV += $(OPENMP_FCFLAGS) $(MOM_LDFLAGS)
+$(BUILD)/target/Makefile: MOM_ENV += $(TARGET_FCFLAGS) $(MOM_LDFLAGS)
+$(BUILD)/opt/Makefile: MOM_ENV += $(OPT_FCFLAGS) $(MOM_LDFLAGS)
+$(BUILD)/opt_target/Makefile: MOM_ENV += $(OPT_FCFLAGS) $(MOM_LDFLAGS)
+$(BUILD)/coupled/Makefile: MOM_ENV += $(SYMMETRIC_FCFLAGS) $(MOM_LDFLAGS)
+$(BUILD)/nuopc/Makefile: MOM_ENV += $(SYMMETRIC_FCFLAGS) $(MOM_LDFLAGS)
+$(BUILD)/cov/Makefile: MOM_ENV += $(COV_FCFLAGS) $(COV_LDFLAGS)
+$(BUILD)/unit/Makefile: MOM_ENV += $(COV_FCFLAGS) $(COV_LDFLAGS)
+$(BUILD)/timing/Makefile: MOM_ENV += $(OPT_FCFLAGS) $(MOM_LDFLAGS)
 
 # Configure script flags
 MOM_ACFLAGS := --with-framework=$(FRAMEWORK)
-build/openmp/Makefile: MOM_ACFLAGS += --enable-openmp
-build/coupled/Makefile: MOM_ACFLAGS += --with-driver=FMS_cap
-build/nuopc/Makefile: MOM_ACFLAGS += --with-driver=nuopc_cap
-build/unit/Makefile: MOM_ACFLAGS += --with-driver=unit_tests
-build/timing/Makefile: MOM_ACFLAGS += --with-driver=timing_tests
-
-# Fetch regression target source code
-build/target/Makefile: | $(TARGET_CODEBASE)
-build/opt_target/Makefile: | $(TARGET_CODEBASE)
-
-
-# Define source code dependencies
-build/target_codebase/configure: $(TARGET_SOURCE)
+$(BUILD)/openmp/Makefile: MOM_ACFLAGS += --enable-openmp
+$(BUILD)/coupled/Makefile: MOM_ACFLAGS += --with-driver=FMS_cap
+$(BUILD)/nuopc/Makefile: MOM_ACFLAGS += --with-driver=nuopc_cap
+$(BUILD)/unit/Makefile: MOM_ACFLAGS += --with-driver=unit_tests
+$(BUILD)/timing/Makefile: MOM_ACFLAGS += --with-driver=timing_tests
 
 
 # Build executables
-build/unit/test_%: build/unit/Makefile FORCE
+$(BUILD)/unit/test_%: $(BUILD)/unit/Makefile FORCE
 	cd $(@D) && $(TIME) $(MAKE) $(@F) -j
-build/unit/Makefile: $(foreach e,$(UNIT_EXECS),../config_src/drivers/unit_tests/$(e).F90)
-build/timing/time_%: build/timing/Makefile FORCE
+$(BUILD)/unit/Makefile: $(foreach e,$(UNIT_EXECS),../config_src/drivers/unit_tests/$(e).F90)
+$(BUILD)/timing/time_%: $(BUILD)/timing/Makefile FORCE
 	cd $(@D) && $(TIME) $(MAKE) $(@F) -j
-build/timing/Makefile: $(foreach e,$(TIMING_EXECS),../config_src/drivers/timing_tests/$(e).F90)
-build/%/MOM6: build/%/Makefile FORCE
+$(BUILD)/timing/Makefile: $(foreach e,$(TIMING_EXECS),../config_src/drivers/timing_tests/$(e).F90)
+$(BUILD)/%/MOM6: $(BUILD)/%/Makefile FORCE
 	cd $(@D) && $(TIME) $(MAKE) $(@F) -j
-FORCE: ;
+FORCE:
 
 
-# Use autoconf to construct the Makefile for each target
-.PRECIOUS: build/%/Makefile
-build/%/Makefile: ../ac/configure ../ac/Makefile.in deps/lib/libFMS.a
-	mkdir -p $(@D)
-	cd $(@D) \
-	&& $(MOM_ENV) ../../../ac/configure $(MOM_ACFLAGS) \
-	|| (cat config.log && false)
+## Use autoconf to construct the Makefile for each target
+# TODO: This could all be moved to a top-level MOM6 Makefile
+.PRECIOUS: $(BUILD)/%/Makefile
+.PRECIOUS: $(BUILD)/%/Makefile.in
+.PRECIOUS: $(BUILD)/%/configure
+.PRECIOUS: $(BUILD)/%/config.status
+.PRECIOUS: $(BUILD)/%/configure.ac
+.PRECIOUS: $(BUILD)/%/m4/
 
+$(BUILD)/%/Makefile: $(BUILD)/%/Makefile.in $(BUILD)/%/config.status
+	cd $(@D) && ./config.status
 
-../ac/configure: ../ac/configure.ac ../ac/m4
-	autoreconf -i $<
+$(BUILD)/%/config.status: $(BUILD)/%/configure $(DEPS)/lib/libFMS.a
+	cd $(@D) && $(MOM_ENV) ./configure -n --srcdir=$(AC_SRCDIR) $(MOM_ACFLAGS) \
+	 || (cat config.log && false)
 
+$(BUILD)/%/Makefile.in: ../ac/Makefile.in | $(BUILD)/%/
+	cp ../ac/Makefile.in $(@D)
+
+$(BUILD)/%/configure: $(BUILD)/%/configure.ac $(BUILD)/%/m4/
+	autoreconf -if $(@D)
+
+$(BUILD)/%/configure.ac: ../ac/configure.ac | $(BUILD)/%/
+	cp ../ac/configure.ac $(@D)
+
+$(BUILD)/%/m4/: ../ac/m4/ | $(BUILD)/%/
+	cp -r ../ac/m4 $(@D)
+
+ALL_EXECS = symmetric asymmetric repro openmp target opt opt_target coupled \
+  nuopc cov unit timing
+$(foreach b,$(ALL_EXECS),$(BUILD)/$(b)/):
+	mkdir -p $@
 
 # Fetch the regression target codebase
-build/target/Makefile build/opt_target/Makefile: \
-  $(TARGET_CODEBASE)/ac/configure deps/lib/libFMS.a
-	mkdir -p $(@D)
-	cd $(@D) \
-	&& $(MOM_ENV) ../../$(TARGET_CODEBASE)/ac/configure $(MOM_ACFLAGS) \
+
+$(BUILD)/target/config.status: $(BUILD)/target/configure $(DEPS)/lib/libFMS.a
+	cd $(@D) && $(MOM_ENV) ./configure -n \
+	  --srcdir=$(abspath $(BUILD))/target_codebase/ac $(MOM_ACFLAGS) \
 	|| (cat config.log && false)
 
+$(BUILD)/target/Makefile.in: | $(TARGET_CODEBASE) $(BUILD)/target/
+	cp $(TARGET_CODEBASE)/ac/Makefile.in $(@D)
 
-$(TARGET_CODEBASE)/ac/configure: $(TARGET_CODEBASE)
-	autoreconf -i $</ac
+$(BUILD)/target/configure.ac: | $(TARGET_CODEBASE) $(BUILD)/target/
+	cp $(TARGET_CODEBASE)/ac/configure.ac $(@D)
 
+$(BUILD)/target/m4/: | $(TARGET_CODEBASE) $(BUILD)/target/
+	cp -r $(TARGET_CODEBASE)/ac/m4 $(@D)
 
 $(TARGET_CODEBASE):
 	git clone --recursive $(MOM_TARGET_URL) $@
 	cd $@ && git checkout --recurse-submodules $(MOM_TARGET_BRANCH)
 
 
-#---
-# FMS
+## FMS
 
 # Set up the FMS build environment variables
 FMS_ENV = \
@@ -337,47 +368,40 @@ FMS_ENV = \
   FCFLAGS="$(FCFLAGS_FMS)" \
   REPORT_ERROR_LOGS="$(REPORT_ERROR_LOGS)"
 
-deps/lib/libFMS.a: deps/Makefile deps/Makefile.fms.in deps/configure.fms.ac deps/m4
-	$(FMS_ENV) $(MAKE) -C deps lib/libFMS.a
+$(DEPS)/lib/libFMS.a: $(DEPS)/Makefile $(DEPS)/Makefile.fms.in $(DEPS)/configure.fms.ac $(DEPS)/m4
+	$(FMS_ENV) $(MAKE) -C $(DEPS) lib/libFMS.a
 
-deps/Makefile: ../ac/deps/Makefile | deps
-	cp ../ac/deps/Makefile deps/Makefile
+$(DEPS)/Makefile: ../ac/deps/Makefile | $(DEPS)
+	cp ../ac/deps/Makefile $(DEPS)/Makefile
 
-deps/Makefile.fms.in: ../ac/deps/Makefile.fms.in | deps
-	cp ../ac/deps/Makefile.fms.in deps/Makefile.fms.in
+$(DEPS)/Makefile.fms.in: ../ac/deps/Makefile.fms.in | $(DEPS)
+	cp ../ac/deps/Makefile.fms.in $(DEPS)/Makefile.fms.in
 
-deps/configure.fms.ac: ../ac/deps/configure.fms.ac | deps
-	cp ../ac/deps/configure.fms.ac deps/configure.fms.ac
+$(DEPS)/configure.fms.ac: ../ac/deps/configure.fms.ac | $(DEPS)
+	cp ../ac/deps/configure.fms.ac $(DEPS)/configure.fms.ac
 
-deps/m4: ../ac/deps/m4 | deps
-	cp -r ../ac/deps/m4 deps/
+$(DEPS)/m4: ../ac/deps/m4 | $(DEPS)
+	cp -r ../ac/deps/m4 $(DEPS)/
 
-deps:
-	mkdir -p deps
+$(DEPS):
+	mkdir -p $(DEPS)
 
 #---
-# The following block does a non-library build of a coupled driver interface to
-# MOM, along with everything below it.  This simply checks that we have not
-# broken the ability to compile.  This is not a means to build a complete
-# coupled executable.
-# TODO:
-#   - Avoid re-building FMS and MOM6 src by re-using existing object/mod files
-#   - Use autoconf rather than mkmf templates
-MK_TEMPLATE ?= ../../deps/mkmf/templates/ncrc-gnu.mk
+# Verify that the coupled model drivers can be compiled.  This does not verify
+# that they can be run, since it would require external submodels.
 
 # NUOPC driver
-build/nuopc/mom_ocean_model_nuopc.o: build/nuopc/Makefile
+$(BUILD)/nuopc/mom_ocean_model_nuopc.o: $(BUILD)/nuopc/Makefile
 	cd $(@D) && make $(@F)
-check_mom6_api_nuopc: build/nuopc/mom_ocean_model_nuopc.o
+check_mom6_api_nuopc: $(BUILD)/nuopc/mom_ocean_model_nuopc.o
 
 # GFDL coupled driver
-build/coupled/ocean_model_MOM.o: build/coupled/Makefile
+$(BUILD)/coupled/ocean_model_MOM.o: $(BUILD)/coupled/Makefile
 	cd $(@D) && make $(@F)
-check_mom6_api_coupled: build/coupled/ocean_model_MOM.o
+check_mom6_api_coupled: $(BUILD)/coupled/ocean_model_MOM.o
 
 
-#---
-# Testing
+## Testing
 
 .PHONY: test
 test: $(foreach t,$(TESTS),test.$(t))
@@ -405,11 +429,11 @@ endef
 $(foreach d,$(DIMS),$(eval $(call TEST_DIM_RULE,$(d))))
 
 .PHONY: run.symmetric run.asymmetric run.nans run.openmp run.cov
-run.symmetric: $(foreach c,$(CONFIGS),$(WORKSPACE)/work/$(c)/symmetric/ocean.stats)
-run.asymmetric: $(foreach c,$(filter-out tc3,$(CONFIGS)),$(CONFIGS),$(WORKSPACE)/work/$(c)/asymmetric/ocean.stats)
-run.nan: $(foreach c,$(CONFIGS),$(WORKSPACE)/work/$(c)/nan/ocean.stats)
-run.openmp: $(foreach c,$(CONFIGS),$(WORKSPACE)/work/$(c)/openmp/ocean.stats)
-run.cov: $(foreach c,$(CONFIGS),$(WORKSPACE)/work/$(c)/cov/ocean.stats)
+run.symmetric: $(foreach c,$(CONFIGS),$(WORK)/$(c)/symmetric/ocean.stats)
+run.asymmetric: $(foreach c,$(filter-out tc3,$(CONFIGS)),$(CONFIGS),$(WORK)/$(c)/asymmetric/ocean.stats)
+run.nan: $(foreach c,$(CONFIGS),$(WORK)/$(c)/nan/ocean.stats)
+run.openmp: $(foreach c,$(CONFIGS),$(WORK)/$(c)/openmp/ocean.stats)
+run.cov: $(foreach c,$(CONFIGS),$(WORK)/$(c)/cov/ocean.stats)
 
 # Configuration test rules
 # $(1): Configuration name (tc1, tc2, &c.)
@@ -441,21 +465,21 @@ FAIL = ${RED}FAIL${RESET}
 # $(2): Test type (grid, layout, &c.)
 # $(3): Comparison targets (symmetric asymmetric, symmetric layout, &c.)
 define CMP_RULE
-.PRECIOUS: $(foreach b,$(3),$(WORKSPACE)/work/$(1)/$(b)/ocean.stats)
-$(1).$(2): $(foreach b,$(3),$(WORKSPACE)/work/$(1)/$(b)/ocean.stats)
-	@test "$$(shell ls -A $(WORKSPACE)/results/$(1) 2>/dev/null)" || rm -rf $(WORKSPACE)/results/$(1)
+.PRECIOUS: $(foreach b,$(3),$(WORK)/$(1)/$(b)/ocean.stats)
+$(1).$(2): $(foreach b,$(3),$(WORK)/$(1)/$(b)/ocean.stats)
+	@test "$$(shell ls -A $(WORK)/results/$(1) 2>/dev/null)" || rm -rf $(WORK)/results/$(1)
 	@cmp $$^ || !( \
-	  mkdir -p $(WORKSPACE)/results/$(1); \
-	  (diff $$^ | tee $(WORKSPACE)/results/$(1)/ocean.stats.$(2).diff | head -n 20) ; \
+	  mkdir -p $(WORK)/results/$(1); \
+	  (diff $$^ | tee $(WORK)/results/$(1)/ocean.stats.$(2).diff | head -n 20) ; \
 	  echo -e "$(FAIL): Solutions $(1).$(2) have changed." \
 	)
 	@echo -e "$(PASS): Solutions $(1).$(2) agree."
 
-.PRECIOUS: $(foreach b,$(3),$(WORKSPACE)/work/$(1)/$(b)/chksum_diag)
-$(1).$(2).diag: $(foreach b,$(3),$(WORKSPACE)/work/$(1)/$(b)/chksum_diag)
+.PRECIOUS: $(foreach b,$(3),$(WORK)/$(1)/$(b)/chksum_diag)
+$(1).$(2).diag: $(foreach b,$(3),$(WORK)/$(1)/$(b)/chksum_diag)
 	@cmp $$^ || !( \
-	  mkdir -p $(WORKSPACE)/results/$(1); \
-	  (diff $$^ | tee $(WORKSPACE)/results/$(1)/chksum_diag.$(2).diff | head -n 20) ; \
+	  mkdir -p $(WORK)/results/$(1); \
+	  (diff $$^ | tee $(WORK)/results/$(1)/chksum_diag.$(2).diff | head -n 20) ; \
 	  echo -e "$(FAIL): Diagnostics $(1).$(2).diag have changed." \
 	)
 	@echo -e "$(PASS): Diagnostics $(1).$(2).diag agree."
@@ -473,17 +497,17 @@ $(foreach d,$(DIMS),$(eval $(call CMP_RULE,$(1),dim.$(d),symmetric dim.$(d))))
 endef
 $(foreach c,$(CONFIGS),$(eval $(call CONFIG_DIM_RULE,$(c))))
 
+
 # Custom comparison rules
 
-
 # Restart tests only compare the final stat record
-.PRECIOUS: $(foreach b,symmetric restart target,$(WORKSPACE)/work/%/$(b)/ocean.stats)
-%.restart: $(foreach b,symmetric restart,$(WORKSPACE)/work/%/$(b)/ocean.stats)
-	@test "$(shell ls -A $(WORKSPACE)/results/$* 2>/dev/null)" || rm -rf $(WORKSPACE)/results/$*
+.PRECIOUS: $(foreach b,symmetric restart target,$(WORK)/%/$(b)/ocean.stats)
+%.restart: $(foreach b,symmetric restart,$(WORK)/%/$(b)/ocean.stats)
+	@test "$(shell ls -A $(WORK)/results/$* 2>/dev/null)" || rm -rf $(WORK)/results/$*
 	@cmp $(foreach f,$^,<(tr -s ' ' < $(f) | cut -d ' ' -f3- | tail -n 1)) \
 	  || !( \
-	    mkdir -p $(WORKSPACE)/results/$*; \
-	    (diff $^ | tee $(WORKSPACE)/results/$*/chksum_diag.restart.diff | head -n 20) ; \
+	    mkdir -p $(WORK)/results/$*; \
+	    (diff $^ | tee $(WORK)/results/$*/chksum_diag.restart.diff | head -n 20) ; \
 	    echo -e "$(FAIL): Solutions $*.restart have changed." \
 	  )
 	@echo -e "$(PASS): Solutions $*.restart agree."
@@ -491,21 +515,22 @@ $(foreach c,$(CONFIGS),$(eval $(call CONFIG_DIM_RULE,$(c))))
 # TODO: chksum_diag parsing of restart files
 
 # stats rule is unchanged, but we cannot use CMP_RULE to generate it.
-%.regression: $(foreach b,symmetric target,$(WORKSPACE)/work/%/$(b)/ocean.stats)
-	@test "$(shell ls -A $(WORKSPACE)/results/$* 2>/dev/null)" || rm -rf $(WORKSPACE)/results/$*
+%.regression: $(foreach b,symmetric target,$(WORK)/%/$(b)/ocean.stats)
+	@test "$(shell ls -A $(WORK)/results/$* 2>/dev/null)" || rm -rf $(WORK)/results/$*
 	@cmp $^ || !( \
-	  mkdir -p $(WORKSPACE)/results/$*; \
-	  (diff $^ | tee $(WORKSPACE)/results/$*/ocean.stats.regression.diff | head -n 20) ; \
+	  mkdir -p $(WORK)/results/$*; \
+	  (diff $^ | tee $(WORK)/results/$*/ocean.stats.regression.diff | head -n 20) ; \
 	  echo -e "$(FAIL): Solutions $*.regression have changed." \
 	)
 	@echo -e "$(PASS): Solutions $*.regression agree."
 
 # Regression testing only checks for changes in existing diagnostics
-%.regression.diag: $(foreach b,symmetric target,$(WORKSPACE)/work/%/$(b)/chksum_diag)
+.PRECIOUS: $(WORK)/%/target/chksum_diag
+%.regression.diag: $(foreach b,symmetric target,$(WORK)/%/$(b)/chksum_diag)
 	@! diff $^ | grep "^[<>]" | grep "^>" > /dev/null \
 	  || ! (\
-	    mkdir -p $(WORKSPACE)/results/$*; \
-	    (diff $^ | tee $(WORKSPACE)/results/$*/chksum_diag.regression.diff | head -n 20) ; \
+	    mkdir -p $(WORK)/results/$*; \
+	    (diff $^ | tee $(WORK)/results/$*/chksum_diag.regression.diff | head -n 20) ; \
 	    echo -e "$(FAIL): Diagnostics $*.regression.diag have changed." \
 	  )
 	@cmp $^ || ( \
@@ -534,7 +559,7 @@ tc4/configure: tc4/configure.ac
 #---
 # Test run output files
 
-# Rule to build $(WORKSPACE)/work/<tc>/{ocean.stats,chksum_diag}.<tag>
+# Rule to build $(WORK)/<tc>/{ocean.stats,chksum_diag}.<tag>
 # $(1): Test configuration name <tag>
 # $(2): Executable type
 # $(3): Enable coverage flag
@@ -543,15 +568,14 @@ tc4/configure: tc4/configure.ac
 # $(6): Number of MPI ranks
 
 define STAT_RULE
-$(WORKSPACE)/work/%/$(1)/ocean.stats $(WORKSPACE)/work/%/$(1)/chksum_diag: build/$(2)/MOM6 | preproc
+$(WORK)/%/$(1)/ocean.stats $(WORK)/%/$(1)/chksum_diag: $(BUILD)/$(2)/MOM6 | preproc
 	@echo "Running test $$*.$(1)..."
 	mkdir -p $$(@D)
 	cp -RL $$*/* $$(@D)
-	mkdir -p $$(@D)/RESTART
 	echo -e "$(4)" > $$(@D)/MOM_override
-	rm -f $(WORKSPACE)/results/$$*/std.$(1).{out,err}
+	rm -f $(WORK)/results/$$*/std.$(1).{out,err}
 	cd $$(@D) \
-	  && $(TIME) $(5) $(MPIRUN) -n $(6) $(abspath $$<) 2> std.err > std.out \
+	  && $(TIME) $(5) $(MPIRUN) -n $(6) $$(abspath $$<) 2> std.err > std.out \
 	  || !( \
 	    mkdir -p ../../../results/$$*/ ; \
 	    cat std.out | tee ../../../results/$$*/std.$(1).out | tail -n 40 ; \
@@ -561,8 +585,8 @@ $(WORKSPACE)/work/%/$(1)/ocean.stats $(WORKSPACE)/work/%/$(1)/chksum_diag: build
 	  )
 	@echo -e "$(DONE): $$*.$(1); no runtime errors."
 	if [ $(3) ]; then \
-	  mkdir -p $(WORKSPACE)/results/$$* ; \
-	  cd build/$(2) ; \
+	  mkdir -p $(WORK)/results/$$* ; \
+	  cd $(BUILD)/$(2) ; \
 	  gcov -b *.gcda > gcov.$$*.$(1).out ; \
 	  find -name "*.gcov" -exec sed -i -r 's/^( *[0-9]*)\*:/ \1:/g' {} \; ; \
 	fi
@@ -585,12 +609,12 @@ codecov:
 
 .PHONY: report.cov
 report.cov: run.cov codecov
-	./codecov $(CODECOV_TOKEN_ARG) -R build/cov -Z -f "*.gcov" \
-	  > build/cov/codecov.out \
-	  2> build/cov/codecov.err \
+	./codecov $(CODECOV_TOKEN_ARG) -R $(BUILD)/cov -Z -f "*.gcov" \
+	  > $(BUILD)/cov/codecov.out \
+	  2> $(BUILD)/cov/codecov.err \
 	  && echo -e "${MAGENTA}Report uploaded to codecov.${RESET}" \
 	  || { \
-	    cat build/cov/codecov.err ; \
+	    cat $(BUILD)/cov/codecov.err ; \
 	    echo -e "${RED}Failed to upload report.${RESET}" ; \
 	    if [ "$(REQUIRE_COVERAGE_UPLOAD)" = true ] ; then false ; fi ; \
 	  }
@@ -620,7 +644,7 @@ $(eval $(call STAT_RULE,cov,cov,true,,,1))
 #  2. Convert DAYMAX from TIMEUNIT to seconds
 #  3. Apply seconds to `ocean_solo_nml` inside input.nml.
 # NOTE: Assumes that runtime set by DAYMAX, will fail if set by input.nml
-$(WORKSPACE)/work/%/restart/ocean.stats: build/symmetric/MOM6 | preproc
+$(WORK)/%/restart/ocean.stats: $(BUILD)/symmetric/MOM6 | preproc
 	rm -rf $(@D)
 	mkdir -p $(@D)
 	cp -RL $*/* $(@D)
@@ -634,7 +658,7 @@ $(WORKSPACE)/work/%/restart/ocean.stats: build/symmetric/MOM6 | preproc
 	  && halfperiod=$$(awk -v t=$${daymax} -v dt=$${timeunit} 'BEGIN {printf "%.f", 0.5*t*dt}') \
 	  && printf "\n&ocean_solo_nml\n    seconds = $${halfperiod}\n/\n" >> input.nml
 	# Remove any previous archived output
-	rm -f $(WORKSPACE)/results/$*/std.restart{1,2}.{out,err}
+	rm -f $(WORK)/results/$*/std.restart{1,2}.{out,err}
 	# Run the first half-period
 	cd $(@D) && $(TIME) $(MPIRUN) -n 1 $(abspath $<) 2> std1.err > std1.out \
 	  || !( \
@@ -660,7 +684,7 @@ $(WORKSPACE)/work/%/restart/ocean.stats: build/symmetric/MOM6 | preproc
 # Not a true rule; only call this after `make test` to summarize test results.
 .PHONY: test.summary
 test.summary:
-	@./tools/report_test_results.sh $(WORKSPACE)/results
+	@./tools/report_test_results.sh $(WORK)/results
 
 
 #---
@@ -668,48 +692,50 @@ test.summary:
 
 # NOTE: Using file parser gcov report as a proxy for test completion
 .PHONY: run.cov.unit
-run.cov.unit: build/unit/MOM_file_parser_tests.F90.gcov
+run.cov.unit: $(BUILD)/unit/MOM_file_parser_tests.F90.gcov
 
 .PHONY: build.unit
-build.unit: $(foreach f, $(UNIT_EXECS), build/unit/$(f))
+build.unit: $(foreach f, $(UNIT_EXECS), $(BUILD)/unit/$(f))
 .PHONY: run.unit
 run.unit: $(foreach f, $(UNIT_EXECS), work/unit/$(f).out)
 .PHONY: build.timing
-build.timing: $(foreach f, $(TIMING_EXECS), build/timing/$(f))
+build.timing: $(foreach f, $(TIMING_EXECS), $(BUILD)/timing/$(f))
 .PHONY: run.timing
 run.timing: $(foreach f, $(TIMING_EXECS), work/timing/$(f).out)
 .PHONY: show.timing
 show.timing: $(foreach f, $(TIMING_EXECS), work/timing/$(f).show)
-$(WORKSPACE)/work/timing/%.show:
+$(WORK)/timing/%.show:
 	./tools/disp_timing.py $(@:.show=.out)
+
 
 # Invoke the above unit/timing rules for a "target" code
 # Invoke with appropriate macros defines, i.e.
-#   make build.timing_target MOM_TARGET_URL=... MOM_TARGET_BRANCH=... TARGET_CODEBASE=build/target_codebase
-#   make run.timing_target TARGET_CODEBASE=build/target_codebase
+#   make build.timing_target MOM_TARGET_URL=... MOM_TARGET_BRANCH=... TARGET_CODEBASE=$(BUILD)/target_codebase
+#   make run.timing_target TARGET_CODEBASE=$(BUILD)/target_codebase
 
 TIMING_TARGET_EXECS ?= $(basename $(notdir $(wildcard $(TARGET_CODEBASE)/config_src/drivers/timing_tests/*.F90) ) )
 
 .PHONY: build.timing_target
-build.timing_target: $(foreach f, $(TIMING_TARGET_EXECS), $(TARGET_CODEBASE)/.testing/build/timing/$(f))
+build.timing_target: $(foreach f, $(TIMING_TARGET_EXECS), $(TARGET_CODEBASE)/.testing/$(BUILD)/timing/$(f))
 .PHONY: run.timing_target
 run.timing_target: $(foreach f, $(TIMING_TARGET_EXECS), $(TARGET_CODEBASE)/.testing/work/timing/$(f).out)
 .PHONY: compare.timing
 compare.timing: $(foreach f, $(filter $(TIMING_EXECS),$(TIMING_TARGET_EXECS)), work/timing/$(f).compare)
-$(WORKSPACE)/work/timing/%.compare: $(TARGET_CODEBASE)
+$(WORK)/timing/%.compare: $(TARGET_CODEBASE)
 	./tools/disp_timing.py -r $(TARGET_CODEBASE)/.testing/$(@:.compare=.out) $(@:.compare=.out)
 $(TARGET_CODEBASE)/.testing/%: | $(TARGET_CODEBASE)
 	cd $(TARGET_CODEBASE)/.testing && make $*
 
+
 # General rule to run a unit test executable
-# Pattern is to run build/unit/executable and direct output to executable.out
-$(WORKSPACE)/work/unit/%.out: build/unit/%
+# Pattern is to run $(BUILD)/unit/executable and direct output to executable.out
+$(WORK)/unit/%.out: $(BUILD)/unit/%
 	@mkdir -p $(@D)
 	cd $(@D) ; $(TIME) $(MPIRUN) -n 1 $(abspath $<) 2> >(tee $*.err) > $*.out
 
-$(WORKSPACE)/work/unit/test_MOM_file_parser.out: build/unit/test_MOM_file_parser
+$(WORK)/unit/test_MOM_file_parser.out: $(BUILD)/unit/test_MOM_file_parser
 	if [ $(REPORT_COVERAGE) ]; then \
-	  find build/unit -name *.gcda -exec rm -f '{}' \; ; \
+	  find $(BUILD)/unit -name *.gcda -exec rm -f '{}' \; ; \
 	fi
 	mkdir -p $(@D)
 	cd $(@D) \
@@ -727,31 +753,31 @@ $(WORKSPACE)/work/unit/test_MOM_file_parser.out: build/unit/test_MOM_file_parser
 	  )
 
 # NOTE: .gcov actually depends on .gcda, but .gcda is produced with std.out
-# TODO: Replace $(WORKSPACE)/work/unit/std.out with *.gcda?
-build/unit/MOM_file_parser_tests.F90.gcov: $(WORKSPACE)/work/unit/test_MOM_file_parser.out
+# TODO: Replace $(WORK)/unit/std.out with *.gcda?
+$(BUILD)/unit/MOM_file_parser_tests.F90.gcov: $(WORK)/unit/test_MOM_file_parser.out
 	cd $(@D) \
 	  && gcov -b *.gcda > gcov.unit.out
 	find $(@D) -name "*.gcov" -exec sed -i -r 's/^( *[0-9]*)\*:/ \1:/g' {} \;
 
 .PHONY: report.cov.unit
-report.cov.unit: build/unit/MOM_file_parser_tests.F90.gcov codecov
-	./codecov $(CODECOV_TOKEN_ARG) -R build/unit -f "*.gcov" -Z -n "Unit tests" \
-	    > build/unit/codecov.out \
-	    2> build/unit/codecov.err \
+report.cov.unit: $(BUILD)/unit/MOM_file_parser_tests.F90.gcov codecov
+	./codecov $(CODECOV_TOKEN_ARG) -R $(BUILD)/unit -f "*.gcov" -Z -n "Unit tests" \
+	    > $(BUILD)/unit/codecov.out \
+	    2> $(BUILD)/unit/codecov.err \
 	  && echo -e "${MAGENTA}Report uploaded to codecov.${RESET}" \
 	  || { \
-	    cat build/unit/codecov.err ; \
+	    cat $(BUILD)/unit/codecov.err ; \
 	    echo -e "${RED}Failed to upload report.${RESET}" ; \
 	    if [ "$(REQUIRE_COVERAGE_UPLOAD)" = true ] ; then false ; fi ; \
 	  }
 
-$(WORKSPACE)/work/timing/%.out: build/timing/% FORCE
+$(WORK)/timing/%.out: $(BUILD)/timing/% FORCE
 	@mkdir -p $(@D)
 	@echo Running $< in $(@D)
 	@cd $(@D) ; $(TIME) $(MPIRUN) -n 1 $(abspath $<) 2> $*.err > $*.out
 
-#---
-# Profiling based on FMS clocks
+
+## Profiling based on FMS clocks
 
 PCONFIGS = p0
 
@@ -759,17 +785,17 @@ PCONFIGS = p0
 profile: $(foreach p,$(PCONFIGS), prof.$(p))
 
 .PHONY: prof.p0
-prof.p0: $(WORKSPACE)/work/p0/opt/clocks.json $(WORKSPACE)/work/p0/opt_target/clocks.json
+prof.p0: $(WORK)/p0/opt/clocks.json $(WORK)/p0/opt_target/clocks.json
 	python tools/compare_clocks.py $^
 
-$(WORKSPACE)/work/p0/%/clocks.json: $(WORKSPACE)/work/p0/%/std.out
+$(WORK)/p0/%/clocks.json: $(WORK)/p0/%/std.out
 	python tools/parse_fms_clocks.py -d $(@D) $^ > $@ \
 	  || !( rm $@ )
 
-$(WORKSPACE)/work/p0/opt/std.out: build/opt/MOM6
-$(WORKSPACE)/work/p0/opt_target/std.out: build/opt_target/MOM6
+$(WORK)/p0/opt/std.out: $(BUILD)/opt/MOM6
+$(WORK)/p0/opt_target/std.out: $(BUILD)/opt_target/MOM6
 
-$(WORKSPACE)/work/p0/%/std.out:
+$(WORK)/p0/%/std.out:
 	mkdir -p $(@D)
 	cp -RL p0/* $(@D)
 	mkdir -p $(@D)/RESTART
@@ -778,8 +804,7 @@ $(WORKSPACE)/work/p0/%/std.out:
 	  && $(MPIRUN) -n 1 $(abspath $<) 2> std.err > std.out
 
 
-#---
-# Profiling based on perf output
+## Profiling based on perf output
 
 # TODO: This expects the -e flag, can I handle it in the command?
 PERF_EVENTS ?=
@@ -788,16 +813,16 @@ PERF_EVENTS ?=
 perf: $(foreach p,$(PCONFIGS), perf.$(p))
 
 .PHONY: prof.p0
-perf.p0: $(WORKSPACE)/work/p0/opt/profile.json $(WORKSPACE)/work/p0/opt_target/profile.json
+perf.p0: $(WORK)/p0/opt/profile.json $(WORK)/p0/opt_target/profile.json
 	python tools/compare_perf.py $^
 
-$(WORKSPACE)/work/p0/%/profile.json: $(WORKSPACE)/work/p0/%/perf.data
+$(WORK)/p0/%/profile.json: $(WORK)/p0/%/perf.data
 	python tools/parse_perf.py -f $< > $@
 
-$(WORKSPACE)/work/p0/opt/perf.data: build/opt/MOM6
-$(WORKSPACE)/work/p0/opt_target/perf.data: build/opt_target/MOM6
+$(WORK)/p0/opt/perf.data: $(BUILD)/opt/MOM6
+$(WORK)/p0/opt_target/perf.data: $(BUILD)/opt_target/MOM6
 
-$(WORKSPACE)/work/p0/%/perf.data:
+$(WORK)/p0/%/perf.data:
 	mkdir -p $(@D)
 	cp -RL p0/* $(@D)
 	mkdir -p $(@D)/RESTART
@@ -810,25 +835,26 @@ $(WORKSPACE)/work/p0/%/perf.data:
 	  || cat std.perf.err
 
 
-#----
+## Cleanup
 # NOTE: These tests assert that we are in the .testing directory.
 
 .PHONY: clean
 clean: clean.build clean.stats
-	@[ $$(basename $$(pwd)) = .testing ]
-	rm -rf deps
+	rm -rf $(BUILD)
 
 
 .PHONY: clean.build
 clean.build:
 	@[ $$(basename $$(pwd)) = .testing ]
-	rm -rf build
+	for b in $(ALL_EXECS); do \
+	  rm -rf $(BUILD)/$${b}; \
+	done
 
 
 .PHONY: clean.stats
 clean.stats:
 	@[ $$(basename $$(pwd)) = .testing ]
-	rm -rf $(WORKSPACE)/work $(WORKSPACE)/results
+	rm -rf $(WORK)
 
 
 .PHONY: clean.preproc

--- a/.testing/Makefile
+++ b/.testing/Makefile
@@ -133,9 +133,6 @@ TIME ?= time
 WORKSPACE ?= .
 
 # Set directories for build/ and work/
-#BUILD ?= $(WORKSPACE)build
-#DEPS ?= $(BUILD)/deps
-#WORK ?= $(WORKSPACE)work
 BUILD ?= $(WORKSPACE)/build
 DEPS ?= $(BUILD)/deps
 WORK ?= $(WORKSPACE)/work
@@ -207,34 +204,6 @@ else
 endif
 
 
-# List of source files to link this Makefile's dependencies to model Makefiles
-# Assumes a depth of two, and the following extensions: F90 inc c h
-# (1): Root directory
-# NOTE: extensions could be a second variable
-SOURCE = \
-  $(foreach ext,F90 inc c h,$(wildcard $(1)/*/*.$(ext) $(1)/*/*/*.$(ext)))
-
-MOM_SOURCE = \
-  $(call SOURCE,../src) \
-  $(wildcard ../config_src/drivers/solo_driver/*.F90) \
-  $(wildcard ../config_src/ext*/*/*.F90)
-
-TARGET_SOURCE = \
-  $(call SOURCE,$(BUILD)/target_codebase/src) \
-  $(wildcard $(BUILD)/target_codebase/config_src/drivers/solo_driver/*.F90) \
-  $(wildcard $(BUILD)target_codebase/config_src/ext*/*.F90)
-
-ifeq ($(FRAMEWORK), fms1)
-  MOM_SOURCE += $(wildcard ../config_src/infra/FMS1/*.F90)
-  TARGET_SOURCE += $(wildcard $(BUILD)/target_codebase/config_src/infra/FMS1/*.F90)
-else
-  MOM_SOURCE +=$(wildcard ../config_src/infra/FMS2/*.F90)
-  TARGET_SOURCE += $(wildcard $(BUILD)/target_codebase/config_src/infra/FMS2/*.F90)
-endif
-
-FMS_SOURCE = $(call SOURCE,$(DEPS)/fms/src)
-
-
 ## Rules
 
 .PHONY: all build.regressions build.prof
@@ -297,11 +266,21 @@ $(BUILD)/timing/Makefile: MOM_ACFLAGS += --with-driver=timing_tests
 $(BUILD)/unit/test_%: $(BUILD)/unit/Makefile FORCE
 	cd $(@D) && $(TIME) $(MAKE) $(@F) -j
 $(BUILD)/unit/Makefile: $(foreach e,$(UNIT_EXECS),../config_src/drivers/unit_tests/$(e).F90)
+
 $(BUILD)/timing/time_%: $(BUILD)/timing/Makefile FORCE
 	cd $(@D) && $(TIME) $(MAKE) $(@F) -j
 $(BUILD)/timing/Makefile: $(foreach e,$(TIMING_EXECS),../config_src/drivers/timing_tests/$(e).F90)
+
 $(BUILD)/%/MOM6: $(BUILD)/%/Makefile FORCE
 	cd $(@D) && $(TIME) $(MAKE) $(@F) -j
+
+# Target codebase should use its own build system
+$(BUILD)/target/MOM6: $(BUILD)/target FORCE | $(TARGET_CODEBASE)
+	$(MAKE) -C $(TARGET_CODEBASE)/.testing build/symmetric/MOM6
+
+$(BUILD)/target: | $(TARGET_CODEBASE)
+	ln -s $(abspath $(TARGET_CODEBASE))/.testing/build/symmetric $@
+
 FORCE:
 
 
@@ -333,27 +312,12 @@ $(BUILD)/%/configure.ac: ../ac/configure.ac | $(BUILD)/%/
 $(BUILD)/%/m4/: ../ac/m4/ | $(BUILD)/%/
 	cp -r ../ac/m4 $(@D)
 
-ALL_EXECS = symmetric asymmetric repro openmp target opt opt_target coupled \
-  nuopc cov unit timing
+ALL_EXECS = symmetric asymmetric repro openmp opt opt_target coupled nuopc \
+  cov unit timing
 $(foreach b,$(ALL_EXECS),$(BUILD)/$(b)/):
 	mkdir -p $@
 
 # Fetch the regression target codebase
-
-$(BUILD)/target/config.status: $(BUILD)/target/configure $(DEPS)/lib/libFMS.a
-	cd $(@D) && $(MOM_ENV) ./configure -n \
-	  --srcdir=$(abspath $(BUILD))/target_codebase/ac $(MOM_ACFLAGS) \
-	|| (cat config.log && false)
-
-$(BUILD)/target/Makefile.in: | $(TARGET_CODEBASE) $(BUILD)/target/
-	cp $(TARGET_CODEBASE)/ac/Makefile.in $(@D)
-
-$(BUILD)/target/configure.ac: | $(TARGET_CODEBASE) $(BUILD)/target/
-	cp $(TARGET_CODEBASE)/ac/configure.ac $(@D)
-
-$(BUILD)/target/m4/: | $(TARGET_CODEBASE) $(BUILD)/target/
-	cp -r $(TARGET_CODEBASE)/ac/m4 $(@D)
-
 $(TARGET_CODEBASE):
 	git clone --recursive $(MOM_TARGET_URL) $@
 	cd $@ && git checkout --recurse-submodules $(MOM_TARGET_BRANCH)

--- a/.testing/Makefile
+++ b/.testing/Makefile
@@ -20,7 +20,6 @@
 #
 # General test configuration:
 #   MPIRUN                  MPI job launcher (mpirun, srun, etc)
-#   FRAMEWORK               Model framework (fms1 or fms2)
 #   DO_REPRO_TESTS          Enable production ("repro") testing equivalence
 #   DO_REGRESSION_TESTS     Enable regression tests (usually dev/gfdl)
 #   DO_COVERAGE             Enable code coverage and generate .gcov reports
@@ -74,8 +73,11 @@ AC_SRCDIR := $(dir $(abspath $(lastword $(MAKEFILE_LIST))))../ac
 # User-defined configuration
 -include config.mk
 
-# Set the infra framework
-FRAMEWORK ?= fms2
+# Set the FMS library
+FMS_COMMIT ?= 2023.03
+FMS_URL ?= https://github.com/NOAA-GFDL/FMS.git
+export FMS_COMMIT
+export FMS_URL
 
 # Set the MPI launcher here
 # TODO: This needs more automated configuration

--- a/.testing/README.rst
+++ b/.testing/README.rst
@@ -47,9 +47,11 @@ Several of the following may require configuration for particular systems.
    Name of the MPI launcher.  Often this is ``mpirun`` or ``mpiexec`` but may
    all need to run through a scheduler, e.g. ``srun`` if using Slurm.
 
-``FRAMEWORK`` (*default:* ``fms1``)
-   Select either the legacy FMS framework (``fms1``) or an FMS2 I/O compatible
-   version (``fms2``).
+``FMS_COMMIT`` (*default:* ``2023.03``)
+   Set the FMS version, either by tag or commit (as defined in ``FMS_URL``).
+
+``FMS_URL`` (*default*: ``https://github.com/NOAA-GFDL/FMS.git``)
+   Set the URL of the FMS repository.
 
 ``DO_REPRO_TESTS`` (*default:* *none*)
    Set to ``true`` to test the REPRO build and confirm equivalence of DEBUG and

--- a/.testing/tools/parse_perf.py
+++ b/.testing/tools/parse_perf.py
@@ -3,9 +3,19 @@ import argparse
 import collections
 import json
 import os
+import re
 import shlex
 import subprocess
 import sys
+
+perf_scanner = re.Scanner([
+  (r'<', lambda scanner, token: token),
+  (r'>', lambda scanner, token: token),
+  (r'\(', lambda scanner, token: token),
+  (r'\)', lambda scanner, token: token),
+  (r'[ \t]+', lambda scanner, token: token),
+  (r'[^<>() \t]+', lambda scanner, token: token),
+])
 
 
 def main():
@@ -58,15 +68,55 @@ def parse_perf_report(perf_data_path):
 
             # get per-symbol count
             else:
+                tokens, remainder = perf_scanner.scan(line)
+                if remainder:
+                    print('Line could not be tokenized', file=sys.stderr)
+                    print(' line:', repr(line), file=sys.stderr)
+                    print(' tokens:', tokens, file=sys.stderr)
+                    print(' remainder:', remainder, file=sys.stderr)
+                    sys.exit(os.EX_DATAERR)
+
+                # Construct record from tokens
+                # (NOTE: Not a proper grammar, just dumb bracket counting)
+                record = []
+                bracks = 0
+                parens = 0
+
+                for tok in tokens:
+                    if tok == '<':
+                        bracks += 1
+
+                    if tok == '(':
+                        parens += 1
+
+                    rec = record[-1] if record else None
+
+                    inside_bracket = rec and (bracks > 0 or parens > 0)
+                    lead_rec = tok in '<(' and rec and not rec.isspace()
+                    tail_rec = not tok.isspace() and rec and rec[-1] in '>)'
+
+                    if inside_bracket or lead_rec or tail_rec:
+                        record[-1] += tok
+                    else:
+                        record.append(tok)
+
+                    if tok == '>':
+                        bracks -= 1
+                    if tok == '(':
+                        parens -= 1
+
+                # Strip any whitespace tokens
+                record = [rec for rec in record if not rec.isspace()]
+
                 try:
-                    tokens = line.split()
-                    symbol = tokens[2]
-                    period = int(tokens[3])
-                except ValueError:
+                    symbol = record[2]
+                    period = int(record[3])
+                except:
                     print("parse_perf.py: Error extracting symbol count",
-                            file=sys.stderr)
+                          file=sys.stderr)
                     print("line:", repr(line), file=sys.stderr)
                     print("tokens:", tokens, file=sys.stderr)
+                    print("record:", record, file=sys.stderr)
                     raise
 
                 profile[event_name]['symbol'][symbol] = period

--- a/.testing/tools/parse_perf.py
+++ b/.testing/tools/parse_perf.py
@@ -58,9 +58,16 @@ def parse_perf_report(perf_data_path):
 
             # get per-symbol count
             else:
-                tokens = line.split()
-                symbol = tokens[2]
-                period = int(tokens[3])
+                try:
+                    tokens = line.split()
+                    symbol = tokens[2]
+                    period = int(tokens[3])
+                except ValueError:
+                    print("parse_perf.py: Error extracting symbol count",
+                            file=sys.stderr)
+                    print("line:", repr(line), file=sys.stderr)
+                    print("tokens:", tokens, file=sys.stderr)
+                    raise
 
                 profile[event_name]['symbol'][symbol] = period
 

--- a/ac/Makefile.in
+++ b/ac/Makefile.in
@@ -19,7 +19,6 @@ SRC_DIRS = @SRC_DIRS@
 
 -include Makefile.dep
 
-
 # Generate Makefile from template
 Makefile: @srcdir@/ac/Makefile.in config.status
 	./config.status
@@ -33,7 +32,7 @@ rwildcard=$(foreach d,$(wildcard $(1:=/*)),$(call rwildcard,$d,$2) $(filter $(su
 .PHONY: depend
 depend: Makefile.dep
 Makefile.dep: $(MAKEDEP) $(call rwildcard,$(SRC_DIRS),*.h *.c *.inc *.F90)
-	$(PYTHON) $(MAKEDEP) -o Makefile.dep -e $(SRC_DIRS)
+	$(PYTHON) $(MAKEDEP) $(DEFS) -o Makefile.dep -e $(SRC_DIRS)
 
 
 # Delete any files associated with configuration (including the Makefile).

--- a/ac/configure.ac
+++ b/ac/configure.ac
@@ -79,18 +79,6 @@ AS_IF([test "x$with_driver" != "x"],
 # used to configure a header based on a template.
 #AC_CONFIG_HEADERS(["$MEM_LAYOUT/MOM_memory.h"])
 
-# Select the model framework (default: FMS1)
-# NOTE: We can phase this out after the FMS1 I/O has been removed from FMS and
-#   replace with a detection test.  For now, it is a user-defined switch.
-MODEL_FRAMEWORK=${srcdir}/config_src/infra/FMS2
-AC_ARG_WITH([framework],
-  AS_HELP_STRING([--with-framework=fms1|fms2], [Select the model framework]))
-AS_CASE(["$with_framework"],
-  [fms1], [MODEL_FRAMEWORK=${srcdir}/config_src/infra/FMS1],
-  [fms2], [MODEL_FRAMEWORK=${srcdir}/config_src/infra/FMS2],
-  [MODEL_FRAMEWORK=${srcdir}/config_src/infra/FMS2]
-)
-
 
 # Explicitly assume free-form Fortran
 AC_LANG(Fortran)
@@ -220,7 +208,6 @@ AX_FC_CHECK_LIB([FMS], [fms_init], [fms_mod],
   ]
 )
 
-
 # Verify that FMS is at least 2019.01.02
 # NOTE: 2019.01.02 introduced two changes:
 #   - diag_axis_init supports an optional domain_position argument
@@ -235,6 +222,14 @@ AC_COMPILE_IFELSE(
     AC_MSG_ERROR([diag_axis_mod in MOM6 requires FMS 2019.01.02 or newer.])
   ]
 )
+
+# Determine the FMS IO implementation.
+AX_FC_CHECK_MODULE([fms2_io_mod], [
+  MODEL_FRAMEWORK=${srcdir}/config_src/infra/FMS2
+],[
+  MODEL_FRAMEWORK=${srcdir}/config_src/infra/FMS1
+])
+
 
 # Python interpreter test
 

--- a/ac/configure.ac
+++ b/ac/configure.ac
@@ -82,13 +82,13 @@ AS_IF([test "x$with_driver" != "x"],
 # Select the model framework (default: FMS1)
 # NOTE: We can phase this out after the FMS1 I/O has been removed from FMS and
 #   replace with a detection test.  For now, it is a user-defined switch.
-MODEL_FRAMEWORK=${srcdir}/config_src/infra/FMS1
+MODEL_FRAMEWORK=${srcdir}/config_src/infra/FMS2
 AC_ARG_WITH([framework],
   AS_HELP_STRING([--with-framework=fms1|fms2], [Select the model framework]))
 AS_CASE(["$with_framework"],
   [fms1], [MODEL_FRAMEWORK=${srcdir}/config_src/infra/FMS1],
   [fms2], [MODEL_FRAMEWORK=${srcdir}/config_src/infra/FMS2],
-  [MODEL_FRAMEWORK=${srcdir}/config_src/infra/FMS1]
+  [MODEL_FRAMEWORK=${srcdir}/config_src/infra/FMS2]
 )
 
 

--- a/ac/deps/Makefile.fms.in
+++ b/ac/deps/Makefile.fms.in
@@ -23,4 +23,4 @@ ARFLAGS = @ARFLAGS@
 .PHONY: depend
 depend: Makefile.dep
 Makefile.dep:
-	$(PYTHON) $(MAKEDEP) -o Makefile.dep -e -x libFMS.a -s @srcdir@/test_fms @srcdir@
+	$(PYTHON) $(MAKEDEP) $(DEFS) -o Makefile.dep -e -x libFMS.a -s @srcdir@/test_fms @srcdir@

--- a/ac/makedep
+++ b/ac/makedep
@@ -10,7 +10,8 @@ import re
 import sys
 
 
-# Pre-compile re searches
+# Fortran tokenization
+
 re_module = re.compile(r"^ *module +([a-z_0-9]+)")
 re_use = re.compile(r"^ *use +([a-z_0-9]+)")
 re_cpp_define = re.compile(r"^ *# *define +[_a-zA-Z][_a-zA-Z0-9]")
@@ -30,6 +31,80 @@ re_procedure = re.compile(
     r"^[^!]*(?<![a-z_])(function|subroutine)(?![a-z_])",
     re.IGNORECASE
 )
+
+
+# Preprocessor expression tokenization
+cpp_scanner = re.Scanner([
+  (r'defined', lambda scanner, token: token),
+  (r'[_A-Za-z][_0-9a-zA-Z]*', lambda scanner, token: token),
+  (r'[0-9]+', lambda scanner, token: token),
+  (r'\(', lambda scanner, token: token),
+  (r'\)', lambda scanner, token: token),
+  (r'\*', lambda scanner, token: token),
+  (r'/', lambda scanner, token: token),
+  (r'\+', lambda scanner, token: token),
+  (r'-', lambda scanner, token: token),
+  (r'!', lambda scanner, token: token),
+  (r'>>', lambda scanner, token: token),
+  (r'>=', lambda scanner, token: token),
+  (r'>', lambda scanner, token: token),
+  (r'<<', lambda scanner, token: token),
+  (r'<=', lambda scanner, token: token),
+  (r'<', lambda scanner, token: token),
+  (r'==', lambda scanner, token: token),
+  (r'&&', lambda scanner, token: token),
+  (r'&', lambda scanner, token: token),
+  (r'\|\|', lambda scanner, token: token),
+  (r'\|', lambda scanner, token: token),
+  (r'^\#if', None),
+  (r'\s+', None),
+])
+
+
+cpp_operate = {
+    '!': lambda x: not x,
+    '*': lambda x, y: x * y,
+    '/': lambda x, y: x // y,
+    '+': lambda x, y: x + y,
+    '-': lambda x, y: x - y,
+    '>>': lambda x, y: x >> y,
+    '<<': lambda x, y: x << y,
+    '==': lambda x, y: x == y,
+    '>': lambda x, y: x > y,
+    '>=': lambda x, y: x >= y,
+    '<': lambda x, y: x < y,
+    '<=': lambda x, y: x <= y,
+    '&': lambda x, y: x & y,
+    '^': lambda x, y: x ^ y,
+    '|': lambda x, y: x | y,
+    '&&': lambda x, y: x and y,
+    '||': lambda x, y: x or y,
+}
+
+
+cpp_op_rank = {
+    '(': 13,
+    '!': 12,
+    '*': 11,
+    '/': 11,
+    '+': 10,
+    '-': 10,
+    '>>': 9,
+    '<<': 9,
+    '>': 8,
+    '>=': 8,
+    '<': 8,
+    '<=': 8,
+    '==': 7,
+    '&': 6,
+    '^': 5,
+    '|': 4,
+    '&&': 2,
+    '||': 2,
+    ')': 1,
+    '$': 1,
+    None: 0,
+}
 
 
 def create_deps(src_dirs, skip_dirs, makefile, debug, exec_target, fc_rule,
@@ -105,7 +180,7 @@ def create_deps(src_dirs, skip_dirs, makefile, debug, exec_target, fc_rule,
         all_modules += mods
 
     for f in c_files:
-        _, _, cpp, inc, _, _ = scan_fortran_file(f)
+        _, _, cpp, inc, _, _ = scan_fortran_file(f, defines)
         # maps object file to .h files included
         o2h[object_file(f)] = cpp
         externals.append(object_file(f))
@@ -158,7 +233,7 @@ def create_deps(src_dirs, skip_dirs, makefile, debug, exec_target, fc_rule,
             ]
             missing_mods = [m for m in o2uses[o] if m not in all_modules]
 
-            incs, inc_used = nested_inc(o2h[o] + o2inc[o], f2F)
+            incs, inc_used = nested_inc(o2h[o] + o2inc[o], f2F, defines)
             inc_mods = [u for u in inc_used if u not in found_mods and u in all_modules]
 
             incdeps = sorted(set([f2F[f] for f in incs if f in f2F]))
@@ -250,7 +325,7 @@ def link_obj(obj, o2uses, mod2o, all_modules):
     return sorted(set(olst))
 
 
-def nested_inc(inc_files, f2F):
+def nested_inc(inc_files, f2F, defines):
     """List of all files included by "inc_files", either by #include or F90
     include."""
     hlst = []
@@ -260,7 +335,7 @@ def nested_inc(inc_files, f2F):
         if hfile not in f2F.keys():
             return
 
-        _, used, cpp, inc, _, _ = scan_fortran_file(f2F[hfile])
+        _, used, cpp, inc, _, _ = scan_fortran_file(f2F[hfile], defines)
 
         # Record any module updates inside of include files
         used_mods.update(used)
@@ -286,7 +361,8 @@ def scan_fortran_file(src_file, defines=None):
 
     cpp_defines = defines if defines is not None else []
 
-    cpp_macros = [define.split('=')[0] for define in cpp_defines]
+    #cpp_macros = [define.split('=')[0] for define in cpp_defines]
+    cpp_macros = dict([t.split('=') for t in cpp_defines])
     cpp_group_stack = []
 
     with io.open(src_file, 'r', errors='replace') as file:
@@ -328,9 +404,9 @@ def scan_fortran_file(src_file, defines=None):
             if match:
                 cpp_group_stack.append(cpp_exclude)
 
-                # XXX: Don't attempt to parse #if statements, but store the state.
-                # if/endif stack.  For now, assume that these always fail.
-                cpp_exclude = False
+                cpp_expr_value = cpp_expr_eval(line, cpp_macros)
+
+                cpp_exclude = not cpp_expr_value
 
             # Complement #else condition group
             match = re_cpp_else.match(line)
@@ -351,8 +427,14 @@ def scan_fortran_file(src_file, defines=None):
             # Activate a new macro (ignoring the value)
             match = re_cpp_define.match(line)
             if match:
-                new_macro = line.lstrip()[1:].split()[1]
-                cpp_macros.append(new_macro)
+                tokens = line.strip()[1:].split(maxsplit=2)
+                macro = tokens[1]
+                value = tokens[2] if tokens[2:] else None
+                if '(' in macro:
+                    # TODO: Actual handling of function macros
+                    macro, arg = macro.split('(', maxsplit=1)
+                    value = '(' + arg + value
+                cpp_macros[macro] = value
 
             # Deactivate a macro
             match = re_cpp_undef.match(line)
@@ -439,6 +521,107 @@ def find_files(src_dirs, skip_dirs):
 def add_suff(lst, suff):
     """Add "suff" to each item in the list"""
     return [f + suff for f in lst]
+
+
+def cpp_expr_eval(expr, macros=None):
+    if macros is None:
+        macros = {}
+
+    results, remainder = cpp_scanner.scan(expr)
+
+    # Abort if any characters are not tokenized
+    if remainder:
+        print('There are untokenized characters!')
+        print('Expression:', repr(expr))
+        print('Tokens:', results)
+        print('Unscanned:', remainder)
+        raise
+
+    # Add an "end of line" character to force evaluation of the final tokens.
+    results.append('$')
+
+    stack = []
+    prior_op = None
+
+    tokens = iter(results)
+    for tok in tokens:
+        # Evaluate "defined()" statements
+        if tok == 'defined':
+            tok = next(tokens)
+
+            parens = tok == '('
+            if parens:
+                tok = next(tokens)
+
+            # NOTE: Any key in `macros` is considered to be set, even if the
+            # value is None.
+            value = tok in macros
+
+            # Negation
+            while prior_op == '!':
+                op = stack.pop()
+                assert op == '!'
+                value = cpp_operate[op](value)
+                prior_op = stack[-1] if stack else None
+
+            stack.append(value)
+
+            if parens:
+                tok = next(tokens)
+                assert tok == ')'
+
+        elif tok.isdigit():
+            value = int(tok)
+            stack.append(value)
+
+        elif tok.isidentifier():
+            # "Identifiers that are not macros, which are all considered to be
+            # the number zero." (CPP manual, 4.2.2)
+            value = macros.get(tok, '0')
+            if value.isdigit():
+                value = int(value)
+            stack.append(value)
+
+        elif tok in cpp_op_rank.keys():
+            while cpp_op_rank[tok] <= cpp_op_rank[prior_op]:
+
+                # Skip unary prefix operators (only '!' at the moment)
+                if tok == '!':
+                    break
+
+                second = stack.pop()
+                op = stack.pop()
+                first = stack.pop()
+
+                value = cpp_operate[op](first, second)
+                prior_op = stack[-1] if stack else None
+
+                if prior_op == '(':
+                    prior_op = None
+                    if tok == ')':
+                        stack.pop()
+
+                stack.append(value)
+
+            if tok == ')':
+                prior_op = stack[-2] if stack and len(stack) > 1 else None
+            else:
+                stack.append(tok)
+                prior_op = tok
+
+                if prior_op in ('(',):
+                    prior_op = None
+
+        else:
+            print("Unsupported token:", tok)
+            raise
+
+    # Remove the tail value
+    eol = stack.pop()
+    assert eol == '$'
+    value = stack.pop()
+
+    return value
 
 
 # Parse arguments

--- a/ac/makedep
+++ b/ac/makedep
@@ -13,9 +13,16 @@ import sys
 # Pre-compile re searches
 re_module = re.compile(r"^ *module +([a-z_0-9]+)")
 re_use = re.compile(r"^ *use +([a-z_0-9]+)")
+re_cpp_define = re.compile(r"^ *# *define +[_a-zA-Z][_a-zA-Z0-9]")
+re_cpp_undef = re.compile(r"^ *# *undef +[_a-zA-Z][_a-zA-Z0-9]")
+re_cpp_ifdef = re.compile(r"^ *# *ifdef +[_a-zA-Z][_a-zA-Z0-9]")
+re_cpp_ifndef = re.compile(r"^ *# *ifndef +[_a-zA-Z][_a-zA-Z0-9]")
+re_cpp_if = re.compile(r"^ *# *if +")
+re_cpp_else = re.compile(r"^ *# *else")
+re_cpp_endif = re.compile(r"^ *# *endif")
 re_cpp_include = re.compile(r"^ *# *include *[<\"']([a-zA-Z_0-9\.]+)[>\"']")
 re_f90_include = re.compile(r"^ *include +[\"']([a-zA-Z_0-9\.]+)[\"']")
-re_program = re.compile(r"^ *[pP][rR][oO][gG][rR][aA][mM] +([a-zA-Z_0-9]+)")
+re_program = re.compile(r"^ *program +([a-z_0-9]+)", re.IGNORECASE)
 re_end = re.compile(r"^ *end *(module|procedure) ", re.IGNORECASE)
 # NOTE: This excludes comments and tokens with substrings containing `function`
 # or `subroutine`, but will fail if the keywords appear in other contexts.
@@ -26,7 +33,7 @@ re_procedure = re.compile(
 
 
 def create_deps(src_dirs, skip_dirs, makefile, debug, exec_target, fc_rule,
-                link_externals, script_path):
+                link_externals, defines):
     """Create "makefile" after scanning "src_dis"."""
 
     # Scan everything Fortran related
@@ -66,7 +73,7 @@ def create_deps(src_dirs, skip_dirs, makefile, debug, exec_target, fc_rule,
     o2mods, o2uses, o2h, o2inc, o2prg, prg2o, mod2o = {}, {}, {}, {}, {}, {}, {}
     externals, all_modules = [], []
     for f in F90_files:
-        mods, used, cpp, inc, prg, has_externals = scan_fortran_file(f)
+        mods, used, cpp, inc, prg, has_externals = scan_fortran_file(f, defines)
         # maps object file to modules produced
         o2mods[object_file(f)] = mods
         # maps module produced to object file
@@ -272,10 +279,16 @@ def nested_inc(inc_files, f2F):
     return inc_files + sorted(set(hlst)), used_mods
 
 
-def scan_fortran_file(src_file):
+def scan_fortran_file(src_file, defines=None):
     """Scan the Fortran file "src_file" and return lists of module defined,
     module used, and files included."""
     module_decl, used_modules, cpp_includes, f90_includes, programs = [], [], [], [], []
+
+    cpp_defines = defines if defines is not None else []
+
+    cpp_macros = [define.split('=')[0] for define in cpp_defines]
+    cpp_group_stack = []
+
     with io.open(src_file, 'r', errors='replace') as file:
         lines = file.readlines()
 
@@ -285,7 +298,72 @@ def scan_fortran_file(src_file):
         file_has_externals = False
             # True if the file contains any external objects
 
+        cpp_exclude = False
+            # True if the parser excludes the subsequent lines
+
+        cpp_group_stack = []
+            # Stack of condition group exclusion states
+
         for line in lines:
+            # Start of #ifdef condition group
+            match = re_cpp_ifdef.match(line)
+            if match:
+                cpp_group_stack.append(cpp_exclude)
+
+                # If outer group is excluding or macro is missing, then exclude
+                macro = line.lstrip()[1:].split()[1]
+                cpp_exclude = cpp_exclude or macro not in cpp_macros
+
+            # Start of #ifndef condition group
+            match = re_cpp_ifndef.match(line)
+            if match:
+                cpp_group_stack.append(cpp_exclude)
+
+                # If outer group is excluding or macro is present, then exclude
+                macro = line.lstrip()[1:].split()[1]
+                cpp_exclude = cpp_exclude or macro in cpp_macros
+
+            # Start of #if condition group
+            match = re_cpp_if.match(line)
+            if match:
+                cpp_group_stack.append(cpp_exclude)
+
+                # XXX: Don't attempt to parse #if statements, but store the state.
+                # if/endif stack.  For now, assume that these always fail.
+                cpp_exclude = False
+
+            # Complement #else condition group
+            match = re_cpp_else.match(line)
+            if match:
+                # Reverse the exclude state, if there is no outer exclude state
+                outer_grp_exclude = cpp_group_stack and cpp_group_stack[-1]
+                cpp_exclude = not cpp_exclude or outer_grp_exclude
+
+            # Restore exclude state when exiting conditional block
+            match = re_cpp_endif.match(line)
+            if match:
+                cpp_exclude = cpp_group_stack.pop()
+
+            # Skip lines inside of false condition blocks
+            if cpp_exclude:
+                continue
+
+            # Activate a new macro (ignoring the value)
+            match = re_cpp_define.match(line)
+            if match:
+                new_macro = line.lstrip()[1:].split()[1]
+                cpp_macros.append(new_macro)
+
+            # Deactivate a macro
+            match = re_cpp_undef.match(line)
+            if match:
+                new_macro = line.lstrip()[1:].split()[1]
+                try:
+                    cpp_macros.remove(new_macro)
+                except:
+                    # Ignore missing macros (for now?)
+                    continue
+
             match = re_module.match(line.lower())
             if match:
                 if match.group(1) not in 'procedure':   # avoid "module procedure" statements
@@ -404,8 +482,13 @@ parser.add_argument(
     action='append',
     help="Skip directory in source code search."
 )
+parser.add_argument(
+    '-D', '--define',
+    action='append',
+    help="Apply preprocessor define macros (of the form -DMACRO[=value])",
+)
 args = parser.parse_args()
 
 # Do the thing
 create_deps(args.path, args.skip, args.makefile, args.debug, args.exec_target,
-            args.fc_rule, args.link_externals, sys.argv[0])
+            args.fc_rule, args.link_externals, args.define)

--- a/ac/makedep
+++ b/ac/makedep
@@ -34,6 +34,8 @@ re_procedure = re.compile(
 
 
 # Preprocessor expression tokenization
+# NOTE: Labels and attributes could be assigned here, but for now we just use
+#   the token string as the label.
 cpp_scanner = re.Scanner([
   (r'defined', lambda scanner, token: token),
   (r'[_A-Za-z][_0-9a-zA-Z]*', lambda scanner, token: token),
@@ -56,13 +58,15 @@ cpp_scanner = re.Scanner([
   (r'&', lambda scanner, token: token),
   (r'\|\|', lambda scanner, token: token),
   (r'\|', lambda scanner, token: token),
-  (r'^\#if', None),
+  (r'^ *\# *if', None),
   (r'\s+', None),
 ])
 
 
 cpp_operate = {
+    '(': lambda x: x,
     '!': lambda x: not x,
+    'defined': lambda x, y: x in y,
     '*': lambda x, y: x * y,
     '/': lambda x, y: x // y,
     '+': lambda x, y: x + y,
@@ -85,6 +89,7 @@ cpp_operate = {
 cpp_op_rank = {
     '(': 13,
     '!': 12,
+    'defined': 12,
     '*': 11,
     '/': 11,
     '+': 10,
@@ -527,7 +532,7 @@ def cpp_expr_eval(expr, macros=None):
     if macros is None:
         macros = {}
 
-    results, remainder = cpp_scanner.scan(expr)
+    results, remainder = cpp_scanner.scan(expr.strip())
 
     # Abort if any characters are not tokenized
     if remainder:
@@ -545,72 +550,59 @@ def cpp_expr_eval(expr, macros=None):
 
     tokens = iter(results)
     for tok in tokens:
-        # Evaluate "defined()" statements
-        if tok == 'defined':
-            tok = next(tokens)
-
-            parens = tok == '('
-            if parens:
-                tok = next(tokens)
-
-            # NOTE: Any key in `macros` is considered to be set, even if the
-            # value is None.
-            value = tok in macros
-
-            # Negation
-            while prior_op == '!':
-                op = stack.pop()
-                assert op == '!'
-                value = cpp_operate[op](value)
-                prior_op = stack[-1] if stack else None
-
-            stack.append(value)
-
-            if parens:
-                tok = next(tokens)
-                assert tok == ')'
-
-        elif tok.isdigit():
-            value = int(tok)
-            stack.append(value)
-
-        elif tok.isidentifier():
-            # "Identifiers that are not macros, which are all considered to be
-            # the number zero." (CPP manual, 4.2.2)
-            value = macros.get(tok, '0')
-            if value.isdigit():
-                value = int(value)
-            stack.append(value)
-
-        elif tok in cpp_op_rank.keys():
+        if tok in cpp_op_rank.keys():
             while cpp_op_rank[tok] <= cpp_op_rank[prior_op]:
 
-                # Skip unary prefix operators (only '!' at the moment)
-                if tok == '!':
+                # Unary operators are "look ahead" so we always skip them.
+                # (However, `op` below could be a unary operator.)
+                if tok in ('!', 'defined', '('):
                     break
 
                 second = stack.pop()
                 op = stack.pop()
-                first = stack.pop()
 
-                value = cpp_operate[op](first, second)
+                if op == '(':
+                    value = second
+
+                elif op == '!':
+                    if isinstance(second, str):
+                        if second.isidentifier():
+                            second = macros.get(second, '0')
+                        if second.isdigit():
+                            second = int(second)
+
+                    value = cpp_operate[op](second)
+
+                elif op == 'defined':
+                    value = cpp_operate[op](second, macros)
+
+                else:
+                    first = stack.pop()
+
+                    if isinstance(first, str):
+                        if first.isidentifier():
+                            first = macros.get(first, '0')
+                        if first.isdigit():
+                            first = int(first)
+
+                    if isinstance(second, str):
+                        if second.isidentifier():
+                            second = macros.get(second, '0')
+                        if second.isdigit():
+                            second = int(second)
+
+                    value = cpp_operate[op](first, second)
+
                 prior_op = stack[-1] if stack else None
-
-                if prior_op == '(':
-                    prior_op = None
-                    if tok == ')':
-                        stack.pop()
-
                 stack.append(value)
 
-            if tok == ')':
-                prior_op = stack[-2] if stack and len(stack) > 1 else None
-            else:
+            # The ) "operator" has already been applied, so it can be dropped.
+            if tok != ')':
                 stack.append(tok)
                 prior_op = tok
 
-                if prior_op in ('(',):
-                    prior_op = None
+        elif tok.isdigit() or tok.isidentifier():
+            stack.append(tok)
 
         else:
             print("Unsupported token:", tok)

--- a/config_src/drivers/FMS_cap/MOM_surface_forcing_gfdl.F90
+++ b/config_src/drivers/FMS_cap/MOM_surface_forcing_gfdl.F90
@@ -137,7 +137,7 @@ type, public :: surface_forcing_CS ; private
                                 !! gustiness calculations.  Values below 20190101 recover the answers
                                 !! from the end of 2018, while higher values use a simpler expression
                                 !! to calculate gustiness.
-  logical :: fix_ustar_gustless_bug         !< If true correct a bug in the time-averaging of the
+  logical :: ustar_gustless_bug             !< If true, include a bug in the time-averaging of the
                                             !! gustless wind friction velocity.
   logical :: check_no_land_fluxes           !< Return warning if IOB flux over land is non-zero
 
@@ -284,7 +284,7 @@ subroutine convert_IOB_to_fluxes(IOB, fluxes, index_bounds, Time, valid_time, G,
   ! flux type has been used.
   if (fluxes%dt_buoy_accum < 0) then
     call allocate_forcing_type(G, fluxes, water=.true., heat=.true., ustar=.not.CS%nonBous, press=.true., &
-                               fix_accum_bug=CS%fix_ustar_gustless_bug, tau_mag=CS%nonBous)
+                               fix_accum_bug=.not.CS%ustar_gustless_bug, tau_mag=CS%nonBous)
 
     call safe_alloc_ptr(fluxes%sw_vis_dir,isd,ied,jsd,jed)
     call safe_alloc_ptr(fluxes%sw_vis_dif,isd,ied,jsd,jed)
@@ -1298,6 +1298,9 @@ subroutine surface_forcing_init(Time, G, US, param_file, diag, CS, wind_stagger)
   logical :: new_sim              ! False if this simulation was started from a restart file
                                   ! or other equivalent files.
   logical :: iceberg_flux_diags   ! If true, diagnostics of fluxes from icebergs are available.
+  logical :: fix_ustar_gustless_bug  ! If false, include a bug using an older run-time parameter.
+  logical :: test_value  ! This is used to determine whether a logical parameter is being set explicitly.
+  logical :: explicit_bug, explicit_fix ! These indicate which parameters are set explicitly.
   integer :: default_answer_date  ! The default setting for the various ANSWER_DATE flags.
   type(time_type)    :: Time_frc
   type(directories)  :: dirs      ! A structure containing relevant directory paths and input filenames.
@@ -1611,9 +1614,32 @@ subroutine surface_forcing_init(Time, G, US, param_file, diag, CS, wind_stagger)
                  "of 2018, while higher values use a simpler expression to calculate gustiness.", &
                  default=default_answer_date)
 
-  call get_param(param_file, mdl, "FIX_USTAR_GUSTLESS_BUG", CS%fix_ustar_gustless_bug, &
+  call get_param(param_file, mdl, "USTAR_GUSTLESS_BUG", CS%ustar_gustless_bug, &
+                 "If true include a bug in the time-averaging of the gustless wind friction velocity", &
+                 default=.false., do_not_log=.true.)
+  ! This is used to test whether USTAR_GUSTLESS_BUG is being actively set.
+  call get_param(param_file, mdl, "USTAR_GUSTLESS_BUG", test_value, default=.true., do_not_log=.true.)
+  explicit_bug = CS%ustar_gustless_bug .eqv. test_value
+  call get_param(param_file, mdl, "FIX_USTAR_GUSTLESS_BUG", fix_ustar_gustless_bug, &
                  "If true correct a bug in the time-averaging of the gustless wind friction velocity", &
-                 default=.true.)
+                 default=.true., do_not_log=.true.)
+  call get_param(param_file, mdl, "FIX_USTAR_GUSTLESS_BUG", test_value, default=.false., do_not_log=.true.)
+  explicit_fix = fix_ustar_gustless_bug .eqv. test_value
+
+  if (explicit_bug .and. explicit_fix .and. (fix_ustar_gustless_bug .eqv. CS%ustar_gustless_bug)) then
+    ! USTAR_GUSTLESS_BUG is being explicitly set, and should not be changed.
+    call MOM_error(FATAL, "USTAR_GUSTLESS_BUG and FIX_USTAR_GUSTLESS_BUG are both being set "//&
+                   "with inconsistent values.  FIX_USTAR_GUSTLESS_BUG is an obsolete "//&
+                   "parameter and should be removed.")
+  elseif (explicit_fix) then
+    call MOM_error(WARNING, "FIX_USTAR_GUSTLESS_BUG is an obsolete parameter.  "//&
+                   "Use USTAR_GUSTLESS_BUG instead (noting that it has the opposite sense).")
+    CS%ustar_gustless_bug = .not.fix_ustar_gustless_bug
+  endif
+  call log_param(param_file, mdl, "USTAR_GUSTLESS_BUG", CS%ustar_gustless_bug, &
+                 "If true include a bug in the time-averaging of the gustless wind friction velocity", &
+                 default=.false.)
+
 
 ! See whether sufficiently thick sea ice should be treated as rigid.
   call get_param(param_file, mdl, "USE_RIGID_SEA_ICE", CS%rigid_sea_ice, &

--- a/config_src/drivers/FMS_cap/MOM_surface_forcing_gfdl.F90
+++ b/config_src/drivers/FMS_cap/MOM_surface_forcing_gfdl.F90
@@ -1522,7 +1522,7 @@ subroutine surface_forcing_init(Time, G, US, param_file, diag, CS, wind_stagger)
   endif
   call get_param(param_file, mdl, "SPEAR_DTFREEZE_DS", CS%SPEAR_dTf_dS, &
                  "The derivative of the freezing temperature with salinity.", &
-                 units="deg C PSU-1", default=-0.054, scale=US%degC_to_C*US%S_to_ppt, &
+                 units="degC ppt-1", default=-0.054, scale=US%degC_to_C*US%S_to_ppt, &
                  do_not_log=.not.CS%trestore_SPEAR_ECDA)
   call get_param(param_file, mdl, "RESTORE_FLUX_RHO", CS%rho_restore, &
                  "The density that is used to convert piston velocities into salt or heat "//&

--- a/config_src/drivers/STALE_mct_cap/mom_surface_forcing_mct.F90
+++ b/config_src/drivers/STALE_mct_cap/mom_surface_forcing_mct.F90
@@ -16,7 +16,7 @@ use MOM_domains,          only : pass_vector, pass_var, fill_symmetric_edges
 use MOM_domains,          only : AGRID, BGRID_NE, CGRID_NE, To_All
 use MOM_domains,          only : To_North, To_East, Omit_Corners
 use MOM_error_handler,    only : MOM_error, WARNING, FATAL, is_root_pe, MOM_mesg
-use MOM_file_parser,      only : get_param, log_version, param_file_type
+use MOM_file_parser,      only : get_param, log_param, log_version, param_file_type
 use MOM_forcing_type,     only : forcing, mech_forcing
 use MOM_forcing_type,     only : forcing_diags, mech_forcing_diags, register_forcing_type_diags
 use MOM_forcing_type,     only : allocate_forcing_type, deallocate_forcing_type
@@ -117,7 +117,7 @@ type, public :: surface_forcing_CS ; private
   real    :: max_delta_srestore             !< maximum delta salinity used for restoring [S ~> ppt]
   real    :: max_delta_trestore             !< maximum delta sst used for restoring [C ~> degC]
   real, pointer, dimension(:,:) :: basin_mask => NULL() !< mask for SSS restoring by basin
-  logical :: fix_ustar_gustless_bug         !< If true correct a bug in the time-averaging of the
+  logical :: ustar_gustless_bug             !< If true, include a bug in the time-averaging of the
                                             !! gustless wind friction velocity.
   type(diag_ctrl), pointer :: diag          !< structure to regulate diagnostic output timing
   character(len=200)       :: inputdir      !< directory where NetCDF input files are
@@ -276,7 +276,7 @@ subroutine convert_IOB_to_fluxes(IOB, fluxes, index_bounds, Time, valid_time, G,
   ! flux type has been used.
   if (fluxes%dt_buoy_accum < 0) then
     call allocate_forcing_type(G, fluxes, water=.true., heat=.true., ustar=.true., &
-                               press=.true., fix_accum_bug=CS%fix_ustar_gustless_bug, tau_mag=.true.)
+                               press=.true., fix_accum_bug=.not.CS%ustar_gustless_bug, tau_mag=.true.)
 
     call safe_alloc_ptr(fluxes%sw_vis_dir,isd,ied,jsd,jed)
     call safe_alloc_ptr(fluxes%sw_vis_dif,isd,ied,jsd,jed)
@@ -1025,11 +1025,13 @@ subroutine surface_forcing_init(Time, G, US, param_file, diag, CS, restore_salt,
   ! Local variables
   real :: utide  ! The RMS tidal velocity [Z T-1 ~> m s-1].
   type(directories)  :: dirs
-  logical            :: new_sim, iceberg_flux_diags
+  logical            :: new_sim, iceberg_flux_diags, fix_ustar_gustless_bug
+  logical :: test_value  ! This is used to determine whether a logical parameter is being set explicitly.
+  logical :: explicit_bug, explicit_fix ! These indicate which parameters are set explicitly.
   type(time_type)    :: Time_frc
   character(len=200) :: TideAmp_file, gust_file, salt_file, temp_file ! Input file names.
-! This include declares and sets the variable "version".
-#include "version_variable.h"
+  ! This include declares and sets the variable "version".
+# include "version_variable.h"
   character(len=40)  :: mdl = "MOM_surface_forcing_mct"  ! This module's name.
   character(len=48)  :: stagger
   character(len=48)  :: flnam
@@ -1257,9 +1259,32 @@ subroutine surface_forcing_init(Time, G, US, param_file, diag, CS, restore_salt,
     call MOM_read_data(gust_file, 'gustiness', CS%gust, G%domain, timelevel=1, &
                scale=US%kg_m3_to_R*US%m_s_to_L_T**2*US%L_to_Z) ! units in file should be Pa
   endif
-  call get_param(param_file, mdl, "FIX_USTAR_GUSTLESS_BUG", CS%fix_ustar_gustless_bug, &
+
+  call get_param(param_file, mdl, "USTAR_GUSTLESS_BUG", CS%ustar_gustless_bug, &
+                 "If true include a bug in the time-averaging of the gustless wind friction velocity", &
+                 default=.false., do_not_log=.true.)
+  ! This is used to test whether USTAR_GUSTLESS_BUG is being actively set.
+  call get_param(param_file, mdl, "USTAR_GUSTLESS_BUG", test_value, default=.true., do_not_log=.true.)
+  explicit_bug = CS%ustar_gustless_bug .eqv. test_value
+  call get_param(param_file, mdl, "FIX_USTAR_GUSTLESS_BUG", fix_ustar_gustless_bug, &
                  "If true correct a bug in the time-averaging of the gustless wind friction velocity", &
-                 default=.true.)
+                 default=.true., do_not_log=.true.)
+  call get_param(param_file, mdl, "FIX_USTAR_GUSTLESS_BUG", test_value, default=.false., do_not_log=.true.)
+  explicit_fix = fix_ustar_gustless_bug .eqv. test_value
+
+  if (explicit_bug .and. explicit_fix .and. (fix_ustar_gustless_bug .eqv. CS%ustar_gustless_bug)) then
+    ! USTAR_GUSTLESS_BUG is being explicitly set, and should not be changed.
+    call MOM_error(FATAL, "USTAR_GUSTLESS_BUG and FIX_USTAR_GUSTLESS_BUG are both being set "//&
+                   "with inconsistent values.  FIX_USTAR_GUSTLESS_BUG is an obsolete "//&
+                   "parameter and should be removed.")
+  elseif (explicit_fix) then
+    call MOM_error(WARNING, "FIX_USTAR_GUSTLESS_BUG is an obsolete parameter.  "//&
+                   "Use USTAR_GUSTLESS_BUG instead (noting that it has the opposite sense).")
+    CS%ustar_gustless_bug = .not.fix_ustar_gustless_bug
+  endif
+  call log_param(param_file, mdl, "USTAR_GUSTLESS_BUG", CS%ustar_gustless_bug, &
+                 "If true include a bug in the time-averaging of the gustless wind friction velocity", &
+                 default=.false.)
 
 ! See whether sufficiently thick sea ice should be treated as rigid.
   call get_param(param_file, mdl, "USE_RIGID_SEA_ICE", CS%rigid_sea_ice, &

--- a/config_src/drivers/ice_solo_driver/ice_shelf_driver.F90
+++ b/config_src/drivers/ice_solo_driver/ice_shelf_driver.F90
@@ -26,6 +26,7 @@ program Shelf_main
   use MOM_debugging,       only : MOM_debugging_init
   use MOM_diag_mediator,   only : diag_mediator_init, diag_mediator_infrastructure_init, set_axes_info
   use MOM_diag_mediator,   only : diag_mediator_end, diag_ctrl, diag_mediator_close_registration
+  use MOM_diag_manager_infra, only : diag_manager_set_time_end_infra
   use MOM_domains,         only : MOM_infra_init, MOM_infra_end
   use MOM_domains,         only : MOM_domains_init, clone_MOM_domain, pass_var
   use MOM_dyn_horgrid,     only : dyn_horgrid_type, create_dyn_horgrid, destroy_dyn_horgrid
@@ -324,6 +325,8 @@ program Shelf_main
                  timeunit=Time_unit, fail_if_missing=.true.)
     Time_end = daymax
   endif
+
+  call diag_manager_set_time_end_infra (Time_end)
 
   if (Time >= Time_end) call MOM_error(FATAL, &
     "Shelf_driver: The run has been started at or after the end time of the run.")

--- a/config_src/drivers/nuopc_cap/mom_cap.F90
+++ b/config_src/drivers/nuopc_cap/mom_cap.F90
@@ -383,7 +383,8 @@ subroutine InitializeP0(gcomp, importState, exportState, clock, rc)
   endif
 
   ! Read end of run restart config option
-  call NUOPC_CompAttributeGet(gcomp, name="write_restart_at_endofrun", value=value, isPresent=isPresent, isSet=isSet, rc=rc)
+  call NUOPC_CompAttributeGet(gcomp, name="write_restart_at_endofrun", value=value, &
+                              isPresent=isPresent, isSet=isSet, rc=rc)
   if (ChkErr(rc,__LINE__,u_FILE_u)) return
   if (isPresent .and. isSet) then
      if (trim(value) .eq. '.true.') restart_eor = .true.

--- a/config_src/drivers/nuopc_cap/mom_surface_forcing_nuopc.F90
+++ b/config_src/drivers/nuopc_cap/mom_surface_forcing_nuopc.F90
@@ -17,7 +17,7 @@ use MOM_domains,          only : pass_vector, pass_var, fill_symmetric_edges
 use MOM_domains,          only : AGRID, BGRID_NE, CGRID_NE, To_All
 use MOM_domains,          only : To_North, To_East, Omit_Corners
 use MOM_error_handler,    only : MOM_error, WARNING, FATAL, is_root_pe, MOM_mesg
-use MOM_file_parser,      only : get_param, log_version, param_file_type
+use MOM_file_parser,      only : get_param, log_param, log_version, param_file_type
 use MOM_forcing_type,     only : forcing, mech_forcing
 use MOM_forcing_type,     only : forcing_diags, mech_forcing_diags, register_forcing_type_diags
 use MOM_forcing_type,     only : allocate_forcing_type, deallocate_forcing_type
@@ -124,7 +124,7 @@ type, public :: surface_forcing_CS ; private
   real    :: max_delta_srestore             !< maximum delta salinity used for restoring [S ~> ppt]
   real    :: max_delta_trestore             !< maximum delta sst used for restoring [C ~> degC]
   real, pointer, dimension(:,:) :: basin_mask => NULL() !< mask for SSS restoring by basin
-  logical :: fix_ustar_gustless_bug         !< If true correct a bug in the time-averaging of the
+  logical :: ustar_gustless_bug             !< If true, include a bug in the time-averaging of the
                                             !! gustless wind friction velocity.
 
   type(diag_ctrl), pointer :: diag                  !< structure to regulate diagnostic output timing
@@ -296,7 +296,7 @@ subroutine convert_IOB_to_fluxes(IOB, fluxes, index_bounds, Time, valid_time, G,
   ! flux type has been used.
   if (fluxes%dt_buoy_accum < 0) then
     call allocate_forcing_type(G, fluxes, water=.true., heat=.true., ustar=.true., &
-                               press=.true., fix_accum_bug=CS%fix_ustar_gustless_bug, &
+                               press=.true., fix_accum_bug=.not.CS%ustar_gustless_bug, &
                                cfc=CS%use_CFC, hevap=CS%enthalpy_cpl, tau_mag=.true.)
     !call safe_alloc_ptr(fluxes%omega_w2x,isd,ied,jsd,jed)
 
@@ -1103,11 +1103,13 @@ subroutine surface_forcing_init(Time, G, US, param_file, diag, CS, restore_salt,
   ! Local variables
   real :: utide  ! The RMS tidal velocity [Z T-1 ~> m s-1].
   type(directories)  :: dirs
-  logical            :: new_sim, iceberg_flux_diags
+  logical            :: new_sim, iceberg_flux_diags, fix_ustar_gustless_bug
+  logical :: test_value  ! This is used to determine whether a logical parameter is being set explicitly.
+  logical :: explicit_bug, explicit_fix ! These indicate which parameters are set explicitly.
   type(time_type)    :: Time_frc
   character(len=200) :: TideAmp_file, gust_file, salt_file, temp_file ! Input file names.
-! This include declares and sets the variable "version".
-#include "version_variable.h"
+  ! This include declares and sets the variable "version".
+# include "version_variable.h"
   character(len=40)  :: mdl = "MOM_surface_forcing_nuopc"  ! This module's name.
   character(len=48)  :: stagger
   character(len=48)  :: flnam
@@ -1342,9 +1344,32 @@ subroutine surface_forcing_init(Time, G, US, param_file, diag, CS, restore_salt,
     call MOM_read_data(gust_file, 'gustiness', CS%gust, G%domain, timelevel=1, &
                scale=US%kg_m3_to_R*US%m_s_to_L_T**2*US%L_to_Z) ! units in file should be Pa
   endif
-  call get_param(param_file, mdl, "FIX_USTAR_GUSTLESS_BUG", CS%fix_ustar_gustless_bug, &
+
+  call get_param(param_file, mdl, "USTAR_GUSTLESS_BUG", CS%ustar_gustless_bug, &
+                 "If true include a bug in the time-averaging of the gustless wind friction velocity", &
+                 default=.false., do_not_log=.true.)
+  ! This is used to test whether USTAR_GUSTLESS_BUG is being actively set.
+  call get_param(param_file, mdl, "USTAR_GUSTLESS_BUG", test_value, default=.true., do_not_log=.true.)
+  explicit_bug = CS%ustar_gustless_bug .eqv. test_value
+  call get_param(param_file, mdl, "FIX_USTAR_GUSTLESS_BUG", fix_ustar_gustless_bug, &
                  "If true correct a bug in the time-averaging of the gustless wind friction velocity", &
-                 default=.true.)
+                 default=.true., do_not_log=.true.)
+  call get_param(param_file, mdl, "FIX_USTAR_GUSTLESS_BUG", test_value, default=.false., do_not_log=.true.)
+  explicit_fix = fix_ustar_gustless_bug .eqv. test_value
+
+  if (explicit_bug .and. explicit_fix .and. (fix_ustar_gustless_bug .eqv. CS%ustar_gustless_bug)) then
+    ! USTAR_GUSTLESS_BUG is being explicitly set, and should not be changed.
+    call MOM_error(FATAL, "USTAR_GUSTLESS_BUG and FIX_USTAR_GUSTLESS_BUG are both being set "//&
+                   "with inconsistent values.  FIX_USTAR_GUSTLESS_BUG is an obsolete "//&
+                   "parameter and should be removed.")
+  elseif (explicit_fix) then
+    call MOM_error(WARNING, "FIX_USTAR_GUSTLESS_BUG is an obsolete parameter.  "//&
+                   "Use USTAR_GUSTLESS_BUG instead (noting that it has the opposite sense).")
+    CS%ustar_gustless_bug = .not.fix_ustar_gustless_bug
+  endif
+  call log_param(param_file, mdl, "USTAR_GUSTLESS_BUG", CS%ustar_gustless_bug, &
+                 "If true include a bug in the time-averaging of the gustless wind friction velocity", &
+                 default=.false.)
 
 ! See whether sufficiently thick sea ice should be treated as rigid.
   call get_param(param_file, mdl, "USE_RIGID_SEA_ICE", CS%rigid_sea_ice, &

--- a/config_src/drivers/solo_driver/MOM_driver.F90
+++ b/config_src/drivers/solo_driver/MOM_driver.F90
@@ -28,6 +28,7 @@ program MOM6
   use MOM_cpu_clock,       only : CLOCK_COMPONENT
   use MOM_data_override,   only : data_override_init
   use MOM_diag_mediator,   only : diag_mediator_end, diag_ctrl, diag_mediator_close_registration
+  use MOM_diag_manager_infra, only : diag_manager_set_time_end_infra
   use MOM,                 only : initialize_MOM, step_MOM, MOM_control_struct, MOM_end
   use MOM,                 only : extract_surface_state, finish_MOM_initialization
   use MOM,                 only : get_MOM_state_elements, MOM_state_is_synchronized
@@ -374,6 +375,8 @@ program MOM6
                  timeunit=Time_unit, fail_if_missing=.true.)
     Time_end = daymax
   endif
+
+  call diag_manager_set_time_end_infra(Time_end)
 
   call get_param(param_file, mod_name, "SINGLE_STEPPING_CALL", single_step_call, &
                  "If true, advance the state of MOM with a single step "//&

--- a/config_src/drivers/solo_driver/MOM_surface_forcing.F90
+++ b/config_src/drivers/solo_driver/MOM_surface_forcing.F90
@@ -1907,19 +1907,19 @@ subroutine surface_forcing_init(Time, G, US, param_file, diag, CS, tracer_flow_C
       call get_param(param_file, mdl, "SST_NORTH", CS%T_north, &
                  "With buoy_config linear, the sea surface temperature "//&
                  "at the northern end of the domain toward which to "//&
-                 "to restore.", units="deg C", default=0.0, scale=US%degC_to_C)
+                 "to restore.", units="degC", default=0.0, scale=US%degC_to_C)
       call get_param(param_file, mdl, "SST_SOUTH", CS%T_south, &
                  "With buoy_config linear, the sea surface temperature "//&
                  "at the southern end of the domain toward which to "//&
-                 "to restore.", units="deg C", default=0.0, scale=US%degC_to_C)
+                 "to restore.", units="degC", default=0.0, scale=US%degC_to_C)
       call get_param(param_file, mdl, "SSS_NORTH", CS%S_north, &
                  "With buoy_config linear, the sea surface salinity "//&
                  "at the northern end of the domain toward which to "//&
-                 "to restore.", units="PSU", default=35.0, scale=US%ppt_to_S)
+                 "to restore.", units="ppt", default=35.0, scale=US%ppt_to_S)
       call get_param(param_file, mdl, "SSS_SOUTH", CS%S_south, &
                  "With buoy_config linear, the sea surface salinity "//&
                  "at the southern end of the domain toward which to "//&
-                 "to restore.", units="PSU", default=35.0, scale=US%ppt_to_S)
+                 "to restore.", units="ppt", default=35.0, scale=US%ppt_to_S)
     endif
     call get_param(param_file, mdl, "RESTORE_FLUX_RHO", CS%rho_restore, &
                  "The density that is used to convert piston velocities into salt or heat "//&

--- a/config_src/drivers/solo_driver/MOM_surface_forcing.F90
+++ b/config_src/drivers/solo_driver/MOM_surface_forcing.F90
@@ -19,7 +19,7 @@ use MOM_domains,             only : pass_var, pass_vector, AGRID, To_South, To_W
 use MOM_domains,             only : fill_symmetric_edges, CGRID_NE
 use MOM_error_handler,       only : MOM_error, FATAL, WARNING, MOM_mesg, is_root_pe
 use MOM_error_handler,       only : callTree_enter, callTree_leave
-use MOM_file_parser,         only : get_param, log_version, param_file_type
+use MOM_file_parser,         only : get_param, log_param, log_version, param_file_type
 use MOM_string_functions,    only : uppercase
 use MOM_forcing_type,        only : forcing, mech_forcing
 use MOM_forcing_type,        only : set_net_mass_forcing, copy_common_forcing_fields
@@ -116,8 +116,8 @@ type, public :: surface_forcing_CS ; private
                              !! Dates before 20190101 use original answers.
                              !! Dates after 20190101 use a form of the gyre wind stresses that are
                              !! rotationally invariant and more likely to be the same between compilers.
-  logical :: fix_ustar_gustless_bug         !< If true correct a bug in the time-averaging of the
-                                            !! gustless wind friction velocity.
+  logical :: ustar_gustless_bug   !< If true, include a bug in the time-averaging of the
+                                  !! gustless wind friction velocity.
   ! if WIND_CONFIG=='scurves' then use the following to define a piecewise scurve profile
   real :: scurves_ydata(20) = 90. !< Latitudes of scurve nodes [degreesN]
   real :: scurves_taux(20) = 0.   !< Zonal wind stress values at scurve nodes [R L Z T-2 ~> Pa]
@@ -256,7 +256,7 @@ subroutine set_forcing(sfc_state, forces, fluxes, day_start, day_interval, G, US
     call allocate_mech_forcing(G, forces, stress=.true., ustar=.not.CS%nonBous, press=.true., tau_mag=CS%nonBous)
 
     call allocate_forcing_type(G, fluxes, ustar=.not.CS%nonBous, tau_mag=CS%nonBous, &
-                               fix_accum_bug=CS%fix_ustar_gustless_bug)
+                               fix_accum_bug=.not.CS%ustar_gustless_bug)
     if (trim(CS%buoy_config) /= "NONE") then
       if ( CS%use_temperature ) then
         call allocate_forcing_type(G, fluxes, water=.true., heat=.true., press=.true.)
@@ -1582,6 +1582,9 @@ subroutine surface_forcing_init(Time, G, US, param_file, diag, CS, tracer_flow_C
   real :: flux_const_default ! The unscaled value of FLUXCONST [m day-1]
   logical :: Boussinesq       ! If true, this run is fully Boussinesq
   logical :: semi_Boussinesq  ! If true, this run is partially non-Boussinesq
+  logical :: fix_ustar_gustless_bug  ! If false, include a bug using an older run-time parameter.
+  logical :: test_value  ! This is used to determine whether a logical parameter is being set explicitly.
+  logical :: explicit_bug, explicit_fix ! These indicate which parameters are set explicitly.
   integer :: default_answer_date  ! The default setting for the various ANSWER_DATE flags.
   character(len=40)  :: mdl = "MOM_surface_forcing" ! This module's name.
   character(len=200) :: filename, gust_file ! The name of the gustiness input file.
@@ -1935,9 +1938,33 @@ subroutine surface_forcing_init(Time, G, US, param_file, diag, CS, tracer_flow_C
   call get_param(param_file, mdl, "GUST_CONST", CS%gust_const, &
                  "The background gustiness in the winds.", &
                  units="Pa", default=0.0, scale=US%Pa_to_RLZ_T2)
-  call get_param(param_file, mdl, "FIX_USTAR_GUSTLESS_BUG", CS%fix_ustar_gustless_bug, &
+
+  call get_param(param_file, mdl, "USTAR_GUSTLESS_BUG", CS%ustar_gustless_bug, &
+                 "If true include a bug in the time-averaging of the gustless wind friction velocity", &
+                 default=.false., do_not_log=.true.)
+  ! This is used to test whether USTAR_GUSTLESS_BUG is being actively set.
+  call get_param(param_file, mdl, "USTAR_GUSTLESS_BUG", test_value, default=.true., do_not_log=.true.)
+  explicit_bug = CS%ustar_gustless_bug .eqv. test_value
+  call get_param(param_file, mdl, "FIX_USTAR_GUSTLESS_BUG", fix_ustar_gustless_bug, &
                  "If true correct a bug in the time-averaging of the gustless wind friction velocity", &
-                 default=.true.)
+                 default=.true., do_not_log=.true.)
+  call get_param(param_file, mdl, "FIX_USTAR_GUSTLESS_BUG", test_value, default=.false., do_not_log=.true.)
+  explicit_fix = fix_ustar_gustless_bug .eqv. test_value
+
+  if (explicit_bug .and. explicit_fix .and. (fix_ustar_gustless_bug .eqv. CS%ustar_gustless_bug)) then
+    ! USTAR_GUSTLESS_BUG is being explicitly set, and should not be changed.
+    call MOM_error(FATAL, "USTAR_GUSTLESS_BUG and FIX_USTAR_GUSTLESS_BUG are both being set "//&
+                   "with inconsistent values.  FIX_USTAR_GUSTLESS_BUG is an obsolete "//&
+                   "parameter and should be removed.")
+  elseif (explicit_fix) then
+    call MOM_error(WARNING, "FIX_USTAR_GUSTLESS_BUG is an obsolete parameter.  "//&
+                   "Use USTAR_GUSTLESS_BUG instead (noting that it has the opposite sense).")
+    CS%ustar_gustless_bug = .not.fix_ustar_gustless_bug
+  endif
+  call log_param(param_file, mdl, "USTAR_GUSTLESS_BUG", CS%ustar_gustless_bug, &
+                 "If true include a bug in the time-averaging of the gustless wind friction velocity", &
+                 default=.false.)
+
   call get_param(param_file, mdl, "READ_GUST_2D", CS%read_gust_2d, &
                  "If true, use a 2-dimensional gustiness supplied from "//&
                  "an input file", default=.false.)

--- a/config_src/drivers/timing_tests/time_MOM_EOS.F90
+++ b/config_src/drivers/timing_tests/time_MOM_EOS.F90
@@ -28,9 +28,9 @@ integer, parameter :: nic=26, halo=4, nits=10000, nsamp=400
 integer, parameter :: nic=23, halo=4, nits=1000, nsamp=400
 #endif
 
-real :: times(nsamp) ! For observing the PDF
+real :: times(nsamp) ! CPU times for observing the PDF [seconds]
 
-! Arrays to hold timings:
+! Arrays to hold timings in [seconds]:
 !  first axis corresponds to the form of EOS
 !  second axis corresponds to the function being timed
 real, dimension(:,:), allocatable :: timings, tmean, tstd, tmin, tmax
@@ -100,14 +100,18 @@ subroutine run_suite(EOS_list, nic, halo, nits, timings)
   integer, intent(in)  :: nits         !< Number of calls to sample
                                        !! (large enough that the CPU timers can resolve
                                        !! the loop)
-  real,    intent(out) :: timings(n_eos,n_fns) !< The average time taken for nits calls
+  real,    intent(out) :: timings(n_eos,n_fns) !< The average time taken for nits calls [seconds]
                                        !! First index corresponds to EOS
                                        !! Second index: 1 = scalar args,
                                        !! 2 = array args without halo,
                                        !! 3 = array args with halo and "dom".
   type(EOS_type) :: EOS
   integer :: e, i, dom(2)
-  real :: start, finish, T, S, P, rho
+  real :: start, finish  ! CPU times [seconds]
+  real :: T  ! A potential or conservative temperature [degC]
+  real :: S  ! A practical salinity or absolute salinity [ppt]
+  real :: P  ! A pressure [Pa]
+  real :: rho ! A density [kg m-3] or specific volume [m3 kg-1]
   real, dimension(nic+2*halo) :: T1, S1, P1, rho1
 
   T = 10.
@@ -171,15 +175,18 @@ subroutine run_one(EOS_list, nic, halo, nits, timing)
   integer, intent(in)  :: nits         !< Number of calls to sample
                                        !! (large enough that the CPU timers can resolve
                                        !! the loop)
-  real,    intent(out) :: timing       !< The average time taken for nits calls
+  real,    intent(out) :: timing       !< The average time taken for nits calls [seconds]
                                        !! First index corresponds to EOS
                                        !! Second index: 1 = scalar args,
                                        !! 2 = array args without halo,
                                        !! 3 = array args with halo and "dom".
   type(EOS_type) :: EOS
   integer :: i, dom(2)
-  real :: start, finish
-  real, dimension(nic+2*halo) :: T1, S1, P1, rho1
+  real :: start, finish  ! CPU times [seconds]
+  real, dimension(nic+2*halo) :: T1   ! Potential or conservative temperatures [degC]
+  real, dimension(nic+2*halo) :: S1   ! A practical salinities or absolute salinities [ppt]
+  real, dimension(nic+2*halo) :: P1   ! Pressures [Pa]
+  real, dimension(nic+2*halo) :: rho1 ! Densities [kg m-3] or specific volumes [m3 kg-1]
 
   ! Time the scalar interface
   call EOS_manual_init(EOS, form_of_EOS=EOS_list(5), &

--- a/config_src/infra/FMS1/MOM_diag_manager_infra.F90
+++ b/config_src/infra/FMS1/MOM_diag_manager_infra.F90
@@ -57,6 +57,7 @@ public get_MOM_diag_axis_name
 public MOM_diag_manager_init
 public MOM_diag_manager_end
 public send_data_infra
+public diag_send_complete_infra
 public MOM_diag_field_add_attribute
 public register_diag_field_infra
 public register_static_field_infra
@@ -450,5 +451,10 @@ subroutine MOM_diag_field_add_attribute_i1d(diag_field_id, att_name, att_value)
   call FMS_diag_field_add_attribute(diag_field_id, att_name, att_value)
 
 end subroutine MOM_diag_field_add_attribute_i1d
+
+!> Finishes the diag manager reduction methods as needed for the time_step
+!! Needed for backwards compatibility, does nothing
+subroutine diag_send_complete_infra ()
+end subroutine diag_send_complete_infra
 
 end module MOM_diag_manager_infra

--- a/config_src/infra/FMS1/MOM_diag_manager_infra.F90
+++ b/config_src/infra/FMS1/MOM_diag_manager_infra.F90
@@ -58,6 +58,7 @@ public MOM_diag_manager_init
 public MOM_diag_manager_end
 public send_data_infra
 public diag_send_complete_infra
+public diag_manager_set_time_end_infra
 public MOM_diag_field_add_attribute
 public register_diag_field_infra
 public register_static_field_infra
@@ -452,9 +453,13 @@ subroutine MOM_diag_field_add_attribute_i1d(diag_field_id, att_name, att_value)
 
 end subroutine MOM_diag_field_add_attribute_i1d
 
-!> Finishes the diag manager reduction methods as needed for the time_step
-!! Needed for backwards compatibility, does nothing
+!> Needed for backwards compatibility, does nothing
 subroutine diag_send_complete_infra ()
 end subroutine diag_send_complete_infra
+
+!> Needed for backwards compatibility, does nothing
+subroutine diag_manager_set_time_end_infra(time)
+  type(time_type), intent(in) :: time !< The model time that simulation ends
+end subroutine diag_manager_set_time_end_infra
 
 end module MOM_diag_manager_infra

--- a/config_src/infra/FMS1/MOM_domain_infra.F90
+++ b/config_src/infra/FMS1/MOM_domain_infra.F90
@@ -19,7 +19,8 @@ use mpp_domains_mod, only : mpp_start_group_update, mpp_complete_group_update
 use mpp_domains_mod, only : mpp_compute_block_extent
 use mpp_domains_mod, only : mpp_broadcast_domain, mpp_redistribute, mpp_global_field
 use mpp_domains_mod, only : AGRID, BGRID_NE, CGRID_NE, SCALAR_PAIR, BITWISE_EXACT_SUM
-use mpp_domains_mod, only : CYCLIC_GLOBAL_DOMAIN, FOLD_NORTH_EDGE
+use mpp_domains_mod, only : CYCLIC_GLOBAL_DOMAIN
+use mpp_domains_mod, only : FOLD_NORTH_EDGE, FOLD_SOUTH_EDGE, FOLD_EAST_EDGE, FOLD_WEST_EDGE
 use mpp_domains_mod, only : To_East => WUPDATE, To_West => EUPDATE, Omit_Corners => EDGEUPDATE
 use mpp_domains_mod, only : To_North => SUPDATE, To_South => NUPDATE
 use mpp_domains_mod, only : CENTER, CORNER, NORTH_FACE => NORTH, EAST_FACE => EAST
@@ -1553,6 +1554,19 @@ subroutine clone_MD_to_MD(MD_in, MOM_dom, min_halo, halo_size, symmetric, domain
     call get_layout_extents(MD_in, exnj, exni)
 
     MOM_dom%X_FLAGS = MD_in%Y_FLAGS ; MOM_dom%Y_FLAGS = MD_in%X_FLAGS
+    ! Correct the position of a tripolar grid, assuming that flags are not additive.
+    if (qturns == 1) then
+      if (MD_in%Y_FLAGS == FOLD_NORTH_EDGE) MOM_dom%X_FLAGS = FOLD_EAST_EDGE
+      if (MD_in%Y_FLAGS == FOLD_SOUTH_EDGE) MOM_dom%X_FLAGS = FOLD_WEST_EDGE
+      if (MD_in%X_FLAGS == FOLD_EAST_EDGE) MOM_dom%Y_FLAGS = FOLD_SOUTH_EDGE
+      if (MD_in%X_FLAGS == FOLD_WEST_EDGE) MOM_dom%Y_FLAGS = FOLD_NORTH_EDGE
+    elseif (qturns == 3) then
+      if (MD_in%Y_FLAGS == FOLD_NORTH_EDGE) MOM_dom%X_FLAGS = FOLD_WEST_EDGE
+      if (MD_in%Y_FLAGS == FOLD_SOUTH_EDGE) MOM_dom%X_FLAGS = FOLD_EAST_EDGE
+      if (MD_in%X_FLAGS == FOLD_EAST_EDGE) MOM_dom%Y_FLAGS = FOLD_NORTH_EDGE
+      if (MD_in%X_FLAGS == FOLD_WEST_EDGE) MOM_dom%Y_FLAGS = FOLD_SOUTH_EDGE
+    endif
+
     MOM_dom%layout(:) = MD_in%layout(2:1:-1)
     MOM_dom%io_layout(:) = io_layout_in(2:1:-1)
   else
@@ -1561,11 +1575,19 @@ subroutine clone_MD_to_MD(MD_in, MOM_dom, min_halo, halo_size, symmetric, domain
     call get_layout_extents(MD_in, exni, exnj)
 
     MOM_dom%X_FLAGS = MD_in%X_FLAGS ; MOM_dom%Y_FLAGS = MD_in%Y_FLAGS
+    ! Correct the position of a tripolar grid, assuming that flags are not additive.
+    if (qturns == 2) then
+      if (MD_in%Y_FLAGS == FOLD_NORTH_EDGE) MOM_dom%Y_FLAGS = FOLD_SOUTH_EDGE
+      if (MD_in%Y_FLAGS == FOLD_SOUTH_EDGE) MOM_dom%Y_FLAGS = FOLD_NORTH_EDGE
+      if (MD_in%X_FLAGS == FOLD_EAST_EDGE) MOM_dom%X_FLAGS = FOLD_WEST_EDGE
+      if (MD_in%X_FLAGS == FOLD_WEST_EDGE) MOM_dom%X_FLAGS = FOLD_EAST_EDGE
+    endif
+
     MOM_dom%layout(:) = MD_in%layout(:)
     MOM_dom%io_layout(:) = io_layout_in(:)
   endif
 
-  ! Ensure that the points per processor are the same on the source and densitation grids.
+  ! Ensure that the points per processor are the same on the source and destination grids.
   select case (qturns)
     case (1) ; call invert(exni)
     case (2) ; call invert(exni) ; call invert(exnj)

--- a/config_src/infra/FMS2/MOM_diag_manager_infra.F90
+++ b/config_src/infra/FMS2/MOM_diag_manager_infra.F90
@@ -15,6 +15,7 @@ use diag_data_mod,    only : null_axis_id
 use diag_manager_mod, only : fms_diag_manager_init => diag_manager_init
 use diag_manager_mod, only : fms_diag_manager_end => diag_manager_end
 use diag_manager_mod, only : diag_send_complete
+use diag_manager_mod, only : diag_manager_set_time_end
 use diag_manager_mod, only : send_data_fms => send_data
 use diag_manager_mod, only : fms_diag_field_add_attribute => diag_field_add_attribute
 use diag_manager_mod, only : DIAG_FIELD_NOT_FOUND
@@ -59,6 +60,7 @@ public MOM_diag_manager_init
 public MOM_diag_manager_end
 public send_data_infra
 public diag_send_complete_infra
+public diag_manager_set_time_end_infra
 public MOM_diag_field_add_attribute
 public register_diag_field_infra
 public register_static_field_infra
@@ -460,5 +462,12 @@ subroutine diag_send_complete_infra ()
   !! It won't have any impact when diag_manager_nml::use_modern_diag=.false.
   call diag_send_complete (set_time(0))
 end subroutine diag_send_complete_infra
+
+!> Sets the time that the simulation ends in the diag manager
+subroutine diag_manager_set_time_end_infra(time)
+  type(time_type),           optional, intent(in) :: time  !< The time the simulation ends
+
+  call diag_manager_set_time_end(time)
+end subroutine diag_manager_set_time_end_infra
 
 end module MOM_diag_manager_infra

--- a/config_src/infra/FMS2/MOM_diag_manager_infra.F90
+++ b/config_src/infra/FMS2/MOM_diag_manager_infra.F90
@@ -14,13 +14,14 @@ use diag_axis_mod,    only : EAST, NORTH
 use diag_data_mod,    only : null_axis_id
 use diag_manager_mod, only : fms_diag_manager_init => diag_manager_init
 use diag_manager_mod, only : fms_diag_manager_end => diag_manager_end
+use diag_manager_mod, only : diag_send_complete
 use diag_manager_mod, only : send_data_fms => send_data
 use diag_manager_mod, only : fms_diag_field_add_attribute => diag_field_add_attribute
 use diag_manager_mod, only : DIAG_FIELD_NOT_FOUND
 use diag_manager_mod, only : register_diag_field_fms => register_diag_field
 use diag_manager_mod, only : register_static_field_fms => register_static_field
 use diag_manager_mod, only : get_diag_field_id_fms => get_diag_field_id
-use MOM_time_manager, only : time_type
+use MOM_time_manager, only : time_type, set_time
 use MOM_domain_infra, only : MOM_domain_type
 use MOM_error_infra,  only : MOM_error => MOM_err, FATAL, WARNING
 
@@ -57,6 +58,7 @@ public get_MOM_diag_axis_name
 public MOM_diag_manager_init
 public MOM_diag_manager_end
 public send_data_infra
+public diag_send_complete_infra
 public MOM_diag_field_add_attribute
 public register_diag_field_infra
 public register_static_field_infra
@@ -450,5 +452,13 @@ subroutine MOM_diag_field_add_attribute_i1d(diag_field_id, att_name, att_value)
   call FMS_diag_field_add_attribute(diag_field_id, att_name, att_value)
 
 end subroutine MOM_diag_field_add_attribute_i1d
+
+!> Finishes the diag manager reduction methods as needed for the time_step
+subroutine diag_send_complete_infra ()
+  !! The time_step in the diag_send_complete call is a dummy argument, needed for backwards compatibility
+  !! It won't be used at all when diag_manager_nml::use_modern_diag=.true.
+  !! It won't have any impact when diag_manager_nml::use_modern_diag=.false.
+  call diag_send_complete (set_time(0))
+end subroutine diag_send_complete_infra
 
 end module MOM_diag_manager_infra

--- a/docs/forcing.rst
+++ b/docs/forcing.rst
@@ -1,5 +1,33 @@
 Forcing
 =======
+Data Override
+-------
+When running MOM6 with the Flexible Modelling System (FMS) coupler, forcing can be specified by a `data_table` file. This is particularly useful when running MOM6 with a data atmosphere, as paths to the relevent atmospheric forcing products (eg. JRA55-do or ERA5) can be provided here. Each item in the data table must be separated by a new line, and contains the following information:
+
+| ``gridname``: The component of the model this data applies to. eg. `atm` `ocn` `lnd` `ice`.
+| ``fieldname_code``: The field name according to the model component. eg. `salt`
+| ``fieldname_file``: The name of the field within the source file. 
+| ``file_name``: Path to the source file.
+| ``interpol_method``: Interpolation method eg. `bilinear`
+| ``factor``: A scalar by which to multiply the field ahead of passing it onto the model. This is a quick way to do unit conversions for example. 
+
+| 
+The data table is commonly formatted by specifying each of the fields in the order listed above, with a new line for each entry.
+
+Example Format:
+    "ATM", "t_bot",  "t2m", "./INPUT/2t_ERA5.nc", "bilinear", 1.0
+
+A `yaml` format is also possible if you prefer. This is outlined in the `FMS data override <https://github.com/NOAA-GFDL/FMS/tree/main/data_override>`_ github page, along with other details. 
+
+Speficying a constant value:
+    Rather than overriding with data from a file, one can also set a field to constant. To do this, pass empty strings to `fieldname_file` and `file_name`. The `factor` now corresponds to the override value. For example, the following sets the temperature at the bottom of the atmosphere to 290 Kelvin.
+
+
+    "ATM", "t_bot",  "", "", "bilinear", 290.0
+
+Which units do I need?
+    For configurations using SIS2 and MOM, a list of available surface flux variables along with the expected units can be found in the `flux_exchange <https://github.com/NOAA-GFDL/FMScoupler/blob/f4782c2c033df086eeac29fbbefb4a0bdac1649f/full/flux_exchange.F90>`_ file. 
+
 
 .. toctree::
     :maxdepth: 2

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -10,3 +10,9 @@ six
 future
 # Old Sphinx requires an old Jinja2
 jinja2<3.1
+sphinxcontrib_applehelp<1.0.8
+sphinxcontrib_devhelp<1.0.6
+sphinxcontrib_htmlhelp<2.0.5
+sphinxcontrib_qthelp<1.0.7
+sphinxcontrib_serializinghtml<1.0.7
+alabaster<0.7.14

--- a/src/ALE/MOM_hybgen_regrid.F90
+++ b/src/ALE/MOM_hybgen_regrid.F90
@@ -41,8 +41,10 @@ type, public :: hybgen_regrid_CS ; private
     dp0k, & !< minimum deep    z-layer separation [H ~> m or kg m-2]
     ds0k    !< minimum shallow z-layer separation [H ~> m or kg m-2]
 
-  real :: coord_scale = 1.0     !< A scaling factor to restores the depth coordinates to values in m
-  real :: Rho_coord_scale = 1.0 !< A scaling factor to restores the denesity coordinates to values in kg m-3
+  real :: coord_scale = 1.0     !< A scaling factor to restores the depth coordinates to
+                                !! values in m [m H-1 ~> 1 or m3 kg-1]
+  real :: Rho_coord_scale = 1.0 !< A scaling factor to restores the denesity coordinates to
+                                !! values in kg m-3 [kg m-3 R-1 ~> 1]
 
   real :: dpns  !< depth to start terrain following [H ~> m or kg m-2]
   real :: dsns  !< depth to stop terrain following [H ~> m or kg m-2]
@@ -68,7 +70,7 @@ type, public :: hybgen_regrid_CS ; private
                      !! the bottom that certain adjustments can be made in the Hybgen regridding
                      !! code [H ~> m or kg m-2].  In Hycom, this is set to onem (nominally 1 m).
   real :: h_thin     !< A layer thickness below which a layer is considered to be too thin for
-                     !! certain adjustments to be made in the Hybgen regridding code.
+                     !! certain adjustments to be made in the Hybgen regridding code [H ~> m or kg m-2].
                      !! In Hycom, this is set to onemm (nominally 0.001 m).
 
   real :: rho_eps    !< A small nonzero density that is used to prevent division by zero
@@ -284,7 +286,7 @@ subroutine get_hybgen_regrid_params(CS, nk, ref_pressure, hybiso, nsigma, dp00i,
   real,    optional, intent(out) :: ref_pressure !< Reference pressure for density calculations [R L2 T-2 ~> Pa]
   real,    optional, intent(out) :: hybiso  !< Hybgen uses PCM if layer is within hybiso of target density [R ~> kg m-3]
   integer, optional, intent(out) :: nsigma  !< Number of sigma levels used by HYBGEN
-  real,    optional, intent(out) :: dp00i   !< Deep isopycnal spacing minimum thickness (m)
+  real,    optional, intent(out) :: dp00i   !< Deep isopycnal spacing minimum thickness [H ~> m or kg m-2]
   real,    optional, intent(out) :: qhybrlx !< Fractional relaxation amount per timestep, 0 < qyhbrlx <= 1 [nondim]
   real,    optional, intent(out) :: dp0k(:) !< minimum deep    z-layer separation [H ~> m or kg m-2]
   real,    optional, intent(out) :: ds0k(:) !< minimum shallow z-layer separation [H ~> m or kg m-2]
@@ -687,8 +689,8 @@ real function cushn(delp, dp0)
   ! These are derivative nondimensional parameters.
   ! real, parameter :: cusha = qqmn**2 * (qqmx-1.0) / (qqmx-qqmn)**2
   ! real, parameter :: I_qqmn = 1.0 / qqmn
-  real, parameter :: qq_scale = (qqmx-1.0) / (qqmx-qqmn)**2
-  real, parameter :: I_qqmx = 1.0 / qqmx
+  real, parameter :: qq_scale = (qqmx-1.0) / (qqmx-qqmn)**2  ! A scaling factor based on qqmn and qqmx [nondim]
+  real, parameter :: I_qqmx = 1.0 / qqmx  ! The inverse of qqmx [nondim]
 
   ! --- if delp >= qqmx*dp0 >>  dp0, cushn returns delp.
   ! --- if delp <= qqmn*dp0 << -dp0, cushn returns dp0.

--- a/src/ALE/MOM_hybgen_remap.F90
+++ b/src/ALE/MOM_hybgen_remap.F90
@@ -126,7 +126,7 @@ subroutine hybgen_ppm_coefs(s, h_src, edges, nk, ns, thin, PCM_lay)
   real :: da        ! Difference between the unlimited scalar edge value estimates [A]
   real :: a6        ! Scalar field differences that are proportional to the curvature [A]
   real :: slk, srk  ! Differences between adjacent cell averages of scalars [A]
-  real :: sck       ! Scalar differences across a cell.
+  real :: sck       ! Scalar differences across a cell [A]
   real :: as(nk)    ! Scalar field difference across each cell [A]
   real :: al(nk), ar(nk)   ! Scalar field at the left and right edges of a cell [A]
   real :: h112(nk+1), h122(nk+1)  ! Combinations of thicknesses [H ~> m or kg m-2]

--- a/src/ALE/MOM_regridding.F90
+++ b/src/ALE/MOM_regridding.F90
@@ -49,11 +49,11 @@ type, public :: regridding_CS ; private
   !> This array is set by function setCoordinateResolution()
   !! It contains the "resolution" or delta coordinate of the target
   !! coordinate.  It has the units of the target coordinate, e.g.
-  !! [Z ~> m] for z*, non-dimensional for sigma, etc.
+  !! [Z ~> m] for z*, [nondim] for sigma, etc.
   real, dimension(:), allocatable :: coordinateResolution
 
   !> This is a scaling factor that restores coordinateResolution to values in
-  !! the natural units for output.
+  !! the natural units for output, perhaps [nondim]
   real :: coord_scale = 1.0
 
   !> This array is set by function set_target_densities()
@@ -102,16 +102,12 @@ type, public :: regridding_CS ; private
   real :: depth_of_time_filter_deep = 0.
 
   !> Fraction (between 0 and 1) of compressibility to add to potential density
-  !! profiles when interpolating for target grid positions. [nondim]
+  !! profiles when interpolating for target grid positions [nondim]
   real :: compressibility_fraction = 0.
 
   !> If true, each interface is given a maximum depth based on a rescaling of
   !! the indexing of coordinateResolution.
   logical :: set_maximum_depths = .false.
-
-  !> A scaling factor (> 1) of the rate at which the coordinateResolution list
-  !! is traversed to set the minimum depth of interfaces.
-  real :: max_depth_index_scale = 2.0
 
   !> If true, integrate for interface positions from the top downward.
   !! If false, integrate from the bottom upward, as does the rest of the model.
@@ -215,7 +211,9 @@ subroutine initialize_regridding(CS, GV, US, max_depth, param_file, mdl, coord_m
   real :: tmpReal  ! A temporary variable used in setting other variables [various]
   real :: P_Ref    ! The coordinate variable reference pression [R L2 T-2 ~> Pa]
   real :: maximum_depth ! The maximum depth of the ocean [m] (not in Z).
-  real :: adaptTimeRatio, adaptZoom, adaptZoomCoeff, adaptBuoyCoeff, adaptAlpha
+  real :: adaptTimeRatio, adaptZoomCoeff ! Temporary variables for input parameters [nondim]
+  real :: adaptBuoyCoeff, adaptAlpha     ! Temporary variables for input parameters [nondim]
+  real :: adaptZoom  ! The thickness of the near-surface zooming region with the adaptive coordinate [H ~> m or kg m-2]
   real :: adaptDrho0 ! Reference density difference for stratification-dependent diffusion. [R ~> kg m-3]
   integer :: k, nzf(4)
   real, dimension(:), allocatable :: dz     ! Resolution (thickness) in units of coordinate, which may be [m]
@@ -226,7 +224,7 @@ subroutine initialize_regridding(CS, GV, US, max_depth, param_file, mdl, coord_m
   real, dimension(:), allocatable :: dz_max ! Thicknesses used to find maximum interface depths
                                             ! [H ~> m or kg m-2] or other units
   real, dimension(:), allocatable :: rho_target ! Target density used in HYBRID mode [kg m-3]
-  ! Thicknesses [m] that give level centers corresponding to table 2 of WOA09
+  !> Thicknesses [m] that give level centers corresponding to table 2 of WOA09
   real, dimension(40) :: woa09_dz = (/ 5.,  10.,  10.,  15.,  22.5, 25., 25.,  25.,  &
                                       37.5, 50.,  50.,  75., 100., 100., 100., 100., &
                                      100., 100., 100., 100., 100., 100., 100., 175., &
@@ -804,7 +802,6 @@ subroutine regridding_main( remapCS, CS, G, GV, US, h, tv, h_new, dzInterface, &
   real :: tot_dz(SZI_(G),SZJ_(G)) !< The total distance between the top and bottom of the water column [Z ~> m]
   real :: Z_to_H  ! A conversion factor used by some routines to convert coordinate
                   ! parameters to depth units [H Z-1 ~> nondim or kg m-3]
-  real :: trickGnuCompiler
   character(len=128) :: mesg    ! A string for error messages
   integer :: i, j, k
 
@@ -967,11 +964,14 @@ end subroutine calc_h_new_by_dz
 subroutine check_grid_column( nk, h, dzInterface, msg )
   integer,               intent(in) :: nk !< Number of cells
   real, dimension(nk),   intent(in) :: h  !< Cell thicknesses [Z ~> m] or arbitrary units
-  real, dimension(nk+1), intent(in) :: dzInterface !< Change in interface positions (same units as h)
+  real, dimension(nk+1), intent(in) :: dzInterface !< Change in interface positions (same units as h), often [Z ~> m]
   character(len=*),      intent(in) :: msg !< Message to append to errors
   ! Local variables
   integer :: k
-  real    :: eps, total_h_old, total_h_new, h_new
+  real :: eps          ! A tiny relative thickness [nondim]
+  real :: total_h_old  ! The total thickness in the old column, in [Z ~> m] or arbitrary units
+  real :: total_h_new  ! The total thickness in the updated column, in [Z ~> m] or arbitrary units
+  real :: h_new        ! A thickness in the updated column, in [Z ~> m] or arbitrary units
 
   eps =1. ; eps = epsilon(eps)
 
@@ -1023,17 +1023,31 @@ subroutine filtered_grid_motion( CS, nk, z_old, z_new, dz_g )
   type(regridding_CS),      intent(in)    :: CS !< Regridding control structure
   integer,                  intent(in)    :: nk !< Number of cells in source grid
   real, dimension(nk+1),    intent(in)    :: z_old !< Old grid position [H ~> m or kg m-2]
-  real, dimension(CS%nk+1), intent(in)    :: z_new !< New grid position [H ~> m or kg m-2]
-  real, dimension(CS%nk+1), intent(inout) :: dz_g !< Change in interface positions [H ~> m or kg m-2]
+  real, dimension(CS%nk+1), intent(in)    :: z_new !< New grid position before filtering [H ~> m or kg m-2]
+  real, dimension(CS%nk+1), intent(inout) :: dz_g  !< Change in interface positions including
+                                                   !! the effects of filtering [H ~> m or kg m-2]
   ! Local variables
-  real :: sgn  ! The sign convention for downward.
-  real :: dz_tgt, zr1, z_old_k
-  real :: Aq, Bq, dz0, z0, F0
-  real :: zs, zd, dzwt, Idzwt
-  real :: wtd, Iwtd
-  real :: Int_zs, Int_zd, dInt_zs_zd
+  real :: sgn     ! The sign convention for downward [nondim].
+  real :: dz_tgt  ! The target grid movement of the unfiltered grid [H ~> m or kg m-2]
+  real :: zr1     ! The old grid position of an interface relative to the surface [H ~> m or kg m-2]
+  real :: z_old_k ! The corrected position of the old grid [H ~> m or kg m-2]
+  real :: Aq      ! A temporary variable related to the grid weights [nondim]
+  real :: Bq      ! A temporary variable used in the linear term in the quadratic expression for the
+                  ! filtered grid movement [H ~> m or kg m-2]
+  real :: z0, dz0 ! Together these give the position of an interface relative to a reference hieght
+                  ! that may be adjusted for numerical accuracy in a solver [H ~> m or kg m-2]
+  real :: F0      ! An estimated grid movement  [H ~> m or kg m-2]
+  real :: zs      ! The depth at which the shallow filtering timescale applies [H ~> m or kg m-2]
+  real :: zd      ! The depth at which the deep filtering timescale applies [H ~> m or kg m-2]
+  real :: dzwt    ! The depth range over which the transition in the filtering timescale occurs [H ~> m or kg m-2]
+  real :: Idzwt   ! The Adcroft reciprocal of dzwt [H-1 ~> m-1 or m2 kg-1]
+  real :: wtd     ! The weight given to the new grid when time filtering [nondim]
+  real :: Iwtd    ! The inverse of wtd [nondim]
+  real :: Int_zs  ! A depth integral of the weights in [H ~> m or kg m-2]
+  real :: Int_zd  ! A depth integral of the weights in [H ~> m or kg m-2]
+  real :: dInt_zs_zd ! The depth integral of the weights between the deep and shallow depths in [H ~> m or kg m-2]
 ! For debugging:
-  real, dimension(nk+1) :: z_act
+  real, dimension(nk+1) :: z_act ! The final grid positions after the filtered movement [H ~> m or kg m-2]
 !  real, dimension(nk+1) :: ddz_g_s, ddz_g_d
   logical :: debug = .false.
   integer :: k
@@ -1552,8 +1566,9 @@ subroutine build_grid_HyCOM1( G, GV, US, h, nom_depth_H, tv, h_new, dzInterface,
   type(regridding_CS),                       intent(in)    :: CS !< Regridding control structure
   real, dimension(SZI_(G),SZJ_(G),CS%nk),    intent(inout) :: h_new !< New layer thicknesses [H ~> m or kg m-2]
   real, dimension(SZI_(G),SZJ_(G),CS%nk+1),  intent(inout) :: dzInterface !< Changes in interface position
+                                                                 !! in thickness units [H ~> m or kg m-2]
   real, dimension(SZI_(G),SZJ_(G)), optional, intent(in)   :: frac_shelf_h !< Fractional ice shelf
-                                                                    !! coverage [nondim]
+                                                                 !! coverage [nondim]
   real,                            optional, intent(in)    :: zScale !< Scaling factor from the target coordinate
                                                                  !! resolution in Z to desired units for zInterface,
                                                                  !! usually Z_to_H in which case it is in
@@ -1564,11 +1579,13 @@ subroutine build_grid_HyCOM1( G, GV, US, h, nom_depth_H, tv, h_new, dzInterface,
   real, dimension(SZK_(GV))   :: p_col  ! Layer center pressure in the input column [R L2 T-2 ~> Pa]
   real, dimension(CS%nk+1) :: z_col_new ! New interface positions relative to the surface [H ~> m or kg m-2]
   real, dimension(CS%nk+1) :: dz_col    ! The realized change in z_col [H ~> m or kg m-2]
-  integer   :: i, j, k, nki
-  real :: nominalDepth
-  real :: h_neglect, h_neglect_edge
-  real :: z_top_col, totalThickness
+  real :: nominalDepth    ! The nominal depth of the seafloor in thickness units [H ~> m or kg m-2]
+  real :: h_neglect, h_neglect_edge ! Negligible thicknesses used for remapping [H ~> m or kg m-2]
+  real :: z_top_col       ! The nominal height of the sea surface or ice-ocean interface
+                          ! in thickness units [H ~> m or kg m-2]
+  real :: totalThickness  ! The total thickness of the water column [H ~> m or kg m-2]
   logical :: ice_shelf
+  integer :: i, j, k, nki
 
   h_neglect = set_h_neglect(GV, CS%remap_answer_date, h_neglect_edge)
 
@@ -1696,11 +1713,16 @@ end subroutine build_grid_adaptive
 subroutine adjust_interface_motion( CS, nk, h_old, dz_int )
   type(regridding_CS),      intent(in)    :: CS !< Regridding control structure
   integer,                  intent(in)    :: nk !< Number of layers in h_old
-  real, dimension(nk),      intent(in)    :: h_old !< Minimum allowed thickness of h [H ~> m or kg m-2]
-  real, dimension(CS%nk+1), intent(inout) :: dz_int !< Minimum allowed thickness of h [H ~> m or kg m-2]
+  real, dimension(nk),      intent(in)    :: h_old  !< Layer thicknesses on the old grid [H ~> m or kg m-2]
+  real, dimension(CS%nk+1), intent(inout) :: dz_int !< Interface movements, adjusted to keep the thicknesses
+                                                    !! thicker than their minimum value [H ~> m or kg m-2]
   ! Local variables
+  real :: h_new   ! A layer thickness on the new grid [H ~> m or kg m-2]
+  real :: eps     ! A tiny relative thickness [nondim]
+  real :: h_total ! The total thickness of the old grid [H ~> m or kg m-2]
+  real :: h_err   ! An error tolerance that use used to flag unacceptably large negative layer thicknesses
+                  ! that can not be explained by roundoff errors [H ~> m or kg m-2]
   integer :: k
-  real :: h_new, eps, h_total, h_err
 
   eps = 1. ; eps = epsilon(eps)
 
@@ -1753,8 +1775,9 @@ end subroutine adjust_interface_motion
 
 
 !------------------------------------------------------------------------------
-! Check grid integrity
-!------------------------------------------------------------------------------
+!> make sure all layers are at least as thick as the minimum thickness allowed
+!! for regridding purposes by inflating thin layers.  This breaks mass conservation
+!! and adds mass to the model when there are excessively thin layers.
 subroutine inflate_vanished_layers_old( CS, G, GV, h )
 !------------------------------------------------------------------------------
 ! This routine is called when initializing the regridding options. The
@@ -1765,14 +1788,14 @@ subroutine inflate_vanished_layers_old( CS, G, GV, h )
 !------------------------------------------------------------------------------
 
   ! Arguments
-  type(regridding_CS),                    intent(in)    :: CS   !< Regridding control structure
-  type(ocean_grid_type),                  intent(in)    :: G    !< The ocean's grid structure
-  type(verticalGrid_type),                intent(in)    :: GV   !< The ocean's vertical grid structure
-  real, dimension(SZI_(G),SZJ_(G), SZK_(GV)), intent(inout) :: h    !< Layer thicknesses [H ~> m or kg m-2]
+  type(regridding_CS),                       intent(in)    :: CS   !< Regridding control structure
+  type(ocean_grid_type),                     intent(in)    :: G    !< The ocean's grid structure
+  type(verticalGrid_type),                   intent(in)    :: GV   !< The ocean's vertical grid structure
+  real, dimension(SZI_(G),SZJ_(G),SZK_(GV)), intent(inout) :: h    !< Layer thicknesses [H ~> m or kg m-2]
 
   ! Local variables
   integer :: i, j, k
-  real    :: hTmp(GV%ke)
+  real    :: hTmp(GV%ke) ! A copy of a 1-d column of h [H ~> m or kg m-2]
 
   do i = G%isc-1,G%iec+1
     do j = G%jsc-1,G%jec+1
@@ -1872,11 +1895,15 @@ function uniformResolution(nk,coordMode,maxDepth,rhoLight,rhoHeavy)
   character(len=*), intent(in) :: coordMode !< A string indicating the coordinate mode.
                                             !! See the documentation for regrid_consts
                                             !! for the recognized values.
-  real,             intent(in) :: maxDepth  !< The range of the grid values in some modes
-  real,             intent(in) :: rhoLight  !< The minimum value of the grid in RHO mode
-  real,             intent(in) :: rhoHeavy  !< The maximum value of the grid in RHO mode
+  real,             intent(in) :: maxDepth  !< The range of the grid values in some modes, in coordinate
+                                            !! dependent units that might be [m] or [kg m-3] or [nondim]
+                                            !! or something else.
+  real,             intent(in) :: rhoLight  !< The minimum value of the grid in RHO mode [kg m-3]
+  real,             intent(in) :: rhoHeavy  !< The maximum value of the grid in RHO mode [kg m-3]
 
-  real                         :: uniformResolution(nk) !< The returned uniform resolution grid.
+  real                         :: uniformResolution(nk) !< The returned uniform resolution grid, in
+                                            !! coordinate dependent units that might be [m] or
+                                            !! [kg m-3] or [nondim] or something else.
 
   ! Local variables
   integer :: scheme
@@ -1935,9 +1962,14 @@ end subroutine initCoord
 !------------------------------------------------------------------------------
 !> Set the fixed resolution data
 subroutine setCoordinateResolution( dz, CS, scale )
-  real, dimension(:),  intent(in)    :: dz !< A vector of vertical grid spacings
+  real, dimension(:),  intent(in)    :: dz !< A vector of vertical grid spacings, in arbitrary coordinate
+                                           !! dependent units, such as [m] for a z-coordinate or [kg m-3]
+                                           !! for a density coordinate.
   type(regridding_CS), intent(inout) :: CS !< Regridding control structure
-  real,      optional, intent(in)    :: scale !< A scaling factor converting dz to coordRes
+  real,      optional, intent(in)    :: scale !< A scaling factor converting dz to the internal represetation
+                                           !! of coordRes, in various units that depend on the coordinate,
+                                           !! such as [Z m-1 ~> 1 for a z-coordinate or [R m3 kg-1 ~> 1] for
+                                           !! a density coordinate.
 
   if (size(dz)/=CS%nk) call MOM_error( FATAL, &
       'setCoordinateResolution: inconsistent number of levels' )
@@ -1990,10 +2022,12 @@ end subroutine set_target_densities
 !> Set maximum interface depths based on a vector of input values.
 subroutine set_regrid_max_depths( CS, max_depths, units_to_H )
   type(regridding_CS),      intent(inout) :: CS !< Regridding control structure
-  real, dimension(CS%nk+1), intent(in)    :: max_depths !< Maximum interface depths, in arbitrary units
-  real, optional,           intent(in)    :: units_to_H !< A conversion factor for max_depths into H units
+  real, dimension(CS%nk+1), intent(in)    :: max_depths !< Maximum interface depths, in arbitrary units, often [m]
+  real, optional,           intent(in)    :: units_to_H !< A conversion factor for max_depths into H units,
+                                                        !! often in [H m-1 ~> 1 or kg m-3]
   ! Local variables
-  real :: val_to_H
+  real :: val_to_H ! A conversion factor from the units for max_depths into H units, often [H m-1 ~> 1 or kg m-3]
+                   ! if units_to_H is present, or [nondim] if it is absent.
   integer :: K
 
   if (.not.allocated(CS%max_interface_depths)) allocate(CS%max_interface_depths(1:CS%nk+1))
@@ -2026,11 +2060,13 @@ end subroutine set_regrid_max_depths
 !> Set maximum layer thicknesses based on a vector of input values.
 subroutine set_regrid_max_thickness( CS, max_h, units_to_H )
   type(regridding_CS),      intent(inout) :: CS !< Regridding control structure
-  real, dimension(CS%nk+1), intent(in)    :: max_h !< Maximum interface depths, in arbitrary units
-  real, optional,           intent(in)    :: units_to_H !< A conversion factor for max_h into H units
+  real, dimension(CS%nk+1), intent(in)    :: max_h !< Maximum layer thicknesses, in arbitrary units, often [m]
+  real, optional,           intent(in)    :: units_to_H !< A conversion factor for max_h into H units,
+                                                        !! often [H m-1 ~> 1 or kg m-3]
   ! Local variables
-  real :: val_to_H
-  integer :: K
+  real :: val_to_H ! A conversion factor from the units for max_h into H units, often [H m-1 ~> 1 or kg m-3]
+                   ! if units_to_H is present, or [nondim] if it is absent.
+  integer :: k
 
   if (.not.allocated(CS%max_layer_thickness)) allocate(CS%max_layer_thickness(1:CS%nk))
 
@@ -2059,7 +2095,9 @@ subroutine write_regrid_file( CS, GV, filepath )
   type(vardesc)      :: vars(2)
   type(MOM_field)    :: fields(2)
   type(MOM_netCDF_file) :: IO_handle ! The I/O handle of the fileset
-  real               :: ds(GV%ke), dsi(GV%ke+1)
+  real               :: ds(GV%ke), dsi(GV%ke+1)  ! The labeling layer and interface coordinates for output
+                                                 ! in axes in files, in coordinate-dependent units that can
+                                                 ! be obtained from getCoordinateUnits [various]
 
   if (CS%regridding_scheme == REGRIDDING_HYBGEN) then
     call write_Hybgen_coord_file(GV, CS%hybgen_CS, filepath)
@@ -2134,7 +2172,8 @@ function getCoordinateResolution( CS, undo_scaling )
   type(regridding_CS), intent(in) :: CS !< Regridding control structure
   logical,   optional, intent(in) :: undo_scaling !< If present and true, undo any internal
                                         !! rescaling of the resolution data.
-  real, dimension(CS%nk)          :: getCoordinateResolution
+  real, dimension(CS%nk)          :: getCoordinateResolution !< The resolution or delta of the target coordinate,
+                                                             !! in units that depend on the coordinate [various]
 
   logical :: unscale
   unscale = .false. ; if (present(undo_scaling)) unscale = undo_scaling
@@ -2152,7 +2191,8 @@ function getCoordinateInterfaces( CS, undo_scaling )
   type(regridding_CS), intent(in) :: CS                      !< Regridding control structure
   logical,   optional, intent(in) :: undo_scaling            !< If present and true, undo any internal
                                                              !! rescaling of the resolution data.
-  real, dimension(CS%nk+1)        :: getCoordinateInterfaces !< Interface positions in target coordinate
+  real, dimension(CS%nk+1)        :: getCoordinateInterfaces !< Interface positions in target coordinate,
+                                                             !! in units that depend on the coordinate [various]
 
   integer :: k
   logical :: unscale
@@ -2258,7 +2298,7 @@ subroutine set_regrid_params( CS, boundary_extrapolation, min_thickness, old_gri
   logical, optional, intent(in) :: boundary_extrapolation !< Extrapolate in boundary cells
   real,    optional, intent(in) :: min_thickness    !< Minimum thickness allowed when building the
                                                     !! new grid [H ~> m or kg m-2]
-  real,    optional, intent(in) :: old_grid_weight  !< Weight given to old coordinate when time-filtering grid
+  real,    optional, intent(in) :: old_grid_weight  !< Weight given to old coordinate when time-filtering grid [nondim]
   character(len=*), optional, intent(in) :: interp_scheme !< Interpolation method for state-dependent coordinates
   real,    optional, intent(in) :: depth_of_time_filter_shallow !< Depth to start cubic [H ~> m or kg m-2]
   real,    optional, intent(in) :: depth_of_time_filter_deep !< Depth to end cubic [H ~> m or kg m-2]
@@ -2379,9 +2419,10 @@ end function get_rho_CS
 !> Return coordinate-derived thicknesses for fixed coordinate systems
 function getStaticThickness( CS, SSH, depth )
   type(regridding_CS), intent(in) :: CS !< Regridding control structure
-  real,                intent(in) :: SSH   !< The sea surface height, in the same units as depth
+  real,                intent(in) :: SSH   !< The sea surface height, in the same units as depth, often [Z ~> m]
   real,                intent(in) :: depth !< The maximum depth of the grid, often [Z ~> m]
-  real, dimension(CS%nk)          :: getStaticThickness !< The returned thicknesses in the units of depth
+  real, dimension(CS%nk)          :: getStaticThickness !< The returned thicknesses in the units of
+                                           !! depth, often [Z ~> m]
   ! Local
   integer :: k
   real :: z, dz  ! Vertical positions and grid spacing [Z ~> m]
@@ -2476,7 +2517,14 @@ integer function rho_function1( string, rho_target )
   real, dimension(:), allocatable, intent(inout) :: rho_target !< Profile of interface densities [kg m-3]
   ! Local variables
   integer :: nki, k, nk
-  real    :: ddx, dx, rho_1, rho_2, rho_3, drho, rho_4, drho_min
+  real    :: dx   ! Fractional distance from interface nki [nondim]
+  real    :: ddx  ! Change in dx between interfaces [nondim]
+  real    :: rho_1, rho_2 ! Density of the top two layers in a profile [kg m-3]
+  real    :: rho_3    ! Density in the third layer, below which the density increase linearly
+                      ! in subsequent layers [kg m-3]
+  real    :: drho     ! Change in density over the linear region [kg m-3]
+  real    :: rho_4    ! The densest density in this profile [kg m-3], which might be very large.
+  real    :: drho_min ! A minimal fractional density difference [nondim]?
 
   read( string, *) nk, rho_1, rho_2, rho_3, drho, rho_4, drho_min
   allocate(rho_target(nk+1))

--- a/src/ALE/MOM_remapping.F90
+++ b/src/ALE/MOM_remapping.F90
@@ -1723,7 +1723,7 @@ logical function test_interp(verbose, msg, nsrc, h_src, u_src, ndest, h_dest, u_
   ! Local variables
   real, dimension(ndest+1) :: u_dest ! Interpolated value at destination cell interfaces [A]
   integer :: k
-  real :: error
+  real :: error ! The difference between the evaluated and expected solutions [A]
 
   ! Interpolate from src to dest
   call interpolate_column(nsrc, h_src, u_src, ndest, h_dest, u_dest, .true.)
@@ -1760,7 +1760,7 @@ logical function test_reintegrate(verbose, msg, nsrc, h_src, uh_src, ndest, h_de
   ! Local variables
   real, dimension(ndest) :: uh_dest ! Reintegrated value on destination cells [A H]
   integer :: k
-  real :: error
+  real :: error  ! The difference between the evaluated and expected solutions [A H]
 
   ! Interpolate from src to dest
   call reintegrate_column(nsrc, h_src, uh_src, ndest, h_dest, uh_dest)

--- a/src/ALE/P1M_functions.F90
+++ b/src/ALE/P1M_functions.F90
@@ -36,7 +36,7 @@ subroutine P1M_interpolation( N, h, u, edge_values, ppoly_coef, h_neglect, answe
 
   ! Local variables
   integer   :: k            ! loop index
-  real      :: u0_l, u0_r   ! edge values (left and right)
+  real      :: u0_l, u0_r   ! edge values (left and right) [A]
 
   ! Bound edge values (routine found in 'edge_values.F90')
   call bound_edge_values( N, h, u, edge_values, h_neglect, answer_date=answer_date )
@@ -74,10 +74,10 @@ subroutine P1M_boundary_extrapolation( N, h, u, edge_values, ppoly_coef )
   real, dimension(:,:), intent(inout) :: ppoly_coef !< coefficients of piecewise polynomials, mainly [A]
 
   ! Local variables
-  real          :: u0, u1               ! cell averages
-  real          :: h0, h1               ! corresponding cell widths
-  real          :: slope                ! retained PLM slope
-  real          :: u0_l, u0_r           ! edge values
+  real          :: u0, u1               ! cell averages [A]
+  real          :: h0, h1               ! corresponding cell widths [H]
+  real          :: slope                ! retained PLM slope [A]
+  real          :: u0_l, u0_r           ! edge values [A]
 
   ! -----------------------------------------
   ! Left edge value in the left boundary cell

--- a/src/ALE/PCM_functions.F90
+++ b/src/ALE/PCM_functions.F90
@@ -17,11 +17,11 @@ contains
 !! defining 'grid' and 'ppoly'. No consistency check is performed.
 subroutine PCM_reconstruction( N, u, edge_values, ppoly_coef )
   integer,              intent(in)    :: N !< Number of cells
-  real, dimension(:),   intent(in)    :: u !< cell averages
+  real, dimension(:),   intent(in)    :: u !< cell averages in arbitrary units [A]
   real, dimension(:,:), intent(inout) :: edge_values !< Edge value of polynomial,
-                                           !! with the same units as u.
+                                           !! with the same units as u [A].
   real, dimension(:,:), intent(inout) :: ppoly_coef !< Coefficients of polynomial,
-                                           !! with the same units as u.
+                                           !! with the same units as u [A].
 
   ! Local variables
   integer :: k

--- a/src/ALE/PLM_functions.F90
+++ b/src/ALE/PLM_functions.F90
@@ -16,20 +16,21 @@ real, parameter :: hNeglect_dflt = 1.E-30 !< Default negligible cell thickness
 
 contains
 
-!> Returns a limited PLM slope following White and Adcroft, 2008. [units of u]
+!> Returns a limited PLM slope following White and Adcroft, 2008, in the same arbitrary
+!! units [A] as the input values.
 !! Note that this is not the same as the Colella and Woodward method.
 real elemental pure function PLM_slope_wa(h_l, h_c, h_r, h_neglect, u_l, u_c, u_r)
-  real, intent(in) :: h_l !< Thickness of left cell [units of grid thickness]
-  real, intent(in) :: h_c !< Thickness of center cell [units of grid thickness]
-  real, intent(in) :: h_r !< Thickness of right cell [units of grid thickness]
-  real, intent(in) :: h_neglect !< A negligible thickness [units of grid thickness]
-  real, intent(in) :: u_l !< Value of left cell [units of u]
-  real, intent(in) :: u_c !< Value of center cell [units of u]
-  real, intent(in) :: u_r !< Value of right cell [units of u]
+  real, intent(in) :: h_l !< Thickness of left cell in arbitrary grid thickness units [H]
+  real, intent(in) :: h_c !< Thickness of center cell in arbitrary grid thickness units [H]
+  real, intent(in) :: h_r !< Thickness of right cell in arbitrary grid thickness units [H]
+  real, intent(in) :: h_neglect !< A negligible thickness [H]
+  real, intent(in) :: u_l !< Value of left cell in arbitrary units [A]
+  real, intent(in) :: u_c !< Value of center cell in arbitrary units [A]
+  real, intent(in) :: u_r !< Value of right cell in arbitrary units [A]
   ! Local variables
   real :: sigma_l, sigma_c, sigma_r ! Left, central and right slope estimates as
-                                    ! differences across the cell [units of u]
-  real :: u_min, u_max ! Minimum and maximum value across cell [units of u]
+                                    ! differences across the cell [A]
+  real :: u_min, u_max ! Minimum and maximum value across cell [A]
 
   ! Side differences
   sigma_r = u_r - u_c
@@ -63,20 +64,21 @@ real elemental pure function PLM_slope_wa(h_l, h_c, h_r, h_neglect, u_l, u_c, u_
 
 end function PLM_slope_wa
 
-!> Returns a limited PLM slope following Colella and Woodward 1984.
+!> Returns a limited PLM slope following Colella and Woodward 1984, in the same
+!! arbitrary units as the input values [A].
 real elemental pure function PLM_slope_cw(h_l, h_c, h_r, h_neglect, u_l, u_c, u_r)
-  real, intent(in) :: h_l !< Thickness of left cell [units of grid thickness]
-  real, intent(in) :: h_c !< Thickness of center cell [units of grid thickness]
-  real, intent(in) :: h_r !< Thickness of right cell [units of grid thickness]
-  real, intent(in) :: h_neglect !< A negligible thickness [units of grid thickness]
-  real, intent(in) :: u_l !< Value of left cell [units of u]
-  real, intent(in) :: u_c !< Value of center cell [units of u]
-  real, intent(in) :: u_r !< Value of right cell [units of u]
+  real, intent(in) :: h_l !< Thickness of left cell in arbitrary grid thickness units [H]
+  real, intent(in) :: h_c !< Thickness of center cell in arbitrary grid thickness units [H]
+  real, intent(in) :: h_r !< Thickness of right cell in arbitrary grid thickness units [H]
+  real, intent(in) :: h_neglect !< A negligible thickness [H]
+  real, intent(in) :: u_l !< Value of left cell in arbitrary units [A]
+  real, intent(in) :: u_c !< Value of center cell in arbitrary units [A]
+  real, intent(in) :: u_r !< Value of right cell in arbitrary units [A]
   ! Local variables
   real :: sigma_l, sigma_c, sigma_r ! Left, central and right slope estimates as
-                                    ! differences across the cell [units of u]
-  real :: u_min, u_max ! Minimum and maximum value across cell [units of u]
-  real :: h_cn ! Thickness of center cell [units of grid thickness]
+                                    ! differences across the cell [A]
+  real :: u_min, u_max ! Minimum and maximum value across cell [A]
+  real :: h_cn ! Thickness of center cell [H]
 
   h_cn = h_c + h_neglect
 
@@ -117,18 +119,19 @@ real elemental pure function PLM_slope_cw(h_l, h_c, h_r, h_neglect, u_l, u_c, u_
 
 end function PLM_slope_cw
 
-!> Returns a limited PLM slope following Colella and Woodward 1984.
+!> Returns a limited PLM slope following Colella and Woodward 1984, in the same
+!! arbitrary units as the input values [A].
 real elemental pure function PLM_monotonized_slope(u_l, u_c, u_r, s_l, s_c, s_r)
-  real, intent(in) :: u_l !< Value of left cell [units of u]
-  real, intent(in) :: u_c !< Value of center cell [units of u]
-  real, intent(in) :: u_r !< Value of right cell [units of u]
-  real, intent(in) :: s_l !< PLM slope of left cell [units of u]
-  real, intent(in) :: s_c !< PLM slope of center cell [units of u]
-  real, intent(in) :: s_r !< PLM slope of right cell [units of u]
+  real, intent(in) :: u_l !< Value of left cell in arbitrary units [A]
+  real, intent(in) :: u_c !< Value of center cell in arbitrary units [A]
+  real, intent(in) :: u_r !< Value of right cell in arbitrary units [A]
+  real, intent(in) :: s_l !< PLM slope of left cell [A]
+  real, intent(in) :: s_c !< PLM slope of center cell [A]
+  real, intent(in) :: s_r !< PLM slope of right cell [A]
   ! Local variables
-  real :: e_r, e_l, edge ! Right, left and temporary edge values [units of u]
-  real :: almost_two ! The number 2, almost.
-  real :: slp ! Magnitude of PLM central slope [units of u]
+  real :: e_r, e_l, edge ! Right, left and temporary edge values [A]
+  real :: almost_two ! The number 2, almost [nondim]
+  real :: slp ! Magnitude of PLM central slope [A]
 
   almost_two = 2. * ( 1. - epsilon(s_c) )
 
@@ -155,17 +158,18 @@ real elemental pure function PLM_monotonized_slope(u_l, u_c, u_r, s_l, s_c, s_r)
 
 end function PLM_monotonized_slope
 
-!> Returns a PLM slope using h2 extrapolation from a cell to the left.
+!> Returns a PLM slope using h2 extrapolation from a cell to the left, in the same
+!! arbitrary units as the input values [A].
 !! Use the negative to extrapolate from the cell to the right.
 real elemental pure function PLM_extrapolate_slope(h_l, h_c, h_neglect, u_l, u_c)
-  real, intent(in) :: h_l !< Thickness of left cell [units of grid thickness]
-  real, intent(in) :: h_c !< Thickness of center cell [units of grid thickness]
-  real, intent(in) :: h_neglect !< A negligible thickness [units of grid thickness]
-  real, intent(in) :: u_l !< Value of left cell [units of u]
-  real, intent(in) :: u_c !< Value of center cell [units of u]
+  real, intent(in) :: h_l !< Thickness of left cell in arbitrary grid thickness units [H]
+  real, intent(in) :: h_c !< Thickness of center cell in arbitrary grid thickness units [H]
+  real, intent(in) :: h_neglect !< A negligible thickness [H]
+  real, intent(in) :: u_l !< Value of left cell in arbitrary units [A]
+  real, intent(in) :: u_c !< Value of center cell in arbitrary units [A]
   ! Local variables
-  real :: left_edge ! Left edge value [units of u]
-  real :: hl, hc ! Left and central cell thicknesses [units of grid thickness]
+  real :: left_edge ! Left edge value [A]
+  real :: hl, hc ! Left and central cell thicknesses [H]
 
   ! Avoid division by zero for vanished cells
   hl = h_l + h_neglect
@@ -185,24 +189,26 @@ end function PLM_extrapolate_slope
 !! defining 'grid' and 'ppoly'. No consistency check is performed here.
 subroutine PLM_reconstruction( N, h, u, edge_values, ppoly_coef, h_neglect )
   integer,              intent(in)    :: N !< Number of cells
-  real, dimension(:),   intent(in)    :: h !< cell widths (size N)
-  real, dimension(:),   intent(in)    :: u !< cell averages (size N)
+  real, dimension(:),   intent(in)    :: h !< cell widths (size N) [H]
+  real, dimension(:),   intent(in)    :: u !< cell averages (size N) in arbitrary units [A]
   real, dimension(:,:), intent(inout) :: edge_values !< edge values of piecewise polynomials,
-                                           !! with the same units as u.
+                                           !! with the same units as u [A].
   real, dimension(:,:), intent(inout) :: ppoly_coef !< coefficients of piecewise polynomials, mainly
-                                           !! with the same units as u.
+                                           !! with the same units as u [A].
   real,       optional, intent(in)    :: h_neglect !< A negligibly small width for
                                            !! the purpose of cell reconstructions
-                                           !! in the same units as h
+                                           !! in the same units as h [H]
 
   ! Local variables
-  integer       :: k                    ! loop index
-  real          :: u_l, u_r             ! left and right cell averages
-  real          :: slope                ! retained PLM slope
-  real          :: e_r, edge
-  real          :: almost_one
-  real, dimension(N) :: slp, mslp
-  real    :: hNeglect
+  integer       :: k           ! loop index
+  real          :: u_l, u_r    ! left and right cell averages [A]
+  real          :: slope       ! retained PLM slope for a normalized cell width [A]
+  real          :: e_r         ! The edge value in the neighboring cell [A]
+  real          :: edge        ! The projected edge value in the cell [A]
+  real          :: almost_one  ! A value that is slightly smaller than 1 [nondim]
+  real, dimension(N) :: slp    ! The first guess at the normalized tracer slopes [A]
+  real, dimension(N) :: mslp   ! The monotonized normalized tracer slopes [A]
+  real    :: hNeglect          ! A negligibly small width used in cell reconstructions [H]
 
   hNeglect = hNeglect_dflt ; if (present(h_neglect)) hNeglect = h_neglect
 
@@ -265,18 +271,18 @@ end subroutine PLM_reconstruction
 !! defining 'grid' and 'ppoly'. No consistency check is performed here.
 subroutine PLM_boundary_extrapolation( N, h, u, edge_values, ppoly_coef, h_neglect )
   integer,              intent(in)    :: N !< Number of cells
-  real, dimension(:),   intent(in)    :: h !< cell widths (size N)
-  real, dimension(:),   intent(in)    :: u !< cell averages (size N)
+  real, dimension(:),   intent(in)    :: h !< cell widths (size N) [H]
+  real, dimension(:),   intent(in)    :: u !< cell averages (size N) in arbitrary units [A]
   real, dimension(:,:), intent(inout) :: edge_values !< edge values of piecewise polynomials,
-                                           !! with the same units as u.
+                                           !! with the same units as u [A].
   real, dimension(:,:), intent(inout) :: ppoly_coef !< coefficients of piecewise polynomials, mainly
-                                           !! with the same units as u.
+                                           !! with the same units as u [A].
   real,       optional, intent(in)    :: h_neglect !< A negligibly small width for
                                            !! the purpose of cell reconstructions
-                                           !! in the same units as h
+                                           !! in the same units as h [H]
   ! Local variables
-  real    :: slope                ! retained PLM slope
-  real    :: hNeglect
+  real    :: slope     ! retained PLM slope for a normalized cell width [A]
+  real    :: hNeglect  ! A negligibly small width used in cell reconstructions [H]
 
   hNeglect = hNeglect_dflt ; if (present(h_neglect)) hNeglect = h_neglect
 

--- a/src/ALE/PPM_functions.F90
+++ b/src/ALE/PPM_functions.F90
@@ -28,7 +28,7 @@ contains
 subroutine PPM_reconstruction( N, h, u, edge_values, ppoly_coef, h_neglect, answer_date)
   integer,              intent(in)    :: N !< Number of cells
   real, dimension(N),   intent(in)    :: h !< Cell widths [H]
-  real, dimension(N),   intent(in)    :: u !< Cell averages [A]
+  real, dimension(N),   intent(in)    :: u !< Cell averages in arbitrary coordinates [A]
   real, dimension(N,2), intent(inout) :: edge_values !< Edge values [A]
   real, dimension(N,3), intent(inout) :: ppoly_coef !< Polynomial coefficients, mainly [A]
   real,       optional, intent(in)    :: h_neglect !< A negligibly small width [H]
@@ -36,7 +36,7 @@ subroutine PPM_reconstruction( N, h, u, edge_values, ppoly_coef, h_neglect, answ
 
   ! Local variables
   integer   :: k              ! Loop index
-  real      :: edge_l, edge_r ! Edge values (left and right)
+  real      :: edge_l, edge_r ! Edge values (left and right) [A]
 
   ! PPM limiter
   call PPM_limiter_standard( N, h, u, edge_values, h_neglect, answer_date=answer_date )
@@ -69,9 +69,9 @@ subroutine PPM_limiter_standard( N, h, u, edge_values, h_neglect, answer_date )
 
   ! Local variables
   integer   :: k              ! Loop index
-  real      :: u_l, u_c, u_r  ! Cell averages (left, center and right)
-  real      :: edge_l, edge_r ! Edge values (left and right)
-  real      :: expr1, expr2
+  real      :: u_l, u_c, u_r  ! Cell averages (left, center and right) [A]
+  real      :: edge_l, edge_r ! Edge values (left and right) [A]
+  real      :: expr1, expr2   ! Temporary expressions [A2]
 
   ! Bound edge values
   call bound_edge_values( N, h, u, edge_values, h_neglect, answer_date=answer_date )
@@ -135,8 +135,8 @@ subroutine PPM_monotonicity( N, u, edge_values )
   real, dimension(:,:), intent(inout) :: edge_values !< Potentially modified edge values [A]
 
   ! Local variables
-  integer   :: k     ! Loop index
-  real      :: a6,da ! scalar temporaries
+  integer   :: k      ! Loop index
+  real      :: a6, da ! Normalized scalar curvature and slope [A]
 
   ! Loop on interior cells to impose monotonicity
   ! Eq. 1.10 of (Colella & Woodward, JCP 84)
@@ -195,14 +195,16 @@ subroutine PPM_boundary_extrapolation( N, h, u, edge_values, ppoly_coef, h_negle
 
   ! Local variables
   integer :: i0, i1
-  real    :: u0, u1
-  real    :: h0, h1
-  real    :: a, b, c
-  real    :: u0_l, u0_r
-  real    :: u1_l, u1_r
-  real    :: slope
-  real    :: exp1, exp2
-  real    :: hNeglect
+  real    :: u0, u1     ! Average concentrations in the two neighboring cells [A]
+  real    :: h0, h1     ! Thicknesses of the two neighboring cells [H]
+  real    :: a, b, c    ! An edge value, normalized slope and normalized curvature
+                        ! of a reconstructed distribution [A]
+  real    :: u0_l, u0_r ! Edge values of a neighboring cell [A]
+  real    :: u1_l, u1_r ! Neighboring cell slopes renormalized by the thickness of
+                        ! the cell being worked on [A]
+  real    :: slope      ! The normalized slope [A]
+  real    :: exp1, exp2 ! Temporary expressions [A2]
+  real    :: hNeglect   ! A negligibly small width used in cell reconstructions [H]
 
   hNeglect = hNeglect_dflt ; if (present(h_neglect)) hNeglect = h_neglect
 

--- a/src/ALE/PQM_functions.F90
+++ b/src/ALE/PQM_functions.F90
@@ -30,10 +30,10 @@ subroutine PQM_reconstruction( N, h, u, edge_values, edge_slopes, ppoly_coef, h_
 
   ! Local variables
   integer   :: k                ! loop index
-  real      :: h_c              ! cell width
+  real      :: h_c              ! cell width [H]
   real      :: u0_l, u0_r       ! edge values (left and right) [A]
   real      :: u1_l, u1_r       ! edge slopes (left and right) [A H-1]
-  real      :: a, b, c, d, e    ! parabola coefficients
+  real      :: a, b, c, d, e    ! quartic fit coefficients [A]
 
   ! PQM limiter
   call PQM_limiter( N, h, u, edge_values, edge_slopes, h_neglect, answer_date=answer_date )
@@ -90,14 +90,15 @@ subroutine PQM_limiter( N, h, u, edge_values, edge_slopes, h_neglect, answer_dat
   real    :: u1_l, u1_r     ! edge slopes [A H-1]
   real    :: u_l, u_c, u_r  ! left, center and right cell averages [A]
   real    :: h_l, h_c, h_r  ! left, center and right cell widths [H]
-  real    :: sigma_l, sigma_c, sigma_r ! left, center and right van Leer slopes
-  real    :: slope          ! retained PLM slope
-  real    :: a, b, c, d, e
-  real    :: alpha1, alpha2, alpha3
-  real    :: rho, sqrt_rho
-  real    :: gradient1, gradient2
-  real    :: x1, x2
-  real    :: hNeglect
+  real    :: sigma_l, sigma_c, sigma_r ! left, center and right van Leer slopes [A H-1]
+  real    :: slope          ! retained PLM slope [A H-1]
+  real    :: a, b, c, d, e  ! quartic fit coefficients [A]
+  real    :: alpha1, alpha2, alpha3 ! Normalized second derivative coefficients [A]
+  real    :: rho            ! A temporary expression [A2]
+  real    :: sqrt_rho       ! The square root of rho [A]
+  real    :: gradient1, gradient2 ! Normalized gradients [A]
+  real    :: x1, x2         ! Fractional inflection point positions in a cell [nondim]
+  real    :: hNeglect       ! A negligibly small width for the purpose of cell reconstructions [H]
 
   hNeglect = hNeglect_dflt ; if (present(h_neglect)) hNeglect = h_neglect
 
@@ -359,13 +360,13 @@ subroutine PQM_boundary_extrapolation( N, h, u, edge_values, ppoly_coef )
   real, dimension(:,:), intent(inout) :: ppoly_coef !< Coefficients of polynomial, mainly [A]
   ! Local variables
   integer       :: i0, i1
-  real          :: u0, u1
-  real          :: h0, h1
-  real          :: a, b, c, d, e
-  real          :: u0_l, u0_r
-  real          :: u1_l, u1_r
-  real          :: slope
-  real          :: exp1, exp2
+  real          :: u0, u1         ! Successive cell averages [A]
+  real          :: h0, h1         ! Successive cell thicknesses [H]
+  real          :: a, b, c, d, e  ! quartic fit coefficients [A]
+  real          :: u0_l, u0_r     ! Edge values [A]
+  real          :: u1_l, u1_r     ! Edge slopes [A H-1]
+  real          :: slope          ! The integrated slope across the cell [A]
+  real          :: exp1, exp2     ! Two temporary expressions [A2]
 
   ! ----- Left boundary -----
   i0 = 1
@@ -511,19 +512,21 @@ subroutine PQM_boundary_extrapolation_v1( N, h, u, edge_values, edge_slopes, ppo
   integer :: i0, i1
   integer :: inflexion_l
   integer :: inflexion_r
-  real    :: u0, u1, um
-  real    :: h0, h1
-  real    :: a, b, c, d, e
-  real    :: ar, br, beta
-  real    :: u0_l, u0_r
-  real    :: u1_l, u1_r
-  real    :: u_plm
-  real    :: slope
-  real    :: alpha1, alpha2, alpha3
-  real    :: rho, sqrt_rho
-  real    :: gradient1, gradient2
-  real    :: x1, x2
-  real    :: hNeglect
+  real    :: u0, u1, um     ! Successive cell averages [A]
+  real    :: h0, h1         ! Successive cell thicknesses [H]
+  real    :: a, b, c, d, e  ! quartic fit coefficients [A]
+  real    :: ar, br         ! Temporary variables in [A]
+  real    :: beta           ! A rational function coefficient [nondim]
+  real    :: u0_l, u0_r     ! Edge values [A]
+  real    :: u1_l, u1_r     ! Edge slopes [A H-1]
+  real    :: u_plm          ! The integrated piecewise linear method slope [A]
+  real    :: slope          ! The integrated slope across the cell [A]
+  real    :: alpha1, alpha2, alpha3 ! Normalized second derivative coefficients [A]
+  real    :: rho            ! A temporary expression [A2]
+  real    :: sqrt_rho       ! The square root of rho [A]
+  real    :: gradient1, gradient2 ! Normalized gradients [A]
+  real    :: x1, x2         ! Fractional inflection point positions in a cell [nondim]
+  real    :: hNeglect       ! A negligibly small width for the purpose of cell reconstructions [H]
 
   hNeglect = hNeglect_dflt ; if (present(h_neglect)) hNeglect = h_neglect
 

--- a/src/ALE/coord_adapt.F90
+++ b/src/ALE/coord_adapt.F90
@@ -93,10 +93,10 @@ subroutine set_adapt_params(CS, adaptTimeRatio, adaptAlpha, adaptZoom, adaptZoom
   type(adapt_CS),    pointer    :: CS  !< The control structure for this module
   real,    optional, intent(in) :: adaptTimeRatio !< Ratio of optimisation and diffusion timescales [nondim]
   real,    optional, intent(in) :: adaptAlpha     !< Nondimensional coefficient determining
-                                                  !! how much optimisation to apply
+                                                  !! how much optimisation to apply [nondim]
   real,    optional, intent(in) :: adaptZoom      !< Near-surface zooming depth [H ~> m or kg m-2]
   real,    optional, intent(in) :: adaptZoomCoeff !< Near-surface zooming coefficient [nondim]
-  real,    optional, intent(in) :: adaptBuoyCoeff !< Stratification-dependent diffusion coefficient
+  real,    optional, intent(in) :: adaptBuoyCoeff !< Stratification-dependent diffusion coefficient [nondim]
   real,    optional, intent(in) :: adaptDrho0  !< Reference density difference for
                                                !! stratification-dependent diffusion [R ~> kg m-3]
   logical, optional, intent(in) :: adaptDoMin  !< If true, form a HYCOM1-like mixed layer by

--- a/src/ALE/coord_adapt.F90
+++ b/src/ALE/coord_adapt.F90
@@ -22,19 +22,19 @@ type, public :: adapt_CS ; private
   !> Nominal near-surface resolution [H ~> m or kg m-2]
   real, allocatable, dimension(:) :: coordinateResolution
 
-  !> Ratio of optimisation and diffusion timescales
+  !> Ratio of optimisation and diffusion timescales [nondim]
   real :: adaptTimeRatio
 
-  !> Nondimensional coefficient determining how much optimisation to apply
+  !> Nondimensional coefficient determining how much optimisation to apply [nondim]
   real :: adaptAlpha
 
   !> Near-surface zooming depth [H ~> m or kg m-2]
   real :: adaptZoom
 
-  !> Near-surface zooming coefficient
+  !> Near-surface zooming coefficient [nondim]
   real :: adaptZoomCoeff
 
-  !> Stratification-dependent diffusion coefficient
+  !> Stratification-dependent diffusion coefficient [nondim]
   real :: adaptBuoyCoeff
 
   !> Reference density difference for stratification-dependent diffusion [R ~> kg m-3]
@@ -55,8 +55,10 @@ subroutine init_coord_adapt(CS, nk, coordinateResolution, m_to_H, kg_m3_to_R)
   integer,            intent(in) :: nk !< Number of layers in the grid
   real, dimension(:), intent(in) :: coordinateResolution !< Nominal near-surface resolution [m] or
                                        !! other units specified with m_to_H
-  real,               intent(in) :: m_to_H !< A conversion factor from m to the units of thicknesses
-  real,               intent(in) :: kg_m3_to_R !< A conversion factor from kg m-3 to the units of density
+  real,               intent(in) :: m_to_H !< A conversion factor from m to the units of thicknesses,
+                                       !! perhaps in units of [H m-1 ~> 1 or kg m-3]
+  real,               intent(in) :: kg_m3_to_R !< A conversion factor from kg m-3 to the units of density,
+                                       !! perhaps in units of [R m3 kg-1 ~> 1]
 
   if (associated(CS)) call MOM_error(FATAL, "init_coord_adapt: CS already associated")
   allocate(CS)
@@ -89,11 +91,11 @@ end subroutine end_coord_adapt
 subroutine set_adapt_params(CS, adaptTimeRatio, adaptAlpha, adaptZoom, adaptZoomCoeff, &
                             adaptBuoyCoeff, adaptDrho0, adaptDoMin)
   type(adapt_CS),    pointer    :: CS  !< The control structure for this module
-  real,    optional, intent(in) :: adaptTimeRatio !< Ratio of optimisation and diffusion timescales
+  real,    optional, intent(in) :: adaptTimeRatio !< Ratio of optimisation and diffusion timescales [nondim]
   real,    optional, intent(in) :: adaptAlpha     !< Nondimensional coefficient determining
                                                   !! how much optimisation to apply
   real,    optional, intent(in) :: adaptZoom      !< Near-surface zooming depth [H ~> m or kg m-2]
-  real,    optional, intent(in) :: adaptZoomCoeff !< Near-surface zooming coefficient
+  real,    optional, intent(in) :: adaptZoomCoeff !< Near-surface zooming coefficient [nondim]
   real,    optional, intent(in) :: adaptBuoyCoeff !< Stratification-dependent diffusion coefficient
   real,    optional, intent(in) :: adaptDrho0  !< Reference density difference for
                                                !! stratification-dependent diffusion [R ~> kg m-3]
@@ -129,17 +131,25 @@ subroutine build_adapt_column(CS, G, GV, US, tv, i, j, zInt, tInt, sInt, h, nom_
                                                                      !! relative to mean sea level or another locally
                                                                      !! valid reference height, converted to thickness
                                                                      !! units [H ~> m or kg m-2]
-  real, dimension(SZK_(GV)+1),                 intent(inout) :: zNext !< updated interface positions
+  real, dimension(SZK_(GV)+1),                 intent(inout) :: zNext !< updated interface positions [H ~> m or kg m-2]
 
   ! Local variables
   integer :: k, nz
-  real :: h_up, b1, b_denom_1, d1, depth, nominal_z, stretching
+  real :: h_up        ! The upwind source grid thickness based on the direction of the
+                      ! adjustive fluxes [H ~> m or kg m-2]
+  real :: b1          ! The inverse of the tridiagonal denominator [nondim]
+  real :: b_denom_1   ! The leading term in the tridiagonal denominator [nondim]
+  real :: d1          ! A term in the tridiagonal expressions [nondim]
+  real :: depth       ! Depth in thickness units [H ~> m or kg m-2]
+  real :: nominal_z   ! A nominal interface position in thickness units [H ~> m or kg m-2]
+  real :: stretching  ! A stretching factor for the water column [nondim]
   real :: drdz  ! The vertical density gradient [R H-1 ~> kg m-4 or m-1]
   real, dimension(SZK_(GV)+1) :: alpha ! drho/dT [R C-1 ~> kg m-3 degC-1]
   real, dimension(SZK_(GV)+1) :: beta  ! drho/dS [R S-1 ~> kg m-3 ppt-1]
   real, dimension(SZK_(GV)+1) :: del2sigma ! Laplacian of in situ density times grid spacing [R ~> kg m-3]
   real, dimension(SZK_(GV)+1) :: dh_d2s ! Thickness change in response to del2sigma [H ~> m or kg m-2]
-  real, dimension(SZK_(GV)) :: kGrid, c1 ! grid diffusivity on layers, and tridiagonal work array
+  real, dimension(SZK_(GV)) :: kGrid ! grid diffusivity on layers [nondim]
+  real, dimension(SZK_(GV)) :: c1 ! A tridiagonal work array [nondim]
 
   nz = CS%nk
 

--- a/src/ALE/coord_sigma.F90
+++ b/src/ALE/coord_sigma.F90
@@ -13,10 +13,10 @@ type, public :: sigma_CS ; private
   !> Number of levels
   integer :: nk
 
-  !> Minimum thickness allowed for layers
+  !> Minimum thickness allowed for layers [H ~> m or kg m-2]
   real :: min_thickness
 
-  !> Target coordinate resolution, nondimensional
+  !> Target coordinate resolution [nondim]
   real, allocatable, dimension(:) :: coordinateResolution
 end type sigma_CS
 

--- a/src/ALE/coord_zlike.F90
+++ b/src/ALE/coord_zlike.F90
@@ -67,13 +67,15 @@ subroutine build_zstar_column(CS, depth, total_thickness, zInterface, &
                                                    !! output units), units may be [Z ~> m] or [H ~> m or kg m-2]
   real,                     intent(in)    :: total_thickness !< Column thickness (positive definite in the same
                                                    !! units as depth) [Z ~> m] or [H ~> m or kg m-2]
-  real, dimension(CS%nk+1), intent(inout) :: zInterface !< Absolute positions of interfaces
+  real, dimension(CS%nk+1), intent(inout) :: zInterface !< Absolute positions of interfaces (in the same
+                                                   !! units as depth) [Z ~> m] or [H ~> m or kg m-2]
   real, optional,           intent(in)    :: z_rigid_top !< The height of a rigid top (positive upward in the same
                                                    !! units as depth) [Z ~> m] or [H ~> m or kg m-2]
-  real, optional,           intent(in)    :: eta_orig !< The actual original height of the top in the same
+  real, optional,           intent(in)    :: eta_orig !< The actual original height of the top (in the same
                                                    !! units as depth) [Z ~> m] or [H ~> m or kg m-2]
   real, optional,           intent(in)    :: zScale !< Scaling factor from the target coordinate resolution
-                                                    !! in Z to desired units for zInterface, perhaps Z_to_H
+                                                    !! in Z to desired units for zInterface, perhaps Z_to_H,
+                                                    !! often [nondim] or [H Z-1 ~> 1 or kg m-3]
   ! Local variables
   real :: eta   ! Free surface height [Z ~> m] or [H ~> m or kg m-2]
   real :: stretching ! A stretching factor for the coordinate [nondim]

--- a/src/ALE/polynomial_functions.F90
+++ b/src/ALE/polynomial_functions.F90
@@ -9,7 +9,7 @@ public :: evaluation_polynomial, integration_polynomial, first_derivative_polyno
 
 contains
 
-!> Pointwise evaluation of a polynomial at x
+!> Pointwise evaluation of a polynomial in arbitrary units [A] at x
 !!
 !! The polynomial is defined by the coefficients contained in the
 !! array of the same name, as follows: C(1) + C(2)x + C(3)x^2 + C(4)x^3 + ...
@@ -17,12 +17,14 @@ contains
 !! The number of coefficients is given by ncoef and x
 !! is the coordinate where the polynomial is to be evaluated.
 real function evaluation_polynomial( coeff, ncoef, x )
-  real, dimension(:), intent(in) :: coeff !< The coefficients of the polynomial
+  real, dimension(:), intent(in) :: coeff !< The coefficients of the polynomial, in units that
+                                          !! vary with the index k as [A H^(k-1)]
   integer,            intent(in) :: ncoef !< The number of polynomial coefficients
   real,               intent(in) :: x     !< The position at which to evaluate the polynomial
+                                          !! in arbitrary thickness units [H]
   ! Local variables
   integer :: k
-  real    :: f    ! value of polynomial at x
+  real    :: f    ! value of polynomial at x in arbitrary units [A]
 
   f = 0.0
   do k = 1,ncoef
@@ -33,7 +35,8 @@ real function evaluation_polynomial( coeff, ncoef, x )
 
 end function evaluation_polynomial
 
-!> Calculates the first derivative of a polynomial evaluated at a point x
+!> Calculates the first derivative of a polynomial evaluated in arbitrary units of [A H-1]
+!! at a point x
 !!
 !! The polynomial is defined by the coefficients contained in the
 !! array of the same name, as follows: C(1) + C(2)x + C(3)x^2 + C(4)x^3 + ...
@@ -41,12 +44,14 @@ end function evaluation_polynomial
 !! The number of coefficients is given by ncoef and x
 !! is the coordinate where the polynomial's derivative is to be evaluated.
 real function first_derivative_polynomial( coeff, ncoef, x )
-  real, dimension(:), intent(in) :: coeff !< The coefficients of the polynomial
+  real, dimension(:), intent(in) :: coeff !< The coefficients of the polynomial, in units that
+                                          !! vary with the index k as [A H^(k-1)]
   integer,            intent(in) :: ncoef !< The number of polynomial coefficients
   real, intent(in)               :: x     !< The position at which to evaluate the derivative
+                                          !! in arbitrary thickness units [H]
   ! Local variables
   integer                               :: k
-  real                                  :: f    ! value of polynomial at x
+  real                                  :: f    ! value of the derivative at x in [A H-1]
 
   f = 0.0
   do k = 2,ncoef
@@ -57,17 +62,20 @@ real function first_derivative_polynomial( coeff, ncoef, x )
 
 end function first_derivative_polynomial
 
-!> Exact integration of polynomial of degree npoly
+!> Exact integration of polynomial of degree npoly in arbitrary units of [A H]
 !!
 !! The array of coefficients (Coeff) must be of size npoly+1.
 real function integration_polynomial( xi0, xi1, Coeff, npoly )
-  real,               intent(in) :: xi0   !< The lower bound of the integral
-  real,               intent(in) :: xi1   !< The lower bound of the integral
-  real, dimension(:), intent(in) :: Coeff !< The coefficients of the polynomial
+  real,               intent(in) :: xi0   !< The lower bound of the integral in arbitrary
+                                          !! thickness units [H]
+  real,               intent(in) :: xi1   !< The upper bound of the integral in arbitrary
+                                          !! thickness units [H]
+  real, dimension(:), intent(in) :: Coeff !< The coefficients of the polynomial, in units that
+                                          !! vary with the index k as [A H^(k-1)]
   integer,            intent(in) :: npoly !< The degree of the polynomial
   ! Local variables
-  integer                           :: k
-  real                              :: integral
+  integer :: k
+  real    :: integral  ! The integral of the polynomial over the specified range in [A H]
 
   integral = 0.0
 

--- a/src/ALE/regrid_edge_values.F90
+++ b/src/ALE/regrid_edge_values.F90
@@ -27,7 +27,7 @@ real, parameter :: hNeglect_edge_dflt = 1.e-10 !< The default value for cut-off 
                                           !! thickness for sum(h) in edge value inversions
 real, parameter :: hNeglect_dflt = 1.e-30 !< The default value for cut-off minimum
                                           !! thickness for sum(h) in other calculations
-real, parameter :: hMinFrac      = 1.e-5  !< A minimum fraction for min(h)/sum(h)
+real, parameter :: hMinFrac      = 1.e-5  !< A minimum fraction for min(h)/sum(h) [nondim]
 
 contains
 
@@ -119,7 +119,7 @@ subroutine average_discontinuous_edge_values( N, edge_val )
                                            !! second index is for the two edges of each cell.
   ! Local variables
   integer       :: k            ! loop index
-  real          :: u0_avg       ! avg value at given edge
+  real          :: u0_avg       ! avg value at given edge [A]
 
   ! Loop on interior edges
   do k = 1,N-1
@@ -231,19 +231,24 @@ subroutine edge_values_explicit_h4( N, h, u, edge_val, h_neglect, answer_date )
   ! Local variables
   real :: h0, h1, h2, h3        ! temporary thicknesses [H]
   real :: h_min                 ! A minimal cell width [H]
-  real :: f1, f2, f3            ! auxiliary variables with various units
+  real :: f1                    ! An auxiliary variable [H]
+  real :: f2                    ! An auxiliary variable [A H]
+  real :: f3                    ! An auxiliary variable [H-1]
   real :: et1, et2, et3         ! terms the expression for edge values [A H]
   real :: I_h12                 ! The inverse of the sum of the two central thicknesses [H-1]
   real :: I_h012, I_h123        ! Inverses of sums of three successive thicknesses [H-1]
   real :: I_den_et2, I_den_et3  ! Inverses of denominators in edge value terms [H-2]
-  real, dimension(5)    :: x          ! Coordinate system with 0 at edges [H]
-  real, dimension(4)    :: dz               ! A temporary array of limited layer thicknesses [H]
-  real, dimension(4)    :: u_tmp            ! A temporary array of cell average properties [A]
-  real, parameter       :: C1_12 = 1.0 / 12.0
-  real                  :: dx               ! Difference of successive values of x [H]
-  real, dimension(4,4)  :: A                ! values near the boundaries
-  real, dimension(4)    :: B, C
-  real      :: hNeglect ! A negligible thickness in the same units as h.
+  real, dimension(5)    :: x     ! Coordinate system with 0 at edges [H]
+  real, dimension(4)    :: dz    ! A temporary array of limited layer thicknesses [H]
+  real, dimension(4)    :: u_tmp ! A temporary array of cell average properties [A]
+  real, parameter       :: C1_12 = 1.0 / 12.0 ! A rational constant [nondim]
+  real                  :: dx    ! Difference of successive values of x [H]
+  real, dimension(4,4)  :: A     ! Differences in successive positions raised to various powers,
+                                 ! in units that vary with the second (j) index as [H^j]
+  real, dimension(4)    :: B     ! The right hand side of the system to solve for C [A H]
+  real, dimension(4)    :: C     ! The coefficients of a fit polynomial in units that vary
+                                 ! with the index (j) as [A H^(j-1)]
+  real      :: hNeglect ! A negligible thickness in the same units as h [H].
   integer               :: i, j
   logical   :: use_2018_answers  ! If true use older, less accurate expressions.
 
@@ -383,11 +388,11 @@ subroutine edge_values_explicit_h4cw( N, h, u, edge_val, h_neglect )
 
   ! Local variables
   real :: dp(N) ! Input grid layer thicknesses, but with a minimum thickness [H ~> m or kg m-2]
-  real :: hNeglect  ! A negligible thickness in the same units as h
+  real :: hNeglect  ! A negligible thickness in the same units as h [H]
   real :: da        ! Difference between the unlimited scalar edge value estimates [A]
   real :: a6        ! Scalar field differences that are proportional to the curvature [A]
   real :: slk, srk  ! Differences between adjacent cell averages of scalars [A]
-  real :: sck       ! Scalar differences across a cell.
+  real :: sck       ! Scalar differences across a cell [A]
   real :: au(N)     ! Scalar field difference across each cell [A]
   real :: al(N), ar(N) ! Scalar field at the left and right edges of a cell [A]
   real :: h112(N+1), h122(N+1) ! Combinations of thicknesses [H ~> m or kg m-2]
@@ -496,22 +501,26 @@ subroutine edge_values_implicit_h4( N, h, u, edge_val, h_neglect, answer_date )
   integer               :: i, j                 ! loop indexes
   real                  :: h0, h1               ! cell widths [H]
   real                  :: h_min                ! A minimal cell width [H]
-  real                  :: h0_2, h1_2, h0h1
-  real                  :: h0ph1_2, h0ph1_4
+  real                  :: h0_2, h1_2, h0h1     ! Squares or products of thicknesses [H2]
+  real                  :: h0ph1_2              ! The square of a sum of thicknesses [H2]
+  real                  :: h0ph1_4              ! The fourth power of a sum of thicknesses [H4]
   real                  :: alpha, beta          ! stencil coefficients [nondim]
   real                  :: I_h2, abmix          ! stencil coefficients [nondim]
-  real                  :: a, b
+  real                  :: a, b                 ! Combinations of stencil coefficients [nondim]
   real, dimension(5)    :: x                    ! Coordinate system with 0 at edges [H]
-  real, parameter       :: C1_12 = 1.0 / 12.0
-  real, parameter       :: C1_3 = 1.0 / 3.0
+  real, parameter       :: C1_12 = 1.0 / 12.0   ! A rational constant [nondim]
+  real, parameter       :: C1_3 = 1.0 / 3.0     ! A rational constant [nondim]
   real, dimension(4)    :: dz                   ! A temporary array of limited layer thicknesses [H]
   real, dimension(4)    :: u_tmp                ! A temporary array of cell average properties [A]
   real                  :: dx                   ! Differences and averages of successive values of x [H]
-  real, dimension(4,4)  :: Asys                 ! boundary conditions
-  real, dimension(4)    :: Bsys, Csys
+  real, dimension(4,4)  :: Asys         ! Differences in successive positions raised to various powers,
+                                        ! in units that vary with the second (j) index as [H^j]
+  real, dimension(4)    :: Bsys         ! The right hand side of the system to solve for C [A H]
+  real, dimension(4)    :: Csys         ! The coefficients of a fit polynomial in units that vary
+                                        ! with the index (j) as [A H^(j-1)]
   real, dimension(N+1)  :: tri_l, &     ! tridiagonal system (lower diagonal) [nondim]
                            tri_d, &     ! tridiagonal system (middle diagonal) [nondim]
-                           tri_c, &     ! tridiagonal system central value, with tri_d = tri_c+tri_l+tri_u
+                           tri_c, &     ! tridiagonal system central value [nondim], with tri_d = tri_c+tri_l+tri_u
                            tri_u, &     ! tridiagonal system (upper diagonal) [nondim]
                            tri_b, &     ! tridiagonal system (right hand side) [A]
                            tri_x        ! tridiagonal system (solution vector) [A]
@@ -667,7 +676,7 @@ subroutine end_value_h4(dz, u, Csys)
   real :: I_denom         ! The inverse of the denominator some expressions [H-3]
   real :: I_denB3         ! The inverse of the product of three sums of thicknesses [H-3]
   real :: min_frac = 1.0e-6  ! The square of min_frac should be much larger than roundoff [nondim]
-  real, parameter :: C1_3 = 1.0 / 3.0
+  real, parameter :: C1_3 = 1.0 / 3.0   ! A rational parameter [nondim]
 
   ! These are only used for code verification
   ! real, dimension(4) :: Atest  ! The  coefficients of an expression that is being tested.
@@ -810,17 +819,21 @@ subroutine edge_slopes_implicit_h3( N, h, u, edge_slopes, h_neglect, answer_date
   real                  :: I_h                  ! Inverses of thicknesses [H-1]
   real                  :: alpha, beta          ! stencil coefficients [nondim]
   real                  :: a, b                 ! weights of cells [H-1]
-  real, parameter       :: C1_12 = 1.0 / 12.0
+  real, parameter       :: C1_12 = 1.0 / 12.0   ! A rational parameter [nondim]
   real, dimension(4)    :: dz                   ! A temporary array of limited layer thicknesses [H]
   real, dimension(4)    :: u_tmp                ! A temporary array of cell average properties [A]
-  real, dimension(5)    :: x          ! Coordinate system with 0 at edges [H]
-  real                  :: dx         ! Differences and averages of successive values of x [H]
-  real, dimension(4,4)  :: Asys       ! matrix used to find boundary conditions
-  real, dimension(4)    :: Bsys, Csys
-  real, dimension(3)    :: Dsys
+  real, dimension(5)    :: x            ! Coordinate system with 0 at edges [H]
+  real                  :: dx           ! Differences and averages of successive values of x [H]
+  real, dimension(4,4)  :: Asys         ! Differences in successive positions raised to various powers,
+                                        ! in units that vary with the second (j) index as [H^j]
+  real, dimension(4)    :: Bsys         ! The right hand side of the system to solve for C [A H]
+  real, dimension(4)    :: Csys         ! The coefficients of a fit polynomial in units that vary with the
+                                        ! index (j) as [A H^(j-1)]
+  real, dimension(3)    :: Dsys         ! The coefficients of the first derivative of the fit polynomial
+                                        ! in units that vary with the index (j) as [A H^(j-2)]
   real, dimension(N+1)  :: tri_l, &     ! tridiagonal system (lower diagonal) [nondim]
                            tri_d, &     ! tridiagonal system (middle diagonal) [nondim]
-                           tri_c, &     ! tridiagonal system central value, with tri_d = tri_c+tri_l+tri_u
+                           tri_c, &     ! tridiagonal system central value [nondim], with tri_d = tri_c+tri_l+tri_u
                            tri_u, &     ! tridiagonal system (upper diagonal) [nondim]
                            tri_b, &     ! tridiagonal system (right hand side) [A H-1]
                            tri_x        ! tridiagonal system (solution vector) [A H-1]
@@ -1009,23 +1022,27 @@ subroutine edge_slopes_implicit_h5( N, h, u, edge_slopes, h_neglect, answer_date
   real :: h01, h01_2           ! Summed thicknesses to various powers [H^n ~> m^n or kg^n m-2n]
   real :: h23, h23_2           ! Summed thicknesses to various powers [H^n ~> m^n or kg^n m-2n]
   real :: hNeglect             ! A negligible thickness [H].
-  real                  :: h1_2, h2_2           ! the coefficients of the
-  real                  :: h1_3, h2_3           ! tridiagonal system
-  real                  :: h1_4, h2_4           ! ...
-  real                  :: h1_5, h2_5           ! ...
-  real                  :: alpha, beta          ! stencil coefficients
-  real, dimension(7)    :: x                    ! Coordinate system with 0 at edges [same units as h]
-  real, parameter       :: C1_12 = 1.0 / 12.0
-  real, parameter       :: C5_6 = 5.0 / 6.0
-  real                  :: dx, xavg             ! Differences and averages of successive values of x [same units as h]
-  real, dimension(6,6)  :: Asys                 ! matrix used to find  boundary conditions
-  real, dimension(6)    :: Bsys, Csys           ! ...
-  real, dimension(N+1)  :: tri_l, &             ! trid. system (lower diagonal)
-                           tri_d, &             ! trid. system (middle diagonal)
-                           tri_u, &             ! trid. system (upper diagonal)
-                           tri_b, &             ! trid. system (unknowns vector)
-                           tri_x                ! trid. system (rhs)
-  real :: h_Min_Frac = 1.0e-4
+  real :: h1_2, h2_2           ! Squares of thicknesses [H2]
+  real :: h1_3, h2_3           ! Cubes of thicknesses [H3]
+  real :: h1_4, h2_4           ! Fourth powers of thicknesses [H4]
+  real :: h1_5, h2_5           ! Fifth powers of thicknesses [H5]
+  real :: alpha, beta          ! stencil coefficients [nondim]
+  real, dimension(7)    :: x            ! Coordinate system with 0 at edges in the same units as h [H]
+  real, parameter       :: C1_12 = 1.0 / 12.0   ! A rational parameter [nondim]
+  real, parameter       :: C5_6 = 5.0 / 6.0     ! A rational parameter [nondim]
+  real                  :: dx, xavg     ! Differences and averages of successive values of x [same units as h]
+  real, dimension(6,6)  :: Asys         ! The matrix that is being inverted for a solution,
+                                        ! in units that might vary with the second (j) index as [H^j]
+  real, dimension(6)    :: Bsys         ! The right hand side of the system to solve for C in various
+                                        ! units that sometimes vary with the intex (j) as [H^(j-1)] or [H^j]
+                                        ! or might be [A]
+  real, dimension(6)    :: Csys         ! The solution to a matrix equation usually [nondim] in this routine.
+  real, dimension(N+1)  :: tri_l, &     ! trid. system (lower diagonal) [nondim]
+                           tri_d, &     ! trid. system (middle diagonal) [nondim]
+                           tri_u, &     ! trid. system (upper diagonal) [nondim]
+                           tri_b, &     ! trid. system (rhs) [A H-1]
+                           tri_x        ! trid. system (unknowns vector) [A H-1]
+  real :: h_Min_Frac = 1.0e-4  ! A minimum fractional thickness [nondim]
   integer :: i, k   ! loop indexes
 
   hNeglect = hNeglect_dflt ; if (present(h_neglect)) hNeglect = h_neglect
@@ -1249,18 +1266,24 @@ subroutine edge_values_implicit_h6( N, h, u, edge_val, h_neglect, answer_date )
   real :: hNeglect             ! A negligible thickness [H].
   real :: h1_2, h2_2, h1_3, h2_3 ! Cell widths raised to the 2nd and 3rd powers [H2] or [H3]
   real :: h1_4, h2_4, h1_5, h2_5 ! Cell widths raised to the 4th and 5th powers [H4] or [H5]
-  real                  :: alpha, beta          ! stencil coefficients
-  real, dimension(7)    :: x          ! Coordinate system with 0 at edges [same units as h]
-  real, parameter       :: C1_12 = 1.0 / 12.0
-  real, parameter       :: C5_6 = 5.0 / 6.0
-  real                  :: dx, xavg   ! Differences and averages of successive values of x [same units as h]
-  real, dimension(6,6)  :: Asys                 ! boundary conditions
-  real, dimension(6)    :: Bsys, Csys           ! ...
-  real, dimension(N+1)  :: tri_l, &             ! trid. system (lower diagonal)
-                           tri_d, &             ! trid. system (middle diagonal)
-                           tri_u, &             ! trid. system (upper diagonal)
-                           tri_b, &             ! trid. system (unknowns vector)
-                           tri_x                ! trid. system (rhs)
+  real :: alpha, beta          ! stencil coefficients [nondim]
+  real, dimension(7)    :: x          ! Coordinate system with 0 at edges in the same units as h [H]
+  real, parameter       :: C1_12 = 1.0 / 12.0   ! A rational parameter [nondim]
+  real, parameter       :: C5_6 = 5.0 / 6.0     ! A rational parameter [nondim]
+  real                  :: dx, xavg   ! Differences and averages of successive values of x [H]
+  real, dimension(6,6)  :: Asys         ! The matrix that is being inverted for a solution,
+                                        ! in units that might vary with the second (j) index as [H^j]
+  real, dimension(6)    :: Bsys         ! The right hand side of the system to solve for C in various
+                                        ! units that sometimes vary with the intex (j) as [H^(j-1)] or [H^j]
+                                        ! or might be [A]
+  real, dimension(6)    :: Csys         ! The solution to a matrix equation, which might be [nondim] or the
+                                        ! coefficients of a fit polynomial in units that vary with the
+                                        ! index (j) as [A H^(j-1)]
+  real, dimension(N+1)  :: tri_l, &     ! trid. system (lower diagonal) [nondim]
+                           tri_d, &     ! trid. system (middle diagonal) [nondim]
+                           tri_u, &     ! trid. system (upper diagonal) [nondim]
+                           tri_b, &     ! trid. system (rhs) [A]
+                           tri_x        ! trid. system (unknowns vector) [A]
   integer :: i, k   ! loop indexes
 
   hNeglect = hNeglect_edge_dflt ; if (present(h_neglect)) hNeglect = h_neglect
@@ -1432,16 +1455,16 @@ end subroutine edge_values_implicit_h6
 
 !> Test that A*C = R to within a tolerance, issuing a fatal error with an explanatory message if they do not.
 subroutine test_line(msg, N, A, C, R, mag, tol)
-  real,               intent(in) :: mag  !< The magnitude of leading order terms in this line
-  integer,            intent(in) :: N    !< The number of points in the system
-  real, dimension(4), intent(in) :: A    !< One of the two vectors being multiplied
-  real, dimension(4), intent(in) :: C    !< One of the two vectors being multiplied
-  real,               intent(in) :: R    !< The expected solution of the equation
   character(len=*),   intent(in) :: msg  !< An identifying message for this test
-  real, optional,     intent(in) :: tol  !< The fractional tolerance for the two solutions
+  integer,            intent(in) :: N    !< The number of points in the system
+  real, dimension(4), intent(in) :: A    !< One of the two vectors being multiplied in arbitrary units [A]
+  real, dimension(4), intent(in) :: C    !< One of the two vectors being multiplied in arbitrary units [B]
+  real,               intent(in) :: R    !< The expected solution of the equation [A B]
+  real,               intent(in) :: mag  !< The magnitude of leading order terms in this line [A B]
+  real, optional,     intent(in) :: tol  !< The fractional tolerance for the sums [nondim]
 
-  real :: sum, sum_mag
-  real :: tolerance
+  real :: sum, sum_mag  ! The sum of the products and their magnitude in arbitrary units [A B]
+  real :: tolerance     ! The fractional tolerance for the sums [nondim]
   character(len=128) :: mesg2
   integer :: i
 

--- a/src/ALE/regrid_interp.F90
+++ b/src/ALE/regrid_interp.F90
@@ -305,7 +305,7 @@ subroutine interpolate_grid( n0, h0, x0, ppoly0_E, ppoly0_coefs, &
 
   ! Local variables
   integer        :: k ! loop index
-  real           :: t ! current interface target density
+  real           :: t ! current interface target density [A]
 
   ! Make sure boundary coordinates of new grid coincide with boundary
   ! coordinates of previous grid
@@ -385,10 +385,10 @@ function get_polynomial_coordinate( N, h, x_g, edge_values, ppoly_coefs, &
   ! Local variables
   real                        :: xi0         ! normalized target coordinate [nondim]
   real, dimension(DEGREE_MAX) :: a           ! polynomial coefficients [A]
-  real                        :: numerator
-  real                        :: denominator
+  real                        :: numerator   ! The numerator of an expression [A]
+  real                        :: denominator ! The denominator of an expression [A]
   real                        :: delta       ! Newton-Raphson increment [nondim]
-!   real                        :: x           ! global target coordinate
+!   real                        :: x           ! global target coordinate [nondim]
   real                        :: eps         ! offset used to get away from boundaries [nondim]
   real                        :: grad        ! gradient during N-R iterations [A]
   integer :: i, k, iter  ! loop indices

--- a/src/ALE/regrid_solvers.F90
+++ b/src/ALE/regrid_solvers.F90
@@ -18,15 +18,19 @@ contains
 !! The matrix A must be square, with the first index varing down the column.
 subroutine solve_linear_system( A, R, X, N, answer_date )
   integer,              intent(in)    :: N  !< The size of the system
-  real, dimension(N,N), intent(inout) :: A  !< The matrix being inverted [nondim]
-  real, dimension(N),   intent(inout) :: R  !< system right-hand side [A]
-  real, dimension(N),   intent(inout) :: X  !< solution vector [A]
+  real, dimension(N,N), intent(inout) :: A  !< The matrix being inverted in arbitrary units [A] on
+                                            !! input, but internally modified to become nondimensional
+                                            !! during the solver.
+  real, dimension(N),   intent(inout) :: R  !< system right-hand side in arbitrary units [A B] on
+                                            !! input, but internally modified to have units of [B]
+                                            !! during the solver
+  real, dimension(N),   intent(inout) :: X  !< solution vector in arbitrary units [B]
   integer,    optional, intent(in)    :: answer_date  !< The vintage of the expressions to use
   ! Local variables
-  real, parameter       :: eps = 0.0        ! Minimum pivot magnitude allowed
-  real    :: factor       ! The factor that eliminates the leading nonzero element in a row.
-  real    :: pivot, I_pivot ! The pivot value and its reciprocal [nondim]
-  real    :: swap_a, swap_b
+  real, parameter       :: eps = 0.0        ! Minimum pivot magnitude allowed [A]
+  real    :: factor       ! The factor that eliminates the leading nonzero element in a row [A-1]
+  real    :: pivot, I_pivot ! The pivot value and its reciprocal, in [A] and [A-1]
+  real    :: swap_a, swap_b ! Swap space in various units [various]
   logical :: found_pivot  ! If true, a pivot has been found
   logical :: old_answers  ! If true, use expressions that give the original (2008 through 2018) MOM6 answers
   integer :: i, j, k
@@ -110,15 +114,18 @@ end subroutine solve_linear_system
 !! The matrix A must be square, with the first index varing along the row.
 subroutine linear_solver( N, A, R, X )
   integer,              intent(in)    :: N  !< The size of the system
-  real, dimension(N,N), intent(inout) :: A  !< The matrix being inverted [nondim]
-  real, dimension(N),   intent(inout) :: R  !< system right-hand side [A]
-  real, dimension(N),   intent(inout) :: X  !< solution vector [A]
+  real, dimension(N,N), intent(inout) :: A  !< The matrix being inverted in arbitrary units [A] on
+                                            !! input, but internally modified to become nondimensional
+                                            !! during the solver.
+  real, dimension(N),   intent(inout) :: R  !< system right-hand side in [A B] on input, but internally
+                                            !! modified to have units of [B] during the solver
+  real, dimension(N),   intent(inout) :: X  !< solution vector [B]
 
   ! Local variables
-  real, parameter :: eps = 0.0   ! Minimum pivot magnitude allowed
-  real    :: factor       ! The factor that eliminates the leading nonzero element in a row.
-  real    :: I_pivot      ! The reciprocal of the pivot value [inverse of the input units of a row of A]
-  real    :: swap
+  real, parameter :: eps = 0.0   ! Minimum pivot magnitude allowed [A]
+  real    :: factor       ! The factor that eliminates the leading nonzero element in a row [A-1].
+  real    :: I_pivot      ! The reciprocal of the pivot value [A-1]
+  real    :: swap         ! Swap space used in various units [various]
   integer :: i, j, k
 
   ! Loop on rows to transform the problem into multiplication by an upper-right matrix.
@@ -175,16 +182,17 @@ end subroutine linear_solver
 !! (A is made up of lower, middle and upper diagonals)
 subroutine solve_tridiagonal_system( Al, Ad, Au, R, X, N, answer_date )
   integer,            intent(in)  :: N   !< The size of the system
-  real, dimension(N), intent(in)  :: Ad  !< Matrix center diagonal
-  real, dimension(N), intent(in)  :: Al  !< Matrix lower diagonal
-  real, dimension(N), intent(in)  :: Au  !< Matrix upper diagonal
-  real, dimension(N), intent(in)  :: R   !< system right-hand side
-  real, dimension(N), intent(out) :: X   !< solution vector
+  real, dimension(N), intent(in)  :: Ad  !< Matrix center diagonal in arbitrary units [A]
+  real, dimension(N), intent(in)  :: Al  !< Matrix lower diagonal [A]
+  real, dimension(N), intent(in)  :: Au  !< Matrix upper diagonal [A]
+  real, dimension(N), intent(in)  :: R   !< system right-hand side in arbitrary units [A B]
+  real, dimension(N), intent(out) :: X   !< solution vector in arbitrary units [B]
   integer,  optional, intent(in)  :: answer_date  !< The vintage of the expressions to use
   ! Local variables
-  real, dimension(N) :: pivot, Al_piv
-  real, dimension(N) :: c1       ! Au / pivot for the backward sweep
-  real    :: I_pivot  ! The inverse of the most recent pivot
+  real, dimension(N) :: pivot    ! The pivot value [A]
+  real, dimension(N) :: Al_piv   ! The lower diagonal divided by the pivot value [nondim]
+  real, dimension(N) :: c1       ! Au / pivot for the backward sweep [nondim]
+  real    :: I_pivot  ! The inverse of the most recent pivot [A-1]
   integer :: k        ! Loop index
   logical :: old_answers  ! If true, use expressions that give the original (2008 through 2018) MOM6 answers
 
@@ -237,16 +245,16 @@ end subroutine solve_tridiagonal_system
 !! roundoff compared with (Al+Au), the answers are prone to inaccuracy.
 subroutine solve_diag_dominant_tridiag( Al, Ac, Au, R, X, N )
   integer,            intent(in)  :: N   !< The size of the system
-  real, dimension(N), intent(in)  :: Ac  !< Matrix center diagonal offset from Al + Au
-  real, dimension(N), intent(in)  :: Al  !< Matrix lower diagonal
-  real, dimension(N), intent(in)  :: Au  !< Matrix upper diagonal
-  real, dimension(N), intent(in)  :: R   !< system right-hand side
-  real, dimension(N), intent(out) :: X   !< solution vector
+  real, dimension(N), intent(in)  :: Ac  !< Matrix center diagonal offset from Al + Au in arbitrary units [A]
+  real, dimension(N), intent(in)  :: Al  !< Matrix lower diagonal [A]
+  real, dimension(N), intent(in)  :: Au  !< Matrix upper diagonal [A]
+  real, dimension(N), intent(in)  :: R   !< system right-hand side in arbitrary units [A B]
+  real, dimension(N), intent(out) :: X   !< solution vector in arbitrary units [B]
   ! Local variables
-  real, dimension(N) :: c1       ! Au / pivot for the backward sweep
-  real               :: d1       ! The next value of 1.0 - c1
-  real               :: I_pivot  ! The inverse of the most recent pivot
-  real               :: denom_t1 ! The first term in the denominator of the inverse of the pivot.
+  real, dimension(N) :: c1       ! Au / pivot for the backward sweep [nondim]
+  real               :: d1       ! The next value of 1.0 - c1 [nondim]
+  real               :: I_pivot  ! The inverse of the most recent pivot [A-1]
+  real               :: denom_t1 ! The first term in the denominator of the inverse of the pivot [A]
   integer            :: k        ! Loop index
 
   ! Factorization and forward sweep, in a form that will never give a division by a

--- a/src/core/MOM.F90
+++ b/src/core/MOM.F90
@@ -2904,6 +2904,11 @@ subroutine initialize_MOM(Time, Time_init, param_file, dirs, CS, &
   if (CS%rotate_index) then
     G_in%ke = GV%ke
 
+    ! Allocate the auxiliary non-symmetric domain for debugging or I/O purposes.
+    if (CS%debug .or. G_in%symmetric) then
+      call clone_MOM_domain(G_in%Domain, G_in%Domain_aux, symmetric=.false.)
+    else ; G_in%Domain_aux => G_in%Domain ; endif
+
     allocate(u_in(G_in%IsdB:G_in%IedB, G_in%jsd:G_in%jed, nz), source=0.0)
     allocate(v_in(G_in%isd:G_in%ied, G_in%JsdB:G_in%JedB, nz), source=0.0)
     allocate(h_in(G_in%isd:G_in%ied, G_in%jsd:G_in%jed, nz), source=GV%Angstrom_H)

--- a/src/core/MOM.F90
+++ b/src/core/MOM.F90
@@ -3152,14 +3152,15 @@ subroutine initialize_MOM(Time, Time_init, param_file, dirs, CS, &
 
   ! Set up pointers within diag mediator control structure,
   ! this needs to occur _after_ CS%h etc. have been allocated.
-  call diag_set_state_ptrs(CS%h, CS%T, CS%S, CS%tv%eqn_of_state, diag)
+  call diag_set_state_ptrs(CS%h, CS%tv, diag)
 
   ! This call sets up the diagnostic axes. These are needed,
   ! e.g. to generate the target grids below.
   call set_axes_info(G, GV, US, param_file, diag)
 
   ! Whenever thickness/T/S changes let the diag manager know, target grids
-  ! for vertical remapping may need to be regenerated.
+  ! for vertical remapping may need to be regenerated.  In non-Boussinesq mode,
+  ! calc_derived_thermo needs to be called before diag_update_remap_grids.
   call diag_update_remap_grids(diag)
 
   ! Setup the diagnostic grid storage types

--- a/src/core/MOM.F90
+++ b/src/core/MOM.F90
@@ -4028,7 +4028,7 @@ subroutine extract_surface_state(CS, sfc_state_in)
     endif
   endif
 
-  if (CS%debug) call MOM_surface_chksum("Post extract_sfc", sfc_state, G, US, haloshift=0)
+  if (CS%debug) call MOM_surface_chksum("Post extract_sfc", sfc_state, G, US, haloshift=0, symmetric=.true.)
 
   ! Rotate sfc_state back onto the input grid, sfc_state_in
   if (CS%rotate_index) then

--- a/src/core/MOM.F90
+++ b/src/core/MOM.F90
@@ -1433,7 +1433,7 @@ subroutine step_MOM_tracer_dyn(CS, G, GV, US, h, Time_local)
   call advect_tracer(h, CS%uhtr, CS%vhtr, CS%OBC, CS%t_dyn_rel_adv, G, GV, US, &
                      CS%tracer_adv_CSp, CS%tracer_Reg, x_first_in=x_first)
   if (CS%debug) call MOM_tracer_chksum("Post-advect ", CS%tracer_Reg, G)
-  call tracer_hordiff(h, CS%t_dyn_rel_adv, CS%MEKE, CS%VarMix, G, GV, US, &
+  call tracer_hordiff(h, CS%t_dyn_rel_adv, CS%MEKE, CS%VarMix, CS%visc, G, GV, US, &
                       CS%tracer_diff_CSp, CS%tracer_Reg, CS%tv)
   if (CS%debug) call MOM_tracer_chksum("Post-diffuse ", CS%tracer_Reg, G)
   if (showCallTree) call callTree_waypoint("finished tracer advection/diffusion (step_MOM)")
@@ -1882,7 +1882,7 @@ subroutine step_offline(forces, fluxes, sfc_state, Time_start, time_interval, CS
             call calc_depth_function(G, CS%VarMix)
             call calc_slope_functions(CS%h, CS%tv, dt_offline, G, GV, US, CS%VarMix, OBC=CS%OBC)
           endif
-          call tracer_hordiff(CS%h, dt_offline, CS%MEKE, CS%VarMix, G, GV, US, &
+          call tracer_hordiff(CS%h, dt_offline, CS%MEKE, CS%VarMix, CS%visc, G, GV, US, &
                               CS%tracer_diff_CSp, CS%tracer_Reg, CS%tv)
         endif
       endif
@@ -1909,7 +1909,7 @@ subroutine step_offline(forces, fluxes, sfc_state, Time_start, time_interval, CS
             call calc_depth_function(G, CS%VarMix)
             call calc_slope_functions(CS%h, CS%tv, dt_offline, G, GV, US, CS%VarMix, OBC=CS%OBC)
           endif
-          call tracer_hordiff(CS%h, dt_offline, CS%MEKE, CS%VarMix, G, GV, US, &
+          call tracer_hordiff(CS%h, dt_offline, CS%MEKE, CS%VarMix, CS%visc, G, GV, US, &
               CS%tracer_diff_CSp, CS%tracer_Reg, CS%tv)
         endif
       endif
@@ -1966,7 +1966,7 @@ subroutine step_offline(forces, fluxes, sfc_state, Time_start, time_interval, CS
                                  CS%h, eatr, ebtr, uhtr, vhtr)
     ! Perform offline diffusion if requested
     if (.not. skip_diffusion) then
-      call tracer_hordiff(h_end, dt_offline, CS%MEKE, CS%VarMix, G, GV, US, &
+      call tracer_hordiff(h_end, dt_offline, CS%MEKE, CS%VarMix, CS%visc, G, GV, US, &
                           CS%tracer_diff_CSp, CS%tracer_Reg, CS%tv)
     endif
 

--- a/src/core/MOM.F90
+++ b/src/core/MOM.F90
@@ -56,6 +56,7 @@ use MOM_ALE,                   only : ALE_updateVerticalGridType, ALE_remap_init
 use MOM_ALE,                   only : ALE_remap_tracers, ALE_remap_velocities
 use MOM_ALE,                   only : ALE_remap_set_h_vel, ALE_remap_set_h_vel_via_dz
 use MOM_ALE,                   only : ALE_update_regrid_weights, pre_ALE_diagnostics, ALE_register_diags
+use MOM_ALE,                   only : ALE_set_extrap_boundaries
 use MOM_ALE_sponge,            only : rotate_ALE_sponge, update_ALE_sponge_field
 use MOM_barotropic,            only : Barotropic_CS
 use MOM_boundary_update,       only : call_OBC_register, OBC_register_end, update_OBC_CS
@@ -3120,8 +3121,11 @@ subroutine initialize_MOM(Time, Time_init, param_file, dirs, CS, &
       endif
     endif
   endif
-  if ( CS%use_ALE_algorithm ) call ALE_updateVerticalGridType( CS%ALE_CSp, GV )
-
+  if ( CS%use_ALE_algorithm ) then
+   call ALE_set_extrap_boundaries (param_file, CS%ALE_CSp)
+   call callTree_waypoint("returned from ALE_init() (initialize_MOM)")
+   call ALE_updateVerticalGridType( CS%ALE_CSp, GV )
+  endif
   ! The basic state variables have now been fully initialized, so update their halos and
   ! calculate any derived thermodynmics quantities.
 

--- a/src/core/MOM.F90
+++ b/src/core/MOM.F90
@@ -77,6 +77,9 @@ use MOM_dynamics_unsplit,      only : MOM_dyn_unsplit_CS
 use MOM_dynamics_split_RK2,    only : step_MOM_dyn_split_RK2, register_restarts_dyn_split_RK2
 use MOM_dynamics_split_RK2,    only : initialize_dyn_split_RK2, end_dyn_split_RK2
 use MOM_dynamics_split_RK2,    only : MOM_dyn_split_RK2_CS, remap_dyn_split_rk2_aux_vars
+use MOM_dynamics_split_RK2b,   only : step_MOM_dyn_split_RK2b, register_restarts_dyn_split_RK2b
+use MOM_dynamics_split_RK2b,   only : initialize_dyn_split_RK2b, end_dyn_split_RK2b
+use MOM_dynamics_split_RK2b,   only : MOM_dyn_split_RK2b_CS, remap_dyn_split_RK2b_aux_vars
 use MOM_dynamics_unsplit_RK2,  only : step_MOM_dyn_unsplit_RK2, register_restarts_dyn_unsplit_RK2
 use MOM_dynamics_unsplit_RK2,  only : initialize_dyn_unsplit_RK2, end_dyn_unsplit_RK2
 use MOM_dynamics_unsplit_RK2,  only : MOM_dyn_unsplit_RK2_CS
@@ -284,6 +287,9 @@ type, public :: MOM_control_struct ; private
   logical :: do_dynamics             !< If false, does not call step_MOM_dyn_*. This is an
                                      !! undocumented run-time flag that is fragile.
   logical :: split                   !< If true, use the split time stepping scheme.
+  logical :: use_alt_split           !< If true, use a version of the split explicit time stepping
+                                     !! with a heavier emphasis on consistent tranports between the
+                                     !! layered and barotroic variables.
   logical :: use_RK2                 !< If true, use RK2 instead of RK3 in unsplit mode
                                      !! (i.e., no split between barotropic and baroclinic).
   logical :: interface_filter        !< If true, apply an interface height filter immediately
@@ -379,6 +385,8 @@ type, public :: MOM_control_struct ; private
     !< Pointer to the control structure used for the unsplit RK2 dynamics
   type(MOM_dyn_split_RK2_CS),    pointer :: dyn_split_RK2_CSp => NULL()
     !< Pointer to the control structure used for the mode-split RK2 dynamics
+  type(MOM_dyn_split_RK2b_CS),    pointer :: dyn_split_RK2b_CSp => NULL()
+    !< Pointer to the control structure used for an alternate version of the mode-split RK2 dynamics
   type(thickness_diffuse_CS) :: thickness_diffuse_CSp
     !< Pointer to the control structure used for the isopycnal height diffusive transport.
     !! This is also common referred to as Gent-McWilliams diffusion
@@ -1220,10 +1228,17 @@ subroutine step_MOM_dynamics(forces, p_surf_begin, p_surf_end, dt, dt_thermo, &
       endif
     endif
 
-    call step_MOM_dyn_split_RK2(u, v, h, CS%tv, CS%visc, Time_local, dt, forces, &
-                p_surf_begin, p_surf_end, CS%uh, CS%vh, CS%uhtr, CS%vhtr, &
-                CS%eta_av_bc, G, GV, US, CS%dyn_split_RK2_CSp, calc_dtbt, CS%VarMix, &
-                CS%MEKE, CS%thickness_diffuse_CSp, CS%pbv, waves=waves)
+    if (CS%use_alt_split) then
+      call step_MOM_dyn_split_RK2b(u, v, h, CS%tv, CS%visc, Time_local, dt, forces, &
+                  p_surf_begin, p_surf_end, CS%uh, CS%vh, CS%uhtr, CS%vhtr, &
+                  CS%eta_av_bc, G, GV, US, CS%dyn_split_RK2b_CSp, calc_dtbt, CS%VarMix, &
+                  CS%MEKE, CS%thickness_diffuse_CSp, CS%pbv, waves=waves)
+    else
+      call step_MOM_dyn_split_RK2(u, v, h, CS%tv, CS%visc, Time_local, dt, forces, &
+                  p_surf_begin, p_surf_end, CS%uh, CS%vh, CS%uhtr, CS%vhtr, &
+                  CS%eta_av_bc, G, GV, US, CS%dyn_split_RK2_CSp, calc_dtbt, CS%VarMix, &
+                  CS%MEKE, CS%thickness_diffuse_CSp, CS%pbv, waves=waves)
+    endif
     if (showCallTree) call callTree_waypoint("finished step_MOM_dyn_split (step_MOM)")
 
   elseif (CS%do_dynamics) then ! ------------------------------------ not SPLIT
@@ -1646,8 +1661,12 @@ subroutine step_MOM_thermo(CS, G, GV, US, u, v, h, tv, fluxes, dtdia, &
       if (allocated(tv%SpV_avg)) tv%valid_SpV_halo = -1   ! Record that SpV_avg is no longer valid.
 
       if (CS%remap_aux_vars) then
-        if (CS%split) &
+        if (CS%split .and. CS%use_alt_split) then
+          call remap_dyn_split_RK2b_aux_vars(G, GV, CS%dyn_split_RK2b_CSp, h_old_u, h_old_v, &
+                                             h_new_u, h_new_v, CS%ALE_CSp)
+        elseif (CS%split) then
           call remap_dyn_split_RK2_aux_vars(G, GV, CS%dyn_split_RK2_CSp, h_old_u, h_old_v, h_new_u, h_new_v, CS%ALE_CSp)
+        endif
 
         if (associated(CS%OBC)) then
           call pass_var(h, G%Domain, complete=.false.)
@@ -2154,6 +2173,10 @@ subroutine initialize_MOM(Time, Time_init, param_file, dirs, CS, &
 
   call get_param(param_file, "MOM", "SPLIT", CS%split, &
                  "Use the split time stepping if true.", default=.true.)
+  call get_param(param_file, "MOM", "SPLIT_RK2B", CS%use_alt_split, &
+                 "If true, use a version of the split explicit time stepping with a heavier "//&
+                 "emphasis on consistent tranports between the layered and barotroic variables.", &
+                 default=.false., do_not_log=.not.CS%split)
   if (CS%split) then
     CS%use_RK2 = .false.
   else
@@ -2771,7 +2794,10 @@ subroutine initialize_MOM(Time, Time_init, param_file, dirs, CS, &
   restart_CSp => CS%restart_CS
 
   call set_restart_fields(GV, US, param_file, CS, restart_CSp)
-  if (CS%split) then
+  if (CS%split .and. CS%use_alt_split) then
+    call register_restarts_dyn_split_RK2b(HI, GV, US, param_file, &
+             CS%dyn_split_RK2b_CSp, restart_CSp, CS%uh, CS%vh)
+  elseif (CS%split) then
     call register_restarts_dyn_split_RK2(HI, GV, US, param_file, &
              CS%dyn_split_RK2_CSp, restart_CSp, CS%uh, CS%vh)
   elseif (CS%use_RK2) then
@@ -3157,12 +3183,19 @@ subroutine initialize_MOM(Time, Time_init, param_file, dirs, CS, &
 
   if (CS%split) then
     allocate(eta(SZI_(G),SZJ_(G)), source=0.0)
-    call initialize_dyn_split_RK2(CS%u, CS%v, CS%h, CS%uh, CS%vh, eta, Time, &
+    if (CS%use_alt_split) then
+      call initialize_dyn_split_RK2b(CS%u, CS%v, CS%h, CS%uh, CS%vh, eta, Time, &
+              G, GV, US, param_file, diag, CS%dyn_split_RK2b_CSp, restart_CSp, &
+              CS%dt, CS%ADp, CS%CDp, MOM_internal_state, CS%VarMix, CS%MEKE, &
+              CS%thickness_diffuse_CSp, CS%OBC, CS%update_OBC_CSp, CS%ALE_CSp, CS%set_visc_CSp, &
+              CS%visc, dirs, CS%ntrunc, CS%pbv, calc_dtbt=calc_dtbt, cont_stencil=CS%cont_stencil)
+    else
+      call initialize_dyn_split_RK2(CS%u, CS%v, CS%h, CS%uh, CS%vh, eta, Time, &
               G, GV, US, param_file, diag, CS%dyn_split_RK2_CSp, restart_CSp, &
               CS%dt, CS%ADp, CS%CDp, MOM_internal_state, CS%VarMix, CS%MEKE, &
-              CS%thickness_diffuse_CSp,                                      &
-              CS%OBC, CS%update_OBC_CSp, CS%ALE_CSp, CS%set_visc_CSp,        &
+              CS%thickness_diffuse_CSp, CS%OBC, CS%update_OBC_CSp, CS%ALE_CSp, CS%set_visc_CSp, &
               CS%visc, dirs, CS%ntrunc, CS%pbv, calc_dtbt=calc_dtbt, cont_stencil=CS%cont_stencil)
+    endif
     if (CS%dtbt_reset_period > 0.0) then
       CS%dtbt_reset_interval = real_to_time(US%T_to_s*CS%dtbt_reset_period)
       ! Set dtbt_reset_time to be the next even multiple of dtbt_reset_interval.
@@ -4116,7 +4149,9 @@ subroutine MOM_end(CS)
 
   if (CS%offline_tracer_mode) call offline_transport_end(CS%offline_CSp)
 
-  if (CS%split) then
+  if (CS%split .and. CS%use_alt_split) then
+    call end_dyn_split_RK2b(CS%dyn_split_RK2b_CSp)
+  elseif (CS%split) then
     call end_dyn_split_RK2(CS%dyn_split_RK2_CSp)
   elseif (CS%use_RK2) then
     call end_dyn_unsplit_RK2(CS%dyn_unsplit_RK2_CSp)

--- a/src/core/MOM.F90
+++ b/src/core/MOM.F90
@@ -263,7 +263,7 @@ type, public :: MOM_control_struct ; private
   type(MOM_stoch_eos_CS) :: stoch_eos_CS !< structure containing random pattern for stoch EOS
   logical :: alternate_first_direction !< If true, alternate whether the x- or y-direction
                     !! updates occur first in directionally split parts of the calculation.
-  real    :: first_dir_restart = -1.0 !< A real copy of G%first_direction for use in restart files
+  real    :: first_dir_restart = -1.0 !< A real copy of G%first_direction for use in restart files [nondim]
   logical :: offline_tracer_mode = .false.
                     !< If true, step_offline() is called instead of step_MOM().
                     !! This is intended for running MOM6 in offline tracer mode
@@ -1205,7 +1205,7 @@ subroutine step_MOM_dynamics(forces, p_surf_begin, p_surf_end, dt, dt_thermo, &
   endif
 
   !OBC segment data update for some fields can be less frequent than others
-  if(associated(CS%OBC)) then
+  if (associated(CS%OBC)) then
     CS%OBC%update_OBC_seg_data = .false.
     if (CS%dt_obc_seg_period == 0.0) CS%OBC%update_OBC_seg_data = .true.
     if (CS%dt_obc_seg_period > 0.0) then
@@ -2079,7 +2079,7 @@ subroutine initialize_MOM(Time, Time_init, param_file, dirs, CS, &
 
   real    :: Hmix_z, Hmix_UV_z ! Temporary variables with averaging depths [Z ~> m]
   real    :: HFrz_z            ! Temporary variable with the melt potential depth [Z ~> m]
-  real    :: default_val       ! default value for a parameter
+  real    :: default_val       ! The default value for DTBT_RESET_PERIOD [s]
   logical :: write_geom_files  ! If true, write out the grid geometry files.
   logical :: new_sim           ! If true, this has been determined to be a new simulation
   logical :: use_geothermal    ! If true, apply geothermal heating.

--- a/src/core/MOM.F90
+++ b/src/core/MOM.F90
@@ -288,8 +288,9 @@ type, public :: MOM_control_struct ; private
                                      !! undocumented run-time flag that is fragile.
   logical :: split                   !< If true, use the split time stepping scheme.
   logical :: use_alt_split           !< If true, use a version of the split explicit time stepping
-                                     !! with a heavier emphasis on consistent tranports between the
-                                     !! layered and barotroic variables.
+                                     !! scheme that exchanges velocities with step_MOM that have the
+                                     !! average barotropic phase over a baroclinic timestep rather
+                                     !! than the instantaneous barotropic phase.
   logical :: use_RK2                 !< If true, use RK2 instead of RK3 in unsplit mode
                                      !! (i.e., no split between barotropic and baroclinic).
   logical :: interface_filter        !< If true, apply an interface height filter immediately
@@ -2174,8 +2175,9 @@ subroutine initialize_MOM(Time, Time_init, param_file, dirs, CS, &
   call get_param(param_file, "MOM", "SPLIT", CS%split, &
                  "Use the split time stepping if true.", default=.true.)
   call get_param(param_file, "MOM", "SPLIT_RK2B", CS%use_alt_split, &
-                 "If true, use a version of the split explicit time stepping with a heavier "//&
-                 "emphasis on consistent tranports between the layered and barotroic variables.", &
+                 "If true, use a version of the split explicit time stepping scheme that "//&
+                 "exchanges velocities with step_MOM that have the average barotropic phase over "//&
+                 "a baroclinic timestep rather than the instantaneous barotropic phase.", &
                  default=.false., do_not_log=.not.CS%split)
   if (CS%split) then
     CS%use_RK2 = .false.

--- a/src/core/MOM.F90
+++ b/src/core/MOM.F90
@@ -3114,10 +3114,10 @@ subroutine initialize_MOM(Time, Time_init, param_file, dirs, CS, &
 
     if (CS%debug) then
       call uvchksum("Post ALE adjust init cond [uv]", CS%u, CS%v, G%HI, haloshift=1)
-      call hchksum(CS%h, "Post ALE adjust init cond h", G%HI, haloshift=1, scale=GV%H_to_MKS)
+      call hchksum(CS%h, "Post ALE adjust init cond h", G%HI, haloshift=2, scale=GV%H_to_MKS)
       if (use_temperature) then
-        call hchksum(CS%tv%T, "Post ALE adjust init cond T", G%HI, haloshift=1, scale=US%C_to_degC)
-        call hchksum(CS%tv%S, "Post ALE adjust init cond S", G%HI, haloshift=1, scale=US%S_to_ppt)
+        call hchksum(CS%tv%T, "Post ALE adjust init cond T", G%HI, haloshift=2, scale=US%C_to_degC)
+        call hchksum(CS%tv%S, "Post ALE adjust init cond S", G%HI, haloshift=2, scale=US%S_to_ppt)
       endif
     endif
   endif
@@ -3221,13 +3221,13 @@ subroutine initialize_MOM(Time, Time_init, param_file, dirs, CS, &
   if (CS%split) then
     allocate(eta(SZI_(G),SZJ_(G)), source=0.0)
     if (CS%use_alt_split) then
-      call initialize_dyn_split_RK2b(CS%u, CS%v, CS%h, CS%uh, CS%vh, eta, Time, &
+      call initialize_dyn_split_RK2b(CS%u, CS%v, CS%h, CS%tv, CS%uh, CS%vh, eta, Time, &
               G, GV, US, param_file, diag, CS%dyn_split_RK2b_CSp, restart_CSp, &
               CS%dt, CS%ADp, CS%CDp, MOM_internal_state, CS%VarMix, CS%MEKE, &
               CS%thickness_diffuse_CSp, CS%OBC, CS%update_OBC_CSp, CS%ALE_CSp, CS%set_visc_CSp, &
               CS%visc, dirs, CS%ntrunc, CS%pbv, calc_dtbt=calc_dtbt, cont_stencil=CS%cont_stencil)
     else
-      call initialize_dyn_split_RK2(CS%u, CS%v, CS%h, CS%uh, CS%vh, eta, Time, &
+      call initialize_dyn_split_RK2(CS%u, CS%v, CS%h, CS%tv, CS%uh, CS%vh, eta, Time, &
               G, GV, US, param_file, diag, CS%dyn_split_RK2_CSp, restart_CSp, &
               CS%dt, CS%ADp, CS%CDp, MOM_internal_state, CS%VarMix, CS%MEKE, &
               CS%thickness_diffuse_CSp, CS%OBC, CS%update_OBC_CSp, CS%ALE_CSp, CS%set_visc_CSp, &

--- a/src/core/MOM.F90
+++ b/src/core/MOM.F90
@@ -2958,7 +2958,7 @@ subroutine initialize_MOM(Time, Time_init, param_file, dirs, CS, &
     endif
 
     if (associated(ALE_sponge_in_CSp)) then
-      call rotate_ALE_sponge(ALE_sponge_in_CSp, G_in, CS%ALE_sponge_CSp, G, GV, turns, param_file)
+      call rotate_ALE_sponge(ALE_sponge_in_CSp, G_in, CS%ALE_sponge_CSp, G, GV, US, turns, param_file)
       call update_ALE_sponge_field(CS%ALE_sponge_CSp, T_in, G, GV, CS%T)
       call update_ALE_sponge_field(CS%ALE_sponge_CSp, S_in, G, GV, CS%S)
     endif

--- a/src/core/MOM.F90
+++ b/src/core/MOM.F90
@@ -1436,8 +1436,11 @@ subroutine step_MOM_tracer_dyn(CS, G, GV, US, h, Time_local)
                       CS%tracer_diff_CSp, CS%tracer_Reg, CS%tv)
   if (CS%debug) call MOM_tracer_chksum("Post-diffuse ", CS%tracer_Reg, G)
   if (showCallTree) call callTree_waypoint("finished tracer advection/diffusion (step_MOM)")
-  call update_segment_tracer_reservoirs(G, GV, CS%uhtr, CS%vhtr, h, CS%OBC, &
+  if (associated(CS%OBC)) then
+    call pass_vector(CS%uhtr, CS%vhtr, G%Domain)
+    call update_segment_tracer_reservoirs(G, GV, CS%uhtr, CS%vhtr, h, CS%OBC, &
                      CS%t_dyn_rel_adv, CS%tracer_Reg)
+  endif
   call cpu_clock_end(id_clock_tracer) ; call cpu_clock_end(id_clock_thermo)
 
   call cpu_clock_begin(id_clock_other) ; call cpu_clock_begin(id_clock_diagnostics)

--- a/src/core/MOM.F90
+++ b/src/core/MOM.F90
@@ -3270,17 +3270,18 @@ subroutine initialize_MOM(Time, Time_init, param_file, dirs, CS, &
 
   CS%mixedlayer_restrat = mixedlayer_restrat_init(Time, G, GV, US, param_file, diag, &
                                                   CS%mixedlayer_restrat_CSp, restart_CSp)
-  if (CS%mixedlayer_restrat) then
-    if (GV%Boussinesq .and. associated(CS%visc%h_ML)) then
-      ! This is here to allow for a transition of restart files between model versions.
-      call get_param(param_file, "MOM", "MLE_USE_PBL_MLD", MLE_use_PBL_MLD, &
-                     default=.false., do_not_log=.true.)
-      if (MLE_use_PBL_MLD .and. .not.query_initialized(CS%visc%h_ML, "h_ML", restart_CSp) .and. &
-          associated(CS%visc%MLD)) then
-        do j=js,je ; do i=is,ie ; CS%visc%h_ML(i,j) = GV%Z_to_H * CS%visc%MLD(i,j) ; enddo ; enddo
-      endif
-    endif
 
+  if (GV%Boussinesq .and. associated(CS%visc%h_ML)) then
+    ! This is here to allow for a transition of restart files between model versions.
+    call get_param(param_file, "MOM", "MLE_USE_PBL_MLD", MLE_use_PBL_MLD, &
+                   default=.false., do_not_log=.true.)
+    if (MLE_use_PBL_MLD .and. .not.query_initialized(CS%visc%h_ML, "h_ML", restart_CSp) .and. &
+        associated(CS%visc%MLD)) then
+      do j=js,je ; do i=is,ie ; CS%visc%h_ML(i,j) = GV%Z_to_H * CS%visc%MLD(i,j) ; enddo ; enddo
+    endif
+  endif
+
+  if (CS%mixedlayer_restrat) then
     if (.not.(bulkmixedlayer .or. CS%use_ALE_algorithm)) &
       call MOM_error(FATAL, "MOM: MIXEDLAYER_RESTRAT true requires a boundary layer scheme.")
     ! When DIABATIC_FIRST=False and using CS%visc%ML in mixedlayer_restrat we need to update after a restart

--- a/src/core/MOM_CoriolisAdv.F90
+++ b/src/core/MOM_CoriolisAdv.F90
@@ -902,20 +902,20 @@ subroutine CorAdCalc(u, v, h, uh, vh, CAu, CAv, OBC, AD, G, GV, US, CS, pbv, Wav
         if (associated(AD%rv_x_u)) then
           do J=Jsq,Jeq ; do i=is,ie
             AD%rv_x_u(i,J,k) = -G%IdyCv(i,J) * C1_12 * &
-              ((q2(I,J) + q2(I-1,J) + q2(I-1,J-1)) * uh(I-1,j,k) + &
-               (q2(I-1,J) + q2(I,J) + q2(I,J-1)) * uh(I,j,k) + &
-               (q2(I-1,J) + q2(I,J+1) + q2(I,J)) * uh(I,j+1,k) + &
-               (q2(I,J) + q2(I-1,J+1) + q2(I-1,J)) * uh(I-1,j+1,k))
+              (((((q2(I,J) + q2(I-1,J-1)) + q2(I-1,J)) * uh(I-1,j,k)) + &
+                (((q2(I-1,J) + q2(I,J+1)) + q2(I,J)) * uh(I,j+1,k))) + &
+               ((((q2(I-1,J) + q2(I,J-1)) + q2(I,J)) * uh(I,j,k))+ &
+                (((q2(I,J) + q2(I-1,J+1)) + q2(I-1,J)) * uh(I-1,j+1,k))))
           enddo ; enddo
         endif
 
         if (associated(AD%rv_x_v)) then
           do j=js,je ; do I=Isq,Ieq
             AD%rv_x_v(I,j,k) = G%IdxCu(I,j) * C1_12 * &
-              ((q2(I+1,J) + q2(I,J) + q2(I,J-1)) * vh(i+1,J,k) + &
-               (q2(I-1,J) + q2(I,J) + q2(I,J-1)) * vh(i,J,k) + &
-               (q2(I-1,J-1) + q2(I,J) + q2(I,J-1)) * vh(i,J-1,k) + &
-               (q2(I+1,J-1) + q2(I,J) + q2(I,J-1)) * vh(i+1,J-1,k))
+              (((((q2(I+1,J) + q2(I,J-1)) + q2(I,J)) * vh(i+1,J,k)) + &
+                (((q2(I-1,J-1) + q2(I,J)) + q2(I,J-1)) * vh(i,J-1,k))) + &
+               ((((q2(I-1,J) + q2(I,J-1)) + q2(I,J)) * vh(i,J,k)) + &
+                (((q2(I+1,J-1) + q2(I,J)) + q2(I,J-1)) * vh(i+1,J-1,k))))
           enddo ; enddo
         endif
       endif

--- a/src/core/MOM_check_scaling.F90
+++ b/src/core/MOM_check_scaling.F90
@@ -29,7 +29,7 @@ subroutine check_MOM6_scaling_factors(GV, US)
 
   ! Local variables
   integer, parameter :: ndims = 8 ! The number of rescalable dimensional factors.
-  real,    dimension(ndims) :: scales ! An array of scaling factors for each of the basic units.
+  real,    dimension(ndims) :: scales ! An array of scaling factors for each of the basic units [various].
   integer, dimension(ndims) :: scale_pow2 ! The powers of 2 that give each element of scales.
   character(len=2), dimension(ndims) :: key
   integer, allocatable :: weights(:)

--- a/src/core/MOM_checksum_packages.F90
+++ b/src/core/MOM_checksum_packages.F90
@@ -268,10 +268,11 @@ subroutine MOM_state_stats(mesg, u, v, h, Temp, Salt, G, GV, US, allowChange, pe
   ! Local variables
   real, dimension(G%isc:G%iec, G%jsc:G%jec) :: &
     tmp_A, &  ! The area per cell [m2] (unscaled to permit reproducing sum).
-    tmp_V, &  ! The column-integrated volume [m3] (unscaled to permit reproducing sum)
-    tmp_T, &  ! The column-integrated temperature [degC m3] (unscaled to permit reproducing sum)
-    tmp_S     ! The column-integrated salinity [ppt m3] (unscaled to permit reproducing sum)
-  real :: Vol, dV    ! The total ocean volume and its change [m3] (unscaled to permit reproducing sum).
+    tmp_V, &  ! The column-integrated volume [m3] or mass [kg] (unscaled to permit reproducing sum),
+              ! depending on whether the Boussinesq approximation is used
+    tmp_T, &  ! The column-integrated temperature [degC m3] or [degC kg] (unscaled to permit reproducing sum)
+    tmp_S     ! The column-integrated salinity [ppt m3] or [ppt kg] (unscaled to permit reproducing sum)
+  real :: Vol, dV    ! The total ocean volume or mass and its change [m3] or [kg] (unscaled to permit reproducing sum).
   real :: Area       ! The total ocean surface area [m2] (unscaled to permit reproducing sum).
   real :: h_minimum  ! The minimum layer thicknesses [H ~> m or kg m-2]
   real :: T_scale    ! The scaling conversion factor for temperatures [degC C-1 ~> 1]
@@ -284,7 +285,7 @@ subroutine MOM_state_stats(mesg, u, v, h, Temp, Salt, G, GV, US, allowChange, pe
   !       assumption we will not turn this on with threads
   type(stats), save :: oldT, oldS
   logical, save :: firstCall = .true.
-  real, save :: oldVol ! The previous total ocean volume [m3]
+  real, save :: oldVol ! The previous total ocean volume [m3] or mass [kg]
 
   character(len=80) :: lMsg
   integer :: is, ie, js, je, nz, i, j, k
@@ -308,7 +309,7 @@ subroutine MOM_state_stats(mesg, u, v, h, Temp, Salt, G, GV, US, allowChange, pe
   h_minimum = 1.E34*GV%m_to_H
   do k=1,nz ; do j=js,je ; do i=is,ie
     if (G%mask2dT(i,j)>0.) then
-      dV = US%L_to_m**2*G%areaT(i,j)*GV%H_to_m*h(i,j,k)
+      dV = US%L_to_m**2*G%areaT(i,j)*GV%H_to_MKS*h(i,j,k)
       tmp_V(i,j) = tmp_V(i,j) + dV
       if (do_TS .and. h(i,j,k)>0.) then
         T%minimum = min( T%minimum, T_scale*Temp(i,j,k) ) ; T%maximum = max( T%maximum, T_scale*Temp(i,j,k) )

--- a/src/core/MOM_checksum_packages.F90
+++ b/src/core/MOM_checksum_packages.F90
@@ -167,7 +167,7 @@ subroutine MOM_surface_chksum(mesg, sfc_state, G, US, haloshift, symmetric)
   logical :: sym
 
   sym = .false. ; if (present(symmetric)) sym = symmetric
-  hs = 1 ; if (present(haloshift)) hs = haloshift
+  hs = 0 ; if (present(haloshift)) hs = haloshift
 
   if (allocated(sfc_state%SST)) call hchksum(sfc_state%SST, mesg//" SST", G%HI, haloshift=hs, &
                                              scale=US%C_to_degC)
@@ -182,6 +182,14 @@ subroutine MOM_surface_chksum(mesg, sfc_state, G, US, haloshift, symmetric)
                   scale=US%L_T_to_m_s)
   if (allocated(sfc_state%frazil)) call hchksum(sfc_state%frazil, mesg//" frazil", G%HI, &
                                                 haloshift=hs, scale=US%Q_to_J_kg*US%RZ_to_kg_m2)
+  if (allocated(sfc_state%melt_potential)) call hchksum(sfc_state%melt_potential, mesg//" melt_potential", &
+                      G%HI, haloshift=hs, scale=US%Q_to_J_kg*US%RZ_to_kg_m2)
+  if (allocated(sfc_state%ocean_mass)) call hchksum(sfc_state%ocean_mass, mesg//" ocean_mass", &
+                      G%HI, haloshift=hs, scale=US%RZ_to_kg_m2)
+  if (allocated(sfc_state%ocean_heat)) call hchksum(sfc_state%ocean_heat, mesg//" ocean_heat", &
+                      G%HI, haloshift=hs, scale=US%C_to_degC*US%RZ_to_kg_m2)
+  if (allocated(sfc_state%ocean_salt)) call hchksum(sfc_state%ocean_salt, mesg//" ocean_salt", &
+                      G%HI, haloshift=hs, scale=US%S_to_ppt*US%RZ_to_kg_m2)
 
 end subroutine MOM_surface_chksum
 

--- a/src/core/MOM_continuity.F90
+++ b/src/core/MOM_continuity.F90
@@ -7,181 +7,24 @@ use MOM_continuity_PPM, only : continuity=>continuity_PPM
 use MOM_continuity_PPM, only : continuity_stencil=>continuity_PPM_stencil
 use MOM_continuity_PPM, only : continuity_init=>continuity_PPM_init
 use MOM_continuity_PPM, only : continuity_CS=>continuity_PPM_CS
-use MOM_continuity_PPM, only : zonal_edge_thickness, meridional_edge_thickness
+use MOM_continuity_PPM, only : continuity_fluxes, continuity_adjust_vel
 use MOM_continuity_PPM, only : zonal_mass_flux, meridional_mass_flux
+use MOM_continuity_PPM, only : zonal_edge_thickness, meridional_edge_thickness
+use MOM_continuity_PPM, only : continuity_zonal_convergence, continuity_merdional_convergence
+use MOM_continuity_PPM, only : zonal_flux_thickness, meridional_flux_thickness
 use MOM_continuity_PPM, only : zonal_BT_mass_flux, meridional_BT_mass_flux
-use MOM_diag_mediator, only : time_type
-use MOM_grid, only : ocean_grid_type
-use MOM_open_boundary, only : ocean_OBC_type
-use MOM_unit_scaling, only : unit_scale_type
-use MOM_variables, only : BT_cont_type, porous_barrier_type
-use MOM_verticalGrid, only : verticalGrid_type
+use MOM_continuity_PPM, only : set_continuity_loop_bounds, cont_loop_bounds_type
 
 implicit none ; private
-
-#include <MOM_memory.h>
 
 ! These are direct pass-throughs of routines in continuity_PPM
 public continuity, continuity_init, continuity_stencil, continuity_CS
 public continuity_fluxes, continuity_adjust_vel
-
-!> Finds the thickness fluxes from the continuity solver or their vertical sum without
-!! actually updating the layer thicknesses.
-interface continuity_fluxes
-  module procedure continuity_3d_fluxes, continuity_2d_fluxes
-end interface continuity_fluxes
-
-contains
-
-!> Finds the thickness fluxes from the continuity solver without actually updating the
-!! layer thicknesses.  Because the fluxes in the two directions are calculated based on the
-!! input thicknesses, which are not updated between the direcitons, the fluxes returned here
-!! are not the same as those that would be returned by a call to continuity.
-subroutine continuity_3d_fluxes(u, v, h, uh, vh, dt, G, GV, US, CS, OBC, pbv)
-  type(ocean_grid_type),   intent(inout) :: G   !< Ocean grid structure.
-  type(verticalGrid_type), intent(in)    :: GV  !< Vertical grid structure.
-  real, dimension(SZIB_(G),SZJ_(G),SZK_(GV)), &
-                           intent(in)    :: u   !< Zonal velocity [L T-1 ~> m s-1].
-  real, dimension(SZI_(G),SZJB_(G),SZK_(GV)), &
-                           intent(in)    :: v   !< Meridional velocity [L T-1 ~> m s-1].
-  real, dimension(SZI_(G),SZJ_(G),SZK_(GV)),  &
-                           intent(in)    :: h   !< Layer thickness [H ~> m or kg m-2].
-  real, dimension(SZIB_(G),SZJ_(G),SZK_(GV)), &
-                           intent(out)   :: uh  !< Thickness fluxes through zonal faces,
-                                                !! u*h*dy [H L2 T-1 ~> m3 s-1 or kg s-1].
-  real, dimension(SZI_(G),SZJB_(G),SZK_(GV)), &
-                           intent(out)   :: vh  !< Thickness fluxes through meridional faces,
-                                                !! v*h*dx [H L2 T-1 ~> m3 s-1 or kg s-1].
-  real,                    intent(in)    :: dt  !< Time increment [T ~> s].
-  type(unit_scale_type),   intent(in)    :: US  !< A dimensional unit scaling type
-  type(continuity_CS),     intent(in)    :: CS  !< Control structure for mom_continuity.
-  type(ocean_OBC_type),    pointer       :: OBC !< Open boundaries control structure.
-  type(porous_barrier_type), intent(in)  :: pbv !< porous barrier fractional cell metrics
-
-  ! Local variables
-  real :: h_W(SZI_(G),SZJ_(G),SZK_(GV)) ! West edge thicknesses in the zonal PPM reconstruction [H ~> m or kg m-2]
-  real :: h_E(SZI_(G),SZJ_(G),SZK_(GV)) ! East edge thicknesses in the zonal PPM reconstruction [H ~> m or kg m-2]
-  real :: h_S(SZI_(G),SZJ_(G),SZK_(GV)) ! South edge thicknesses in the meridional PPM reconstruction [H ~> m or kg m-2]
-  real :: h_N(SZI_(G),SZJ_(G),SZK_(GV)) ! North edge thicknesses in the meridional PPM reconstruction [H ~> m or kg m-2]
-
-  call zonal_edge_thickness(h, h_W, h_E, G, GV, US, CS, OBC)
-  call zonal_mass_flux(u, h, h_W, h_E, uh, dt, G, GV, US, CS, OBC, pbv%por_face_areaU)
-
-  call meridional_edge_thickness(h, h_S, h_N, G, GV, US, CS, OBC)
-  call meridional_mass_flux(v, h, h_S, h_N, vh, dt, G, GV, US, CS, OBC, pbv%por_face_areaV)
-
-end subroutine continuity_3d_fluxes
-
-!> Find the vertical sum of the thickness fluxes from the continuity solver without actually
-!! updating the layer thicknesses.  Because the fluxes in the two directions are calculated
-!! based on the input thicknesses, which are not updated between the directions, the fluxes
-!! returned here are not the same as those that would be returned by a call to continuity.
-subroutine continuity_2d_fluxes(u, v, h, uhbt, vhbt, dt, G, GV, US, CS, OBC, pbv)
-  type(ocean_grid_type),   intent(inout) :: G   !< Ocean grid structure.
-  type(verticalGrid_type), intent(in)    :: GV  !< Vertical grid structure.
-  real, dimension(SZIB_(G),SZJ_(G),SZK_(GV)), &
-                           intent(in)    :: u   !< Zonal velocity [L T-1 ~> m s-1].
-  real, dimension(SZI_(G),SZJB_(G),SZK_(GV)), &
-                           intent(in)    :: v   !< Meridional velocity [L T-1 ~> m s-1].
-  real, dimension(SZI_(G),SZJ_(G),SZK_(GV)),  &
-                           intent(in)    :: h   !< Layer thickness [H ~> m or kg m-2].
-  real, dimension(SZIB_(G),SZJ_(G)), &
-                           intent(out)   :: uhbt !< Vertically summed thickness flux through
-                                                !! zonal faces [H L2 T-1 ~> m3 s-1 or kg s-1].
-  real, dimension(SZI_(G),SZJB_(G)), &
-                           intent(out)   :: vhbt !< Vertically summed thickness flux through
-                                                !! meridional faces [H L2 T-1 ~> m3 s-1 or kg s-1].
-  real,                    intent(in)    :: dt  !< Time increment [T ~> s].
-  type(unit_scale_type),   intent(in)    :: US  !< A dimensional unit scaling type
-  type(continuity_CS),     intent(in)    :: CS  !< Control structure for mom_continuity.
-  type(ocean_OBC_type),    pointer       :: OBC !< Open boundaries control structure.
-  type(porous_barrier_type), intent(in)  :: pbv !< porous barrier fractional cell metrics
-
-  ! Local variables
-  real :: h_W(SZI_(G),SZJ_(G),SZK_(GV)) ! West edge thicknesses in the zonal PPM reconstruction [H ~> m or kg m-2]
-  real :: h_E(SZI_(G),SZJ_(G),SZK_(GV)) ! East edge thicknesses in the zonal PPM reconstruction [H ~> m or kg m-2]
-  real :: h_S(SZI_(G),SZJ_(G),SZK_(GV)) ! South edge thicknesses in the meridional PPM reconstruction [H ~> m or kg m-2]
-  real :: h_N(SZI_(G),SZJ_(G),SZK_(GV)) ! North edge thicknesses in the meridional PPM reconstruction [H ~> m or kg m-2]
-
-  call zonal_edge_thickness(h, h_W, h_E, G, GV, US, CS, OBC)
-  call zonal_BT_mass_flux(u, h, h_W, h_E, uhbt, dt, G, GV, US, CS, OBC, pbv%por_face_areaU)
-
-  call meridional_edge_thickness(h, h_S, h_N, G, GV, US, CS, OBC)
-  call meridional_BT_mass_flux(v, h, h_S, h_N, vhbt, dt, G, GV, US, CS, OBC, pbv%por_face_areaV)
-
-end subroutine continuity_2d_fluxes
-
-
-!> Correct the velocities to give the specified depth-integrated transports by applying a
-!! barotropic acceleration (subject to viscous drag) to the velocities.
-subroutine continuity_adjust_vel(u, v, h, dt, G, GV, US, CS, OBC, pbv, uhbt, vhbt, visc_rem_u, visc_rem_v)
-  type(ocean_grid_type),   intent(inout) :: G   !< Ocean grid structure.
-  type(verticalGrid_type), intent(in)    :: GV  !< Vertical grid structure.
-  real, dimension(SZIB_(G),SZJ_(G),SZK_(GV)), &
-                           intent(inout) :: u   !< Zonal velocity, which will be adjusted to
-                                                !! give uhbt as the depth-integrated
-                                                !! transport [L T-1 ~> m s-1].
-  real, dimension(SZI_(G),SZJB_(G),SZK_(GV)), &
-                           intent(inout) :: v   !< Meridional velocity, which will be adjusted
-                                                !! to give vhbt as the depth-integrated
-                                                !! transport [L T-1 ~> m s-1].
-  real, dimension(SZI_(G),SZJ_(G),SZK_(GV)),  &
-                           intent(in)    :: h   !< Layer thickness [H ~> m or kg m-2].
-  real,                    intent(in)    :: dt  !< Time increment [T ~> s].
-  type(unit_scale_type),   intent(in)    :: US  !< A dimensional unit scaling type
-  type(continuity_CS),     intent(in)    :: CS  !< Control structure for mom_continuity.
-  type(ocean_OBC_type),    pointer       :: OBC !< Open boundaries control structure.
-  type(porous_barrier_type), intent(in)  :: pbv !< porous barrier fractional cell metrics
-  real, dimension(SZIB_(G),SZJ_(G)), &
-                           intent(in)    :: uhbt !< The vertically summed thickness flux through
-                                                !! zonal faces [H L2 T-1 ~> m3 s-1 or kg s-1].
-  real, dimension(SZI_(G),SZJB_(G)), &
-                           intent(in)    :: vhbt !< The vertically summed thickness flux through
-                                                !! meridional faces [H L2 T-1 ~> m3 s-1 or kg s-1].
-  real, dimension(SZIB_(G),SZJ_(G),SZK_(GV)), &
-                 optional, intent(in)    :: visc_rem_u !< Both the fraction of the zonal momentum
-                                                !! that remains after a time-step of viscosity, and
-                                                !! the fraction of a time-step's worth of a barotropic
-                                                !! acceleration that a layer experiences after viscosity
-                                                !! is applied [nondim].  This goes between 0 (at the
-                                                !! bottom) and 1 (far above the bottom).  When this
-                                                !! column is under an ice shelf, this also goes to 0
-                                                !! at the top due to the no-slip boundary condition there.
-  real, dimension(SZI_(G),SZJB_(G),SZK_(GV)), &
-                 optional, intent(in)    :: visc_rem_v !< Both the fraction of the meridional momentum
-                                                !! that remains after a time-step of viscosity, and
-                                                !! the fraction of a time-step's worth of a barotropic
-                                                !! acceleration that a layer experiences after viscosity
-                                                !! is applied [nondim].  This goes between 0 (at the
-                                                !! bottom) and 1 (far above the bottom).  When this
-                                                !! column is under an ice shelf, this also goes to 0
-                                                !! at the top due to the no-slip boundary condition there.
-
-  ! Local variables
-  real, dimension(SZIB_(G),SZJ_(G),SZK_(GV)) :: u_in  !< Input zonal velocity [L T-1 ~> m s-1]
-  real, dimension(SZI_(G),SZJB_(G),SZK_(GV)) :: v_in  !< Input meridional velocity [L T-1 ~> m s-1]
-  real, dimension(SZIB_(G),SZJ_(G),SZK_(GV)) :: uh  !< Volume flux through zonal faces =
-                                                !! u*h*dy [H L2 T-1 ~> m3 s-1 or kg s-1].
-  real, dimension(SZI_(G),SZJB_(G),SZK_(GV)) :: vh  !< Volume flux through meridional faces =
-                                                !! v*h*dx [H L2 T-1 ~> m3 s-1 or kg s-1].
-  real :: h_W(SZI_(G),SZJ_(G),SZK_(GV)) ! West edge thicknesses in the zonal PPM reconstruction [H ~> m or kg m-2]
-  real :: h_E(SZI_(G),SZJ_(G),SZK_(GV)) ! East edge thicknesses in the zonal PPM reconstruction [H ~> m or kg m-2]
-  real :: h_S(SZI_(G),SZJ_(G),SZK_(GV)) ! South edge thicknesses in the meridional PPM reconstruction [H ~> m or kg m-2]
-  real :: h_N(SZI_(G),SZJ_(G),SZK_(GV)) ! North edge thicknesses in the meridional PPM reconstruction [H ~> m or kg m-2]
-
-  ! It might not be necessary to separate the input velocity array from the adjusted velocities,
-  ! but it seems safer to do so, even if it might be less efficient.
-  u_in(:,:,:) = u(:,:,:)
-  v_in(:,:,:) = v(:,:,:)
-
-  call zonal_edge_thickness(h, h_W, h_E, G, GV, US, CS, OBC)
-  call zonal_mass_flux(u_in, h, h_W, h_E, uh, dt, G, GV, US, CS, OBC, pbv%por_face_areaU, &
-                       uhbt=uhbt, visc_rem_u=visc_rem_u, u_cor=u)
-
-  call meridional_edge_thickness(h, h_S, h_N, G, GV, US, CS, OBC)
-  call meridional_mass_flux(v_in, h, h_S, h_N, vh, dt, G, GV, US, CS, OBC, pbv%por_face_areaV, &
-                            vhbt=vhbt, visc_rem_v=visc_rem_v, v_cor=v)
-
-end subroutine continuity_adjust_vel
+public zonal_mass_flux, meridional_mass_flux
+public zonal_edge_thickness, meridional_edge_thickness
+public continuity_zonal_convergence, continuity_merdional_convergence
+public zonal_flux_thickness, meridional_flux_thickness
+public zonal_BT_mass_flux, meridional_BT_mass_flux
+public set_continuity_loop_bounds, cont_loop_bounds_type
 
 end module MOM_continuity

--- a/src/core/MOM_continuity.F90
+++ b/src/core/MOM_continuity.F90
@@ -9,6 +9,7 @@ use MOM_continuity_PPM, only : continuity_init=>continuity_PPM_init
 use MOM_continuity_PPM, only : continuity_CS=>continuity_PPM_CS
 use MOM_continuity_PPM, only : zonal_edge_thickness, meridional_edge_thickness
 use MOM_continuity_PPM, only : zonal_mass_flux, meridional_mass_flux
+use MOM_continuity_PPM, only : zonal_BT_mass_flux, meridional_BT_mass_flux
 use MOM_diag_mediator, only : time_type
 use MOM_grid, only : ocean_grid_type
 use MOM_open_boundary, only : ocean_OBC_type
@@ -101,29 +102,12 @@ subroutine continuity_2d_fluxes(u, v, h, uhbt, vhbt, dt, G, GV, US, CS, OBC, pbv
   real :: h_E(SZI_(G),SZJ_(G),SZK_(GV)) ! East edge thicknesses in the zonal PPM reconstruction [H ~> m or kg m-2]
   real :: h_S(SZI_(G),SZJ_(G),SZK_(GV)) ! South edge thicknesses in the meridional PPM reconstruction [H ~> m or kg m-2]
   real :: h_N(SZI_(G),SZJ_(G),SZK_(GV)) ! North edge thicknesses in the meridional PPM reconstruction [H ~> m or kg m-2]
-  real :: uh(SZIB_(G),SZJ_(G),SZK_(GV)) ! Thickness fluxes through zonal faces, u*h*dy [H L2 T-1 ~> m3 s-1 or kg s-1]
-  real :: vh(SZI_(G),SZJB_(G),SZK_(GV)) ! Thickness fluxes through v-point faces, v*h*dx [H L2 T-1 ~> m3 s-1 or kg s-1]
-  integer :: i, j, k
-
-  uh(:,:,:) = 0.0
-  vh(:,:,:) = 0.0
 
   call zonal_edge_thickness(h, h_W, h_E, G, GV, US, CS, OBC)
-  call zonal_mass_flux(u, h, h_W, h_E, uh, dt, G, GV, US, CS, OBC, pbv%por_face_areaU)
+  call zonal_BT_mass_flux(u, h, h_W, h_E, uhbt, dt, G, GV, US, CS, OBC, pbv%por_face_areaU)
 
   call meridional_edge_thickness(h, h_S, h_N, G, GV, US, CS, OBC)
-  call meridional_mass_flux(v, h, h_S, h_N, vh, dt, G, GV, US, CS, OBC, pbv%por_face_areaV)
-
-  uhbt(:,:) = 0.0
-  vhbt(:,:) = 0.0
-
-  do k=1,GV%ke ; do j=G%jsc,G%jec ; do I=G%isc-1,G%iec
-    uhbt(I,j) = uhbt(I,j) + uh(I,j,k)
-  enddo ; enddo ; enddo
-
-  do k=1,GV%ke ; do J=G%jsc-1,G%jec ; do i=G%isc,G%iec
-    vhbt(I,j) = vhbt(I,j) + vh(I,j,k)
-  enddo ; enddo ; enddo
+  call meridional_BT_mass_flux(v, h, h_S, h_N, vhbt, dt, G, GV, US, CS, OBC, pbv%por_face_areaV)
 
 end subroutine continuity_2d_fluxes
 

--- a/src/core/MOM_continuity.F90
+++ b/src/core/MOM_continuity.F90
@@ -3,13 +3,12 @@ module MOM_continuity
 
 ! This file is part of MOM6. See LICENSE.md for the license.
 
-use MOM_continuity_PPM, only : continuity_PPM, zonal_mass_flux, meridional_mass_flux
-use MOM_continuity_PPM, only : continuity_PPM_stencil, continuity_PPM_init
-use MOM_continuity_PPM, only : continuity_PPM_CS
-use MOM_diag_mediator, only : time_type, diag_ctrl
-use MOM_error_handler, only : MOM_error, MOM_mesg, FATAL, WARNING, is_root_pe
-use MOM_file_parser, only : get_param, log_version, param_file_type
-use MOM_string_functions, only : uppercase
+use MOM_continuity_PPM, only : continuity=>continuity_PPM
+use MOM_continuity_PPM, only : continuity_stencil=>continuity_PPM_stencil
+use MOM_continuity_PPM, only : continuity_init=>continuity_PPM_init
+use MOM_continuity_PPM, only : continuity_CS=>continuity_PPM_CS
+use MOM_continuity_PPM, only : zonal_mass_flux, meridional_mass_flux
+use MOM_diag_mediator, only : time_type
 use MOM_grid, only : ocean_grid_type
 use MOM_open_boundary, only : ocean_OBC_type
 use MOM_unit_scaling, only : unit_scale_type
@@ -20,20 +19,9 @@ implicit none ; private
 
 #include <MOM_memory.h>
 
-public continuity, continuity_fluxes, continuity_adjust_vel, continuity_init, continuity_stencil
-
-!> Control structure for mom_continuity
-type, public :: continuity_CS ; private
-  integer :: continuity_scheme !< Selects the discretization for the continuity solver.
-                               !! Valid values are:
-                               !! - PPM - A directionally split piecewise parabolic reconstruction solver.
-                               !! The default, PPM, seems most appropriate for use with our current
-                               !! time-splitting strategies.
-  type(continuity_PPM_CS) :: PPM  !< Control structure for mom_continuity_ppm
-end type continuity_CS
-
-integer, parameter :: PPM_SCHEME = 1 !< Enumerated constant to select PPM
-character(len=20), parameter :: PPM_STRING = "PPM" !< String to select PPM
+! These are direct pass-throughs of routines in continuity_PPM
+public continuity, continuity_init, continuity_stencil, continuity_CS
+public continuity_fluxes, continuity_adjust_vel
 
 !> Finds the thickness fluxes from the continuity solver or their vertical sum without
 !! actually updating the layer thicknesses.
@@ -42,75 +30,6 @@ interface continuity_fluxes
 end interface continuity_fluxes
 
 contains
-
-!> Time steps the layer thicknesses, using a monotonically or positive-definite limited, directionally
-!! split PPM scheme, based on Lin (1994).
-subroutine continuity(u, v, hin, h, uh, vh, dt, G, GV, US, CS, OBC, pbv, uhbt, vhbt, &
-                      visc_rem_u, visc_rem_v, u_cor, v_cor, BT_cont)
-  type(ocean_grid_type),   intent(inout) :: G   !< Ocean grid structure.
-  type(verticalGrid_type), intent(in)    :: GV  !< Vertical grid structure.
-  real, dimension(SZIB_(G),SZJ_(G),SZK_(GV)), &
-                           intent(in)    :: u   !< Zonal velocity [L T-1 ~> m s-1].
-  real, dimension(SZI_(G),SZJB_(G),SZK_(GV)), &
-                           intent(in)    :: v   !< Meridional velocity [L T-1 ~> m s-1].
-  real, dimension(SZI_(G),SZJ_(G),SZK_(GV)),  &
-                           intent(in)    :: hin !< Initial layer thickness [H ~> m or kg m-2].
-  real, dimension(SZI_(G),SZJ_(G),SZK_(GV)),  &
-                           intent(inout) :: h   !< Final layer thickness [H ~> m or kg m-2].
-  real, dimension(SZIB_(G),SZJ_(G),SZK_(GV)), &
-                           intent(out)   :: uh  !< Volume flux through zonal faces =
-                                                !! u*h*dy [H L2 T-1 ~> m3 s-1 or kg s-1].
-  real, dimension(SZI_(G),SZJB_(G),SZK_(GV)), &
-                           intent(out)   :: vh  !< Volume flux through meridional faces =
-                                                !! v*h*dx [H L2 T-1 ~> m3 s-1 or kg s-1].
-  real,                    intent(in)    :: dt  !< Time increment [T ~> s].
-  type(unit_scale_type),   intent(in)    :: US  !< A dimensional unit scaling type
-  type(continuity_CS),     intent(in)    :: CS  !< Control structure for mom_continuity.
-  type(ocean_OBC_type),    pointer       :: OBC !< Open boundaries control structure.
-  type(porous_barrier_type), intent(in)  :: pbv !< porous barrier fractional cell metrics
-  real, dimension(SZIB_(G),SZJ_(G)), &
-                 optional, intent(in)    :: uhbt !< The vertically summed volume flux through
-                                                !! zonal faces [H L2 T-1 ~> m3 s-1 or kg s-1].
-  real, dimension(SZI_(G),SZJB_(G)), &
-                 optional, intent(in)    :: vhbt !< The vertically summed volume flux through
-                                                !! meridional faces [H L2 T-1 ~> m3 s-1 or kg s-1].
-  real, dimension(SZIB_(G),SZJ_(G),SZK_(GV)), &
-                 optional, intent(in)    :: visc_rem_u !< Both the fraction of
-          !! zonal momentum that remains after a time-step of viscosity, and the fraction of a time-step's
-          !! worth of a barotropic acceleration that a layer experiences after viscosity is applied [nondim].
-          !! Non-dimensional between 0 (at the bottom) and 1 (far above the bottom).  When this column is
-          !! under an ice shelf, this can also go to 0 at the top due to the no-slip boundary condition there.
-  real, dimension(SZI_(G),SZJB_(G),SZK_(GV)), &
-                 optional, intent(in)    :: visc_rem_v !< Both the fraction of
-          !! meridional momentum that remains after a time-step of viscosity, and the fraction of a time-step's
-          !! worth of a barotropic acceleration that a layer experiences after viscosity is applied [nondim].
-          !! Non-dimensional between 0 (at the bottom) and 1 (far above the bottom).  When this column is
-          !! under an ice shelf, this can also go to 0 at the top due to the no-slip boundary condition there.
-  real, dimension(SZIB_(G),SZJ_(G),SZK_(GV)), &
-                 optional, intent(out)   :: u_cor !< The zonal velocities that
-          !! give uhbt as the depth-integrated transport [L T-1 ~> m s-1].
-  real, dimension(SZI_(G),SZJB_(G),SZK_(GV)), &
-                 optional, intent(out)   :: v_cor !< The meridional velocities that
-          !! give vhbt as the depth-integrated transport [L T-1 ~> m s-1].
-  type(BT_cont_type), &
-                 optional, pointer       :: BT_cont !< A structure with elements
-          !! that describe the effective open face areas as a function of barotropic flow.
-
-  if (present(visc_rem_u) .neqv. present(visc_rem_v)) call MOM_error(FATAL, &
-      "MOM_continuity: Either both visc_rem_u and visc_rem_v or neither"// &
-       " one must be present in call to continuity.")
-  if (present(u_cor) .neqv. present(v_cor)) call MOM_error(FATAL, &
-      "MOM_continuity: Either both u_cor and v_cor or neither"// &
-       " one must be present in call to continuity.")
-
-  if (CS%continuity_scheme == PPM_SCHEME) then
-    call continuity_PPM(u, v, hin, h, uh, vh, dt, G, GV, US, CS%PPM, OBC, pbv, uhbt, vhbt, &
-                        visc_rem_u, visc_rem_v, u_cor, v_cor, BT_cont=BT_cont)
-  else
-    call MOM_error(FATAL, "continuity: Unrecognized value of continuity_scheme")
-  endif
-
-end subroutine continuity
 
 !> Finds the thickness fluxes from the continuity solver without actually updating the
 !! layer thicknesses.  Because the fluxes in the two directions are calculated based on the
@@ -137,13 +56,9 @@ subroutine continuity_3d_fluxes(u, v, h, uh, vh, dt, G, GV, US, CS, OBC, pbv)
   type(ocean_OBC_type),    pointer       :: OBC !< Open boundaries control structure.
   type(porous_barrier_type), intent(in)  :: pbv !< porous barrier fractional cell metrics
 
-  if (CS%continuity_scheme == PPM_SCHEME) then
-    call zonal_mass_flux(u, h, uh, dt, G, GV, US, CS%PPM, OBC, pbv%por_face_areaU)
+    call zonal_mass_flux(u, h, uh, dt, G, GV, US, CS, OBC, pbv%por_face_areaU)
 
-    call meridional_mass_flux(v, h, vh, dt, G, GV, US, CS%PPM, OBC, pbv%por_face_areaV)
-  else
-    call MOM_error(FATAL, "continuity: Unrecognized value of continuity_scheme")
-  endif
+    call meridional_mass_flux(v, h, vh, dt, G, GV, US, CS, OBC, pbv%por_face_areaV)
 
 end subroutine continuity_3d_fluxes
 
@@ -182,13 +97,9 @@ subroutine continuity_2d_fluxes(u, v, h, uhbt, vhbt, dt, G, GV, US, CS, OBC, pbv
   uh(:,:,:) = 0.0
   vh(:,:,:) = 0.0
 
-  if (CS%continuity_scheme == PPM_SCHEME) then
-    call zonal_mass_flux(u, h, uh, dt, G, GV, US, CS%PPM, OBC, pbv%por_face_areaU)
+  call zonal_mass_flux(u, h, uh, dt, G, GV, US, CS, OBC, pbv%por_face_areaU)
 
-    call meridional_mass_flux(v, h, vh, dt, G, GV, US, CS%PPM, OBC, pbv%por_face_areaV)
-  else
-    call MOM_error(FATAL, "continuity: Unrecognized value of continuity_scheme")
-  endif
+  call meridional_mass_flux(v, h, vh, dt, G, GV, US, CS, OBC, pbv%por_face_areaV)
 
   uhbt(:,:) = 0.0
   vhbt(:,:) = 0.0
@@ -262,70 +173,12 @@ subroutine continuity_adjust_vel(u, v, h, dt, G, GV, US, CS, OBC, pbv, uhbt, vhb
   u_in(:,:,:) = u(:,:,:)
   v_in(:,:,:) = v(:,:,:)
 
-  if (CS%continuity_scheme == PPM_SCHEME) then
-    call zonal_mass_flux(u_in, h, uh, dt, G, GV, US, CS%PPM, OBC, pbv%por_face_areaU, &
-                         uhbt=uhbt, visc_rem_u=visc_rem_u, u_cor=u)
+  call zonal_mass_flux(u_in, h, uh, dt, G, GV, US, CS, OBC, pbv%por_face_areaU, &
+                       uhbt=uhbt, visc_rem_u=visc_rem_u, u_cor=u)
 
-    call meridional_mass_flux(v_in, h, vh, dt, G, GV, US, CS%PPM, OBC, pbv%por_face_areaV, &
-                              vhbt=vhbt, visc_rem_v=visc_rem_v, v_cor=v)
-  else
-    call MOM_error(FATAL, "continuity: Unrecognized value of continuity_scheme")
-  endif
+  call meridional_mass_flux(v_in, h, vh, dt, G, GV, US, CS, OBC, pbv%por_face_areaV, &
+                            vhbt=vhbt, visc_rem_v=visc_rem_v, v_cor=v)
 
 end subroutine continuity_adjust_vel
-
-!> Initializes continuity_cs
-subroutine continuity_init(Time, G, GV, US, param_file, diag, CS)
-  type(time_type), target, intent(in)    :: Time       !< Current model time.
-  type(ocean_grid_type),   intent(in)    :: G          !< Ocean grid structure.
-  type(verticalGrid_type), intent(in)    :: GV         !< Vertical grid structure.
-  type(unit_scale_type),   intent(in)    :: US  !< A dimensional unit scaling type
-  type(param_file_type),   intent(in)    :: param_file !< Parameter file handles.
-  type(diag_ctrl), target, intent(inout) :: diag       !< Diagnostics control structure.
-  type(continuity_CS),     intent(inout) :: CS         !< Control structure for mom_continuity.
-
-  ! This include declares and sets the variable "version".
-# include "version_variable.h"
-  character(len=40)  :: mdl = "MOM_continuity" ! This module's name.
-  character(len=20)  :: tmpstr
-
-  ! Read all relevant parameters and write them to the model log.
-  call log_version(param_file, mdl, version, "")
-  call get_param(param_file, mdl, "CONTINUITY_SCHEME", tmpstr, &
-                 "CONTINUITY_SCHEME selects the discretization for the "//&
-                 "continuity solver. The only valid value currently is: \n"//&
-                 "\t PPM - use a positive-definite (or monotonic) \n"//&
-                 "\t       piecewise parabolic reconstruction solver.", &
-                 default=PPM_STRING)
-
-  tmpstr = uppercase(tmpstr) ; CS%continuity_scheme = 0
-  select case (trim(tmpstr))
-    case (PPM_STRING) ; CS%continuity_scheme = PPM_SCHEME
-    case default
-      call MOM_mesg('continuity_init: CONTINUITY_SCHEME ="'//trim(tmpstr)//'"', 0)
-      call MOM_mesg("continuity_init: The only valid value is currently "// &
-                     trim(PPM_STRING), 0)
-      call MOM_error(FATAL, "continuity_init: Unrecognized setting "// &
-            "#define CONTINUITY_SCHEME "//trim(tmpstr)//" found in input file.")
-  end select
-
-  if (CS%continuity_scheme == PPM_SCHEME) then
-    call continuity_PPM_init(Time, G, GV, US, param_file, diag, CS%PPM)
-  endif
-
-end subroutine continuity_init
-
-
-!> continuity_stencil returns the continuity solver stencil size
-function continuity_stencil(CS) result(stencil)
-  type(continuity_CS), intent(in) :: CS !< Module's control structure.
-  integer ::  stencil !< The continuity solver stencil size with the current settings.
-
-  stencil = 1
-
-  if (CS%continuity_scheme == PPM_SCHEME) then
-    stencil = continuity_PPM_stencil(CS%PPM)
-  endif
-end function continuity_stencil
 
 end module MOM_continuity

--- a/src/core/MOM_continuity_PPM.F90
+++ b/src/core/MOM_continuity_PPM.F90
@@ -19,6 +19,7 @@ implicit none ; private
 #include <MOM_memory.h>
 
 public continuity_PPM, continuity_PPM_init, continuity_PPM_stencil
+public continuity_fluxes, continuity_adjust_vel
 public zonal_mass_flux, meridional_mass_flux
 public zonal_edge_thickness, meridional_edge_thickness
 public continuity_zonal_convergence, continuity_merdional_convergence
@@ -71,6 +72,12 @@ type, public :: cont_loop_bounds_type ; private
   integer :: ish, ieh, jsh, jeh
   !>@}
 end type cont_loop_bounds_type
+
+!> Finds the thickness fluxes from the continuity solver or their vertical sum without
+!! actually updating the layer thicknesses.
+interface continuity_fluxes
+  module procedure continuity_3d_fluxes, continuity_2d_fluxes
+end interface continuity_fluxes
 
 contains
 
@@ -179,6 +186,156 @@ subroutine continuity_PPM(u, v, hin, h, uh, vh, dt, G, GV, US, CS, OBC, pbv, uhb
   endif
 
 end subroutine continuity_PPM
+
+!> Finds the thickness fluxes from the continuity solver without actually updating the
+!! layer thicknesses.  Because the fluxes in the two directions are calculated based on the
+!! input thicknesses, which are not updated between the direcitons, the fluxes returned here
+!! are not the same as those that would be returned by a call to continuity.
+subroutine continuity_3d_fluxes(u, v, h, uh, vh, dt, G, GV, US, CS, OBC, pbv)
+  type(ocean_grid_type),   intent(inout) :: G   !< Ocean grid structure.
+  type(verticalGrid_type), intent(in)    :: GV  !< Vertical grid structure.
+  real, dimension(SZIB_(G),SZJ_(G),SZK_(GV)), &
+                           intent(in)    :: u   !< Zonal velocity [L T-1 ~> m s-1].
+  real, dimension(SZI_(G),SZJB_(G),SZK_(GV)), &
+                           intent(in)    :: v   !< Meridional velocity [L T-1 ~> m s-1].
+  real, dimension(SZI_(G),SZJ_(G),SZK_(GV)),  &
+                           intent(in)    :: h   !< Layer thickness [H ~> m or kg m-2].
+  real, dimension(SZIB_(G),SZJ_(G),SZK_(GV)), &
+                           intent(out)   :: uh  !< Thickness fluxes through zonal faces,
+                                                !! u*h*dy [H L2 T-1 ~> m3 s-1 or kg s-1].
+  real, dimension(SZI_(G),SZJB_(G),SZK_(GV)), &
+                           intent(out)   :: vh  !< Thickness fluxes through meridional faces,
+                                                !! v*h*dx [H L2 T-1 ~> m3 s-1 or kg s-1].
+  real,                    intent(in)    :: dt  !< Time increment [T ~> s].
+  type(unit_scale_type),   intent(in)    :: US  !< A dimensional unit scaling type
+  type(continuity_PPM_CS), intent(in)    :: CS  !< Control structure for mom_continuity.
+  type(ocean_OBC_type),    pointer       :: OBC !< Open boundaries control structure.
+  type(porous_barrier_type), intent(in)  :: pbv !< porous barrier fractional cell metrics
+
+  ! Local variables
+  real :: h_W(SZI_(G),SZJ_(G),SZK_(GV)) ! West edge thicknesses in the zonal PPM reconstruction [H ~> m or kg m-2]
+  real :: h_E(SZI_(G),SZJ_(G),SZK_(GV)) ! East edge thicknesses in the zonal PPM reconstruction [H ~> m or kg m-2]
+  real :: h_S(SZI_(G),SZJ_(G),SZK_(GV)) ! South edge thicknesses in the meridional PPM reconstruction [H ~> m or kg m-2]
+  real :: h_N(SZI_(G),SZJ_(G),SZK_(GV)) ! North edge thicknesses in the meridional PPM reconstruction [H ~> m or kg m-2]
+
+  call zonal_edge_thickness(h, h_W, h_E, G, GV, US, CS, OBC)
+  call zonal_mass_flux(u, h, h_W, h_E, uh, dt, G, GV, US, CS, OBC, pbv%por_face_areaU)
+
+  call meridional_edge_thickness(h, h_S, h_N, G, GV, US, CS, OBC)
+  call meridional_mass_flux(v, h, h_S, h_N, vh, dt, G, GV, US, CS, OBC, pbv%por_face_areaV)
+
+end subroutine continuity_3d_fluxes
+
+!> Find the vertical sum of the thickness fluxes from the continuity solver without actually
+!! updating the layer thicknesses.  Because the fluxes in the two directions are calculated
+!! based on the input thicknesses, which are not updated between the directions, the fluxes
+!! returned here are not the same as those that would be returned by a call to continuity.
+subroutine continuity_2d_fluxes(u, v, h, uhbt, vhbt, dt, G, GV, US, CS, OBC, pbv)
+  type(ocean_grid_type),   intent(inout) :: G   !< Ocean grid structure.
+  type(verticalGrid_type), intent(in)    :: GV  !< Vertical grid structure.
+  real, dimension(SZIB_(G),SZJ_(G),SZK_(GV)), &
+                           intent(in)    :: u   !< Zonal velocity [L T-1 ~> m s-1].
+  real, dimension(SZI_(G),SZJB_(G),SZK_(GV)), &
+                           intent(in)    :: v   !< Meridional velocity [L T-1 ~> m s-1].
+  real, dimension(SZI_(G),SZJ_(G),SZK_(GV)),  &
+                           intent(in)    :: h   !< Layer thickness [H ~> m or kg m-2].
+  real, dimension(SZIB_(G),SZJ_(G)), &
+                           intent(out)   :: uhbt !< Vertically summed thickness flux through
+                                                !! zonal faces [H L2 T-1 ~> m3 s-1 or kg s-1].
+  real, dimension(SZI_(G),SZJB_(G)), &
+                           intent(out)   :: vhbt !< Vertically summed thickness flux through
+                                                !! meridional faces [H L2 T-1 ~> m3 s-1 or kg s-1].
+  real,                    intent(in)    :: dt  !< Time increment [T ~> s].
+  type(unit_scale_type),   intent(in)    :: US  !< A dimensional unit scaling type
+  type(continuity_PPM_CS), intent(in)    :: CS  !< Control structure for mom_continuity.
+  type(ocean_OBC_type),    pointer       :: OBC !< Open boundaries control structure.
+  type(porous_barrier_type), intent(in)  :: pbv !< porous barrier fractional cell metrics
+
+  ! Local variables
+  real :: h_W(SZI_(G),SZJ_(G),SZK_(GV)) ! West edge thicknesses in the zonal PPM reconstruction [H ~> m or kg m-2]
+  real :: h_E(SZI_(G),SZJ_(G),SZK_(GV)) ! East edge thicknesses in the zonal PPM reconstruction [H ~> m or kg m-2]
+  real :: h_S(SZI_(G),SZJ_(G),SZK_(GV)) ! South edge thicknesses in the meridional PPM reconstruction [H ~> m or kg m-2]
+  real :: h_N(SZI_(G),SZJ_(G),SZK_(GV)) ! North edge thicknesses in the meridional PPM reconstruction [H ~> m or kg m-2]
+
+  call zonal_edge_thickness(h, h_W, h_E, G, GV, US, CS, OBC)
+  call zonal_BT_mass_flux(u, h, h_W, h_E, uhbt, dt, G, GV, US, CS, OBC, pbv%por_face_areaU)
+
+  call meridional_edge_thickness(h, h_S, h_N, G, GV, US, CS, OBC)
+  call meridional_BT_mass_flux(v, h, h_S, h_N, vhbt, dt, G, GV, US, CS, OBC, pbv%por_face_areaV)
+
+end subroutine continuity_2d_fluxes
+
+!> Correct the velocities to give the specified depth-integrated transports by applying a
+!! barotropic acceleration (subject to viscous drag) to the velocities.
+subroutine continuity_adjust_vel(u, v, h, dt, G, GV, US, CS, OBC, pbv, uhbt, vhbt, visc_rem_u, visc_rem_v)
+  type(ocean_grid_type),   intent(inout) :: G   !< Ocean grid structure.
+  type(verticalGrid_type), intent(in)    :: GV  !< Vertical grid structure.
+  real, dimension(SZIB_(G),SZJ_(G),SZK_(GV)), &
+                           intent(inout) :: u   !< Zonal velocity, which will be adjusted to
+                                                !! give uhbt as the depth-integrated
+                                                !! transport [L T-1 ~> m s-1].
+  real, dimension(SZI_(G),SZJB_(G),SZK_(GV)), &
+                           intent(inout) :: v   !< Meridional velocity, which will be adjusted
+                                                !! to give vhbt as the depth-integrated
+                                                !! transport [L T-1 ~> m s-1].
+  real, dimension(SZI_(G),SZJ_(G),SZK_(GV)),  &
+                           intent(in)    :: h   !< Layer thickness [H ~> m or kg m-2].
+  real,                    intent(in)    :: dt  !< Time increment [T ~> s].
+  type(unit_scale_type),   intent(in)    :: US  !< A dimensional unit scaling type
+  type(continuity_PPM_CS), intent(in)    :: CS  !< Control structure for mom_continuity.
+  type(ocean_OBC_type),    pointer       :: OBC !< Open boundaries control structure.
+  type(porous_barrier_type), intent(in)  :: pbv !< porous barrier fractional cell metrics
+  real, dimension(SZIB_(G),SZJ_(G)), &
+                           intent(in)    :: uhbt !< The vertically summed thickness flux through
+                                                !! zonal faces [H L2 T-1 ~> m3 s-1 or kg s-1].
+  real, dimension(SZI_(G),SZJB_(G)), &
+                           intent(in)    :: vhbt !< The vertically summed thickness flux through
+                                                !! meridional faces [H L2 T-1 ~> m3 s-1 or kg s-1].
+  real, dimension(SZIB_(G),SZJ_(G),SZK_(GV)), &
+                 optional, intent(in)    :: visc_rem_u !< Both the fraction of the zonal momentum
+                                                !! that remains after a time-step of viscosity, and
+                                                !! the fraction of a time-step's worth of a barotropic
+                                                !! acceleration that a layer experiences after viscosity
+                                                !! is applied [nondim].  This goes between 0 (at the
+                                                !! bottom) and 1 (far above the bottom).  When this
+                                                !! column is under an ice shelf, this also goes to 0
+                                                !! at the top due to the no-slip boundary condition there.
+  real, dimension(SZI_(G),SZJB_(G),SZK_(GV)), &
+                 optional, intent(in)    :: visc_rem_v !< Both the fraction of the meridional momentum
+                                                !! that remains after a time-step of viscosity, and
+                                                !! the fraction of a time-step's worth of a barotropic
+                                                !! acceleration that a layer experiences after viscosity
+                                                !! is applied [nondim].  This goes between 0 (at the
+                                                !! bottom) and 1 (far above the bottom).  When this
+                                                !! column is under an ice shelf, this also goes to 0
+                                                !! at the top due to the no-slip boundary condition there.
+
+  ! Local variables
+  real, dimension(SZIB_(G),SZJ_(G),SZK_(GV)) :: u_in  !< Input zonal velocity [L T-1 ~> m s-1]
+  real, dimension(SZI_(G),SZJB_(G),SZK_(GV)) :: v_in  !< Input meridional velocity [L T-1 ~> m s-1]
+  real, dimension(SZIB_(G),SZJ_(G),SZK_(GV)) :: uh  !< Volume flux through zonal faces =
+                                                !! u*h*dy [H L2 T-1 ~> m3 s-1 or kg s-1].
+  real, dimension(SZI_(G),SZJB_(G),SZK_(GV)) :: vh  !< Volume flux through meridional faces =
+                                                !! v*h*dx [H L2 T-1 ~> m3 s-1 or kg s-1].
+  real :: h_W(SZI_(G),SZJ_(G),SZK_(GV)) ! West edge thicknesses in the zonal PPM reconstruction [H ~> m or kg m-2]
+  real :: h_E(SZI_(G),SZJ_(G),SZK_(GV)) ! East edge thicknesses in the zonal PPM reconstruction [H ~> m or kg m-2]
+  real :: h_S(SZI_(G),SZJ_(G),SZK_(GV)) ! South edge thicknesses in the meridional PPM reconstruction [H ~> m or kg m-2]
+  real :: h_N(SZI_(G),SZJ_(G),SZK_(GV)) ! North edge thicknesses in the meridional PPM reconstruction [H ~> m or kg m-2]
+
+  ! It might not be necessary to separate the input velocity array from the adjusted velocities,
+  ! but it seems safer to do so, even if it might be less efficient.
+  u_in(:,:,:) = u(:,:,:)
+  v_in(:,:,:) = v(:,:,:)
+
+  call zonal_edge_thickness(h, h_W, h_E, G, GV, US, CS, OBC)
+  call zonal_mass_flux(u_in, h, h_W, h_E, uh, dt, G, GV, US, CS, OBC, pbv%por_face_areaU, &
+                       uhbt=uhbt, visc_rem_u=visc_rem_u, u_cor=u)
+
+  call meridional_edge_thickness(h, h_S, h_N, G, GV, US, CS, OBC)
+  call meridional_mass_flux(v_in, h, h_S, h_N, vh, dt, G, GV, US, CS, OBC, pbv%por_face_areaV, &
+                            vhbt=vhbt, visc_rem_v=visc_rem_v, v_cor=v)
+
+end subroutine continuity_adjust_vel
 
 
 !> Updates the thicknesses due to zonal thickness fluxes.

--- a/src/core/MOM_density_integrals.F90
+++ b/src/core/MOM_density_integrals.F90
@@ -141,14 +141,21 @@ subroutine int_density_dz_generic_pcm(T, S, z_t, z_b, rho_ref, rho_0, G_e, HI, &
   real,       optional, intent(in)  :: Z_0p !< The height at which the pressure is 0 [Z ~> m]
 
   ! Local variables
-  real :: T5(5), S5(5) ! Temperatures and salinities at five quadrature points [C ~> degC] and [S ~> ppt]
-  real :: p5(5)      ! Pressures at five quadrature points [R L2 T-2 ~> Pa]
-  real :: r5(5)      ! Densities at five quadrature points [R ~> kg m-3]
+  real :: T5((5*HI%iscB+1):(5*(HI%iecB+2)))  ! Temperatures along a line of subgrid locations [C ~> degC]
+  real :: S5((5*HI%iscB+1):(5*(HI%iecB+2)))  ! Salinities along a line of subgrid locations [S ~> ppt]
+  real :: p5((5*HI%iscB+1):(5*(HI%iecB+2)))  ! Pressures along a line of subgrid locations [R L2 T-2 ~> Pa]
+  real :: r5((5*HI%iscB+1):(5*(HI%iecB+2)))  ! Densities anomalies along a line of subgrid locations [R ~> kg m-3]
+  real :: T15((15*HI%iscB+1):(15*(HI%iecB+1))) ! Temperatures at an array of subgrid locations [C ~> degC]
+  real :: S15((15*HI%iscB+1):(15*(HI%iecB+1))) ! Salinities at an array of subgrid locations [S ~> ppt]
+  real :: p15((15*HI%iscB+1):(15*(HI%iecB+1))) ! Pressures at an array of subgrid locations [R L2 T-2 ~> Pa]
+  real :: r15((15*HI%iscB+1):(15*(HI%iecB+1))) ! Densities at an array of subgrid locations [R ~> kg m-3]
   real :: rho_anom   ! The depth averaged density anomaly [R ~> kg m-3]
   real, parameter :: C1_90 = 1.0/90.0  ! A rational constant [nondim]
   real :: GxRho      ! The product of the gravitational acceleration and reference density [R L2 Z-1 T-2 ~> Pa m-1]
   real :: I_Rho      ! The inverse of the Boussinesq density [R-1 ~> m3 kg-1]
   real :: dz         ! The layer thickness [Z ~> m]
+  real :: dz_x(5,HI%iscB:HI%iecB) ! Layer thicknesses along an x-line of subgrid locations [Z ~> m]
+  real :: dz_y(5,HI%isc:HI%iec)   ! Layer thicknesses along a y-line of subgrid locations [Z ~> m]
   real :: z0pres     ! The height at which the pressure is zero [Z ~> m]
   real :: hWght      ! A pressure-thickness below topography [Z ~> m]
   real :: hL, hR     ! Pressure-thicknesses of the columns to the left and right [Z ~> m]
@@ -162,7 +169,10 @@ subroutine int_density_dz_generic_pcm(T, S, z_t, z_b, rho_ref, rho_0, G_e, HI, &
   logical :: do_massWeight ! Indicates whether to do mass weighting.
   logical :: use_rho_ref ! Pass rho_ref to the equation of state for more accurate calculation
                          ! of density anomalies.
-  integer :: is, ie, js, je, Isq, Ieq, Jsq, Jeq, i, j, m, n
+  integer, dimension(2) :: EOSdom_h5  ! The 5-point h-point i-computational domain for the equation of state
+  integer, dimension(2) :: EOSdom_q15 ! The 3x5-point q-point i-computational domain for the equation of state
+  integer, dimension(2) :: EOSdom_h15 ! The 3x5-point h-point i-computational domain for the equation of state
+  integer :: is, ie, js, je, Isq, Ieq, Jsq, Jeq, i, j, m, n, pos
 
   ! These array bounds work for the indexing convention of the input arrays, but
   ! on the computational domain defined for the output arrays.
@@ -188,123 +198,169 @@ subroutine int_density_dz_generic_pcm(T, S, z_t, z_b, rho_ref, rho_0, G_e, HI, &
         "dz_neglect must be present if useMassWghtInterp is present and true.")
   endif ; endif
 
-  do j=Jsq,Jeq+1 ; do i=Isq,Ieq+1
-    dz = z_t(i,j) - z_b(i,j)
-    do n=1,5
-      T5(n) = T(i,j) ; S5(n) = S(i,j)
-      p5(n) = -GxRho*((z_t(i,j) - z0pres) - 0.25*real(n-1)*dz)
+  ! Set the loop ranges for equation of state calculations at various points.
+  EOSdom_h5(1) = 1 ; EOSdom_h5(2) = 5*(Ieq-Isq+2)
+  EOSdom_q15(1) = 1 ; EOSdom_q15(2) = 15*(Ieq-Isq+1)
+  EOSdom_h15(1) = 1 ; EOSdom_h15(2) = 15*(HI%iec-HI%isc+1)
+
+  do j=Jsq,Jeq+1
+    do i=Isq,Ieq+1
+      dz = z_t(i,j) - z_b(i,j)
+      do n=1,5
+        T5(i*5+n) = T(i,j) ; S5(i*5+n) = S(i,j)
+        p5(i*5+n) = -GxRho*((z_t(i,j) - z0pres) - 0.25*real(n-1)*dz)
+      enddo
     enddo
+
     if (use_rho_ref) then
-      call calculate_density(T5, S5, p5, r5, EOS, rho_ref=rho_ref)
-      ! Use Boole's rule to estimate the pressure anomaly change.
-      rho_anom = C1_90*(7.0*(r5(1)+r5(5)) + 32.0*(r5(2)+r5(4)) + 12.0*r5(3))
+      call calculate_density(T5, S5, p5, r5, EOS, EOSdom_h5, rho_ref=rho_ref)
     else
-      call calculate_density(T5, S5, p5, r5, EOS)
-      ! Use Boole's rule to estimate the pressure anomaly change.
-      rho_anom = C1_90*(7.0*(r5(1)+r5(5)) + 32.0*(r5(2)+r5(4)) + 12.0*r5(3)) - rho_ref
+      call calculate_density(T5, S5, p5, r5, EOS, EOSdom_h5)
     endif
 
-    dpa(i,j) = G_e*dz*rho_anom
-    ! Use a Boole's-rule-like fifth-order accurate estimate of the double integral of
-    ! the pressure anomaly.
-    if (present(intz_dpa)) intz_dpa(i,j) = 0.5*G_e*dz**2 * &
-          (rho_anom - C1_90*(16.0*(r5(4)-r5(2)) + 7.0*(r5(5)-r5(1))) )
-  enddo ; enddo
+    do i=Isq,Ieq+1
+      ! Use Boole's rule to estimate the pressure anomaly change.
+      rho_anom = C1_90*(7.0*(r5(i*5+1)+r5(i*5+5)) + 32.0*(r5(i*5+2)+r5(i*5+4)) + 12.0*r5(i*5+3))
+      if (.not.use_rho_ref) rho_anom = rho_anom - rho_ref
+      dz = z_t(i,j) - z_b(i,j)
+      dpa(i,j) = G_e*dz*rho_anom
+      ! Use a Boole's-rule-like fifth-order accurate estimate of the double integral of
+      ! the pressure anomaly.
+      if (present(intz_dpa)) intz_dpa(i,j) = 0.5*G_e*dz**2 * &
+            (rho_anom - C1_90*(16.0*(r5(i*5+4)-r5(i*5+2)) + 7.0*(r5(i*5+5)-r5(i*5+1))) )
+    enddo
+  enddo
 
-  if (present(intx_dpa)) then ; do j=js,je ; do I=Isq,Ieq
-    ! hWght is the distance measure by which the cell is violation of
-    ! hydrostatic consistency. For large hWght we bias the interpolation of
-    ! T & S along the top and bottom integrals, akin to thickness weighting.
-    hWght = 0.0
-    if (do_massWeight) &
-      hWght = max(0., -bathyT(i,j)-z_t(i+1,j), -bathyT(i+1,j)-z_t(i,j))
-    if (hWght > 0.) then
-      hL = (z_t(i,j) - z_b(i,j)) + dz_neglect
-      hR = (z_t(i+1,j) - z_b(i+1,j)) + dz_neglect
-      hWght = hWght * ( (hL-hR)/(hL+hR) )**2
-      iDenom = 1.0 / ( hWght*(hR + hL) + hL*hR )
-      hWt_LL = (hWght*hL + hR*hL) * iDenom ; hWt_LR = (hWght*hR) * iDenom
-      hWt_RR = (hWght*hR + hR*hL) * iDenom ; hWt_RL = (hWght*hL) * iDenom
-    else
-      hWt_LL = 1.0 ; hWt_LR = 0.0 ; hWt_RR = 1.0 ; hWt_RL = 0.0
-    endif
-
-    intz(1) = dpa(i,j) ; intz(5) = dpa(i+1,j)
-    do m=2,4
-      ! T, S, and z are interpolated in the horizontal.  The z interpolation
-      ! is linear, but for T and S it may be thickness weighted.
-      wt_L = 0.25*real(5-m) ; wt_R = 1.0-wt_L
-      wtT_L = wt_L*hWt_LL + wt_R*hWt_RL ; wtT_R = wt_L*hWt_LR + wt_R*hWt_RR
-      dz = wt_L*(z_t(i,j) - z_b(i,j)) + wt_R*(z_t(i+1,j) - z_b(i+1,j))
-      T5(1) = wtT_L*T(i,j) + wtT_R*T(i+1,j)
-      S5(1) = wtT_L*S(i,j) + wtT_R*S(i+1,j)
-      p5(1) = -GxRho*((wt_L*z_t(i,j) + wt_R*z_t(i+1,j)) - z0pres)
-      do n=2,5
-        T5(n) = T5(1) ; S5(n) = S5(1) ; p5(n) = p5(n-1) + GxRho*0.25*dz
-      enddo
-      if (use_rho_ref) then
-        call calculate_density(T5, S5, p5, r5, EOS, rho_ref=rho_ref)
-        ! Use Boole's rule to estimate the pressure anomaly change.
-        intz(m) = G_e*dz*( C1_90*(7.0*(r5(1)+r5(5)) + 32.0*(r5(2)+r5(4)) + 12.0*r5(3)))
+  if (present(intx_dpa)) then ; do j=js,je
+    do I=Isq,Ieq
+      ! hWght is the distance measure by which the cell is violation of
+      ! hydrostatic consistency. For large hWght we bias the interpolation of
+      ! T & S along the top and bottom integrals, akin to thickness weighting.
+      hWght = 0.0
+      if (do_massWeight) &
+        hWght = max(0., -bathyT(i,j)-z_t(i+1,j), -bathyT(i+1,j)-z_t(i,j))
+      if (hWght > 0.) then
+        hL = (z_t(i,j) - z_b(i,j)) + dz_neglect
+        hR = (z_t(i+1,j) - z_b(i+1,j)) + dz_neglect
+        hWght = hWght * ( (hL-hR)/(hL+hR) )**2
+        iDenom = 1.0 / ( hWght*(hR + hL) + hL*hR )
+        hWt_LL = (hWght*hL + hR*hL) * iDenom ; hWt_LR = (hWght*hR) * iDenom
+        hWt_RR = (hWght*hR + hR*hL) * iDenom ; hWt_RL = (hWght*hL) * iDenom
       else
-        call calculate_density(T5, S5, p5, r5, EOS)
-        ! Use Boole's rule to estimate the pressure anomaly change.
-        intz(m) = G_e*dz*( C1_90*(7.0*(r5(1)+r5(5)) + 32.0*(r5(2)+r5(4)) + 12.0*r5(3)) - rho_ref )
+        hWt_LL = 1.0 ; hWt_LR = 0.0 ; hWt_RR = 1.0 ; hWt_RL = 0.0
       endif
 
+      do m=2,4
+        ! T, S, and z are interpolated in the horizontal.  The z interpolation
+        ! is linear, but for T and S it may be thickness weighted.
+        wt_L = 0.25*real(5-m) ; wt_R = 1.0-wt_L
+        wtT_L = wt_L*hWt_LL + wt_R*hWt_RL ; wtT_R = wt_L*hWt_LR + wt_R*hWt_RR
+        dz_x(m,i) = wt_L*(z_t(i,j) - z_b(i,j)) + wt_R*(z_t(i+1,j) - z_b(i+1,j))
+        pos = i*15+(m-2)*5
+        T15(pos+1) = wtT_L*T(i,j) + wtT_R*T(i+1,j)
+        S15(pos+1) = wtT_L*S(i,j) + wtT_R*S(i+1,j)
+        p15(pos+1) = -GxRho*((wt_L*z_t(i,j) + wt_R*z_t(i+1,j)) - z0pres)
+        do n=2,5
+          T15(pos+n) = T15(pos+1) ; S15(pos+n) = S15(pos+1)
+          p15(pos+n) = p15(pos+n-1) + GxRho*0.25*dz_x(m,i)
+        enddo
+      enddo
     enddo
-    ! Use Boole's rule to integrate the bottom pressure anomaly values in x.
-    intx_dpa(i,j) = C1_90*(7.0*(intz(1)+intz(5)) + 32.0*(intz(2)+intz(4)) + &
-                           12.0*intz(3))
-  enddo ; enddo ; endif
 
-  if (present(inty_dpa)) then ; do J=Jsq,Jeq ; do i=is,ie
-    ! hWght is the distance measure by which the cell is violation of
-    ! hydrostatic consistency. For large hWght we bias the interpolation of
-    ! T & S along the top and bottom integrals, akin to thickness weighting.
-    hWght = 0.0
-    if (do_massWeight) &
-      hWght = max(0., -bathyT(i,j)-z_t(i,j+1), -bathyT(i,j+1)-z_t(i,j))
-    if (hWght > 0.) then
-      hL = (z_t(i,j) - z_b(i,j)) + dz_neglect
-      hR = (z_t(i,j+1) - z_b(i,j+1)) + dz_neglect
-      hWght = hWght * ( (hL-hR)/(hL+hR) )**2
-      iDenom = 1.0 / ( hWght*(hR + hL) + hL*hR )
-      hWt_LL = (hWght*hL + hR*hL) * iDenom ; hWt_LR = (hWght*hR) * iDenom
-      hWt_RR = (hWght*hR + hR*hL) * iDenom ; hWt_RL = (hWght*hL) * iDenom
+    if (use_rho_ref) then
+      call calculate_density(T15, S15, p15, r15, EOS, EOSdom_q15, rho_ref=rho_ref)
     else
-      hWt_LL = 1.0 ; hWt_LR = 0.0 ; hWt_RR = 1.0 ; hWt_RL = 0.0
+      call calculate_density(T15, S15, p15, r15, EOS, EOSdom_q15)
     endif
 
-    intz(1) = dpa(i,j) ; intz(5) = dpa(i,j+1)
-    do m=2,4
-      ! T, S, and z are interpolated in the horizontal.  The z interpolation
-      ! is linear, but for T and S it may be thickness weighted.
-      wt_L = 0.25*real(5-m) ; wt_R = 1.0-wt_L
-      wtT_L = wt_L*hWt_LL + wt_R*hWt_RL ; wtT_R = wt_L*hWt_LR + wt_R*hWt_RR
-      dz = wt_L*(z_t(i,j) - z_b(i,j)) + wt_R*(z_t(i,j+1) - z_b(i,j+1))
-      T5(1) = wtT_L*T(i,j) + wtT_R*T(i,j+1)
-      S5(1) = wtT_L*S(i,j) + wtT_R*S(i,j+1)
-      p5(1) = -GxRho*((wt_L*z_t(i,j) + wt_R*z_t(i,j+1)) - z0pres)
-      do n=2,5
-        T5(n) = T5(1) ; S5(n) = S5(1)
-        p5(n) = p5(n-1) + GxRho*0.25*dz
-      enddo
+    do I=Isq,Ieq
+      intz(1) = dpa(i,j) ; intz(5) = dpa(i+1,j)
+      ! Use Boole's rule to estimate the pressure anomaly change.
       if (use_rho_ref) then
-        call calculate_density(T5, S5, p5, r5, EOS, rho_ref=rho_ref)
-        ! Use Boole's rule to estimate the pressure anomaly change.
-        intz(m) = G_e*dz*( C1_90*(7.0*(r5(1)+r5(5)) + 32.0*(r5(2)+r5(4)) + 12.0*r5(3)))
+        do m=2,4
+          pos = i*15+(m-2)*5
+          intz(m) = G_e*dz_x(m,i)*( C1_90*( 7.0*(r15(pos+1)+r15(pos+5)) + &
+                                           32.0*(r15(pos+2)+r15(pos+4)) + &
+                                           12.0*r15(pos+3)))
+        enddo
       else
-        call calculate_density(T5, S5, p5, r5, EOS)
-        ! Use Boole's rule to estimate the pressure anomaly change.
-        intz(m) = G_e*dz*( C1_90*(7.0*(r5(1)+r5(5)) + 32.0*(r5(2)+r5(4)) + 12.0*r5(3)) - rho_ref )
+        do m=2,4
+          pos = i*15+(m-2)*5
+          intz(m) = G_e*dz_x(m,i)*( C1_90*( 7.0*(r15(pos+1)+r15(pos+5)) + &
+                                           32.0*(r15(pos+2)+r15(pos+4)) + &
+                                           12.0*r15(pos+3)) - rho_ref )
+        enddo
+      endif
+      ! Use Boole's rule to integrate the bottom pressure anomaly values in x.
+      intx_dpa(i,j) = C1_90*(7.0*(intz(1)+intz(5)) + 32.0*(intz(2)+intz(4)) + &
+                             12.0*intz(3))
+    enddo
+  enddo ; endif
+
+  if (present(inty_dpa)) then ; do J=Jsq,Jeq
+    do i=is,ie
+      ! hWght is the distance measure by which the cell is violation of
+      ! hydrostatic consistency. For large hWght we bias the interpolation of
+      ! T & S along the top and bottom integrals, akin to thickness weighting.
+      hWght = 0.0
+      if (do_massWeight) &
+        hWght = max(0., -bathyT(i,j)-z_t(i,j+1), -bathyT(i,j+1)-z_t(i,j))
+      if (hWght > 0.) then
+        hL = (z_t(i,j) - z_b(i,j)) + dz_neglect
+        hR = (z_t(i,j+1) - z_b(i,j+1)) + dz_neglect
+        hWght = hWght * ( (hL-hR)/(hL+hR) )**2
+        iDenom = 1.0 / ( hWght*(hR + hL) + hL*hR )
+        hWt_LL = (hWght*hL + hR*hL) * iDenom ; hWt_LR = (hWght*hR) * iDenom
+        hWt_RR = (hWght*hR + hR*hL) * iDenom ; hWt_RL = (hWght*hL) * iDenom
+      else
+        hWt_LL = 1.0 ; hWt_LR = 0.0 ; hWt_RR = 1.0 ; hWt_RL = 0.0
       endif
 
+      do m=2,4
+        ! T, S, and z are interpolated in the horizontal.  The z interpolation
+        ! is linear, but for T and S it may be thickness weighted.
+        wt_L = 0.25*real(5-m) ; wt_R = 1.0-wt_L
+        wtT_L = wt_L*hWt_LL + wt_R*hWt_RL ; wtT_R = wt_L*hWt_LR + wt_R*hWt_RR
+        dz_y(m,i) = wt_L*(z_t(i,j) - z_b(i,j)) + wt_R*(z_t(i,j+1) - z_b(i,j+1))
+        pos = i*15+(m-2)*5
+        T15(pos+1) = wtT_L*T(i,j) + wtT_R*T(i,j+1)
+        S15(pos+1) = wtT_L*S(i,j) + wtT_R*S(i,j+1)
+        p15(pos+1) = -GxRho*((wt_L*z_t(i,j) + wt_R*z_t(i,j+1)) - z0pres)
+        do n=2,5
+          T15(pos+n) = T15(pos+1) ; S15(pos+n) = S15(pos+1)
+          p15(pos+n) = p15(pos+n-1) + GxRho*0.25*dz_y(m,i)
+        enddo
+      enddo
     enddo
-    ! Use Boole's rule to integrate the values.
-    inty_dpa(i,j) = C1_90*(7.0*(intz(1)+intz(5)) + 32.0*(intz(2)+intz(4)) + &
-                                     12.0*intz(3))
-  enddo ; enddo ; endif
+
+    if (use_rho_ref) then
+      call calculate_density(T15(15*HI%isc+1:), S15(15*HI%isc+1:), p15(15*HI%isc+1:), &
+                             r15(15*HI%isc+1:), EOS, EOSdom_h15, rho_ref=rho_ref)
+    else
+      call calculate_density(T15(15*HI%isc+1:), S15(15*HI%isc+1:), p15(15*HI%isc+1:), &
+                             r15(15*HI%isc+1:), EOS, EOSdom_h15)
+    endif
+
+    do i=is,ie
+      intz(1) = dpa(i,j) ; intz(5) = dpa(i,j+1)
+      ! Use Boole's rule to estimate the pressure anomaly change.
+      do m=2,4
+        pos = i*15+(m-2)*5
+        if (use_rho_ref) then
+          intz(m) = G_e*dz_y(m,i)*( C1_90*(7.0*(r15(pos+1)+r15(pos+5)) + &
+                                          32.0*(r15(pos+2)+r15(pos+4)) + &
+                                          12.0*r15(pos+3)))
+        else
+          intz(m) = G_e*dz_y(m,i)*( C1_90*(7.0*(r15(pos+1)+r15(pos+5)) + &
+                                          32.0*(r15(pos+2)+r15(pos+4)) + &
+                                          12.0*r15(pos+3)) - rho_ref )
+        endif
+      enddo
+      ! Use Boole's rule to integrate the values.
+      inty_dpa(i,j) = C1_90*(7.0*(intz(1)+intz(5)) + 32.0*(intz(2)+intz(4)) + &
+                                       12.0*intz(3))
+    enddo
+  enddo ; endif
 end subroutine int_density_dz_generic_pcm
 
 
@@ -414,10 +470,9 @@ subroutine int_density_dz_generic_plm(k, tv, T_t, T_b, S_t, S_b, e, rho_ref, &
   logical :: use_rho_ref ! Pass rho_ref to the equation of state for more accurate calculation
                          ! of density anomalies.
   logical :: use_varT, use_varS, use_covarTS ! Logicals for SGS variances fields
-  integer, dimension(2) :: EOSdom_q5  ! The 5-point q-point i-computational domain for the equation of state
+  integer, dimension(2) :: EOSdom_h5  ! The 5-point h-point i-computational domain for the equation of state
   integer, dimension(2) :: EOSdom_q15 ! The 3x5-point q-point i-computational domain for the equation of state
   integer, dimension(2) :: EOSdom_h15 ! The 3x5-point h-point i-computational domain for the equation of state
-
   integer :: Isq, Ieq, Jsq, Jeq, i, j, m, n, pos
 
   Isq = HI%IscB ; Ieq = HI%IecB ; Jsq = HI%JscB ; Jeq = HI%JecB
@@ -456,8 +511,8 @@ subroutine int_density_dz_generic_plm(k, tv, T_t, T_b, S_t, S_b, e, rho_ref, &
   enddo
 
   ! Set the loop ranges for equation of state calculations at various points.
-  EOSdom_q5(1) = 1 ; EOSdom_q5(2) = (ieq-isq+2)*5
-  EOSdom_q15(1) = 1 ; EOSdom_q15(2) = 15*(ieq-isq+1)
+  EOSdom_h5(1) = 1 ; EOSdom_h5(2) = 5*(Ieq-Isq+2)
+  EOSdom_q15(1) = 1 ; EOSdom_q15(2) = 15*(Ieq-Isq+1)
   EOSdom_h15(1) = 1 ; EOSdom_h15(2) = 15*(HI%iec-HI%isc+1)
 
   ! 1. Compute vertical integrals
@@ -475,12 +530,12 @@ subroutine int_density_dz_generic_plm(k, tv, T_t, T_b, S_t, S_b, e, rho_ref, &
       if (use_varS) S25(i*5+1:i*5+5) = tv%varS(i,j,k)
     enddo
     if (use_Stanley_eos) then
-      call calculate_density(T5, S5, p5, T25, TS5, S25, r5, EOS, EOSdom_q5, rho_ref=rho_ref)
+      call calculate_density(T5, S5, p5, T25, TS5, S25, r5, EOS, EOSdom_h5, rho_ref=rho_ref)
     else
       if (use_rho_ref) then
-        call calculate_density(T5, S5, p5, r5, EOS, EOSdom_q5, rho_ref=rho_ref)
+        call calculate_density(T5, S5, p5, r5, EOS, EOSdom_h5, rho_ref=rho_ref)
       else
-        call calculate_density(T5, S5, p5, r5, EOS, EOSdom_q5)
+        call calculate_density(T5, S5, p5, r5, EOS, EOSdom_h5)
         u5(:) = r5(:) - rho_ref
       endif
     endif
@@ -491,8 +546,8 @@ subroutine int_density_dz_generic_plm(k, tv, T_t, T_b, S_t, S_b, e, rho_ref, &
         rho_anom = C1_90*(7.0*(r5(i*5+1)+r5(i*5+5)) + 32.0*(r5(i*5+2)+r5(i*5+4)) + 12.0*r5(i*5+3))
         dpa(i,j) = G_e*dz(i)*rho_anom
         if (present(intz_dpa)) then
-        ! Use a Boole's-rule-like fifth-order accurate estimate of
-        ! the double integral of the pressure anomaly.
+          ! Use a Boole's-rule-like fifth-order accurate estimate of
+          ! the double integral of the pressure anomaly.
           intz_dpa(i,j) = 0.5*G_e*dz(i)**2 * &
                   (rho_anom - C1_90*(16.0*(r5(i*5+4)-r5(i*5+2)) + 7.0*(r5(i*5+5)-r5(i*5+1))) )
         endif
@@ -504,8 +559,8 @@ subroutine int_density_dz_generic_plm(k, tv, T_t, T_b, S_t, S_b, e, rho_ref, &
                    - rho_ref
         dpa(i,j) = G_e*dz(i)*rho_anom
         if (present(intz_dpa)) then
-        ! Use a Boole's-rule-like fifth-order accurate estimate of
-        ! the double integral of the pressure anomaly.
+          ! Use a Boole's-rule-like fifth-order accurate estimate of
+          ! the double integral of the pressure anomaly.
           intz_dpa(i,j) = 0.5*G_e*dz(i)**2 * &
                   (rho_anom - C1_90*(16.0*(u5(i*5+4)-u5(i*5+2)) + 7.0*(u5(i*5+5)-u5(i*5+1))) )
         endif
@@ -774,13 +829,26 @@ subroutine int_density_dz_generic_ppm(k, tv, T_t, T_b, S_t, S_b, e, &
 ! a parabolic interpolation is used to compute intermediate values.
 
   ! Local variables
-  real :: T5(5) ! Temperatures along a line of subgrid locations [C ~> degC]
-  real :: S5(5) ! Salinities along a line of subgrid locations [S ~> ppt]
-  real :: T25(5) ! SGS temperature variance along a line of subgrid locations [C2 ~> degC2]
-  real :: TS5(5) ! SGS temperature-salinity covariance along a line of subgrid locations [C S ~> degC ppt]
-  real :: S25(5) ! SGS salinity variance along a line of subgrid locations [S2 ~> ppt2]
-  real :: p5(5) ! Pressures at five quadrature points [R L2 T-2 ~> Pa]
-  real :: r5(5) ! Density anomalies from rho_ref at quadrature points [R ~> kg m-3]
+  real :: T5((5*HI%iscB+1):(5*(HI%iecB+2)))  ! Temperatures along a line of subgrid locations [C ~> degC]
+  real :: S5((5*HI%iscB+1):(5*(HI%iecB+2)))  ! Salinities along a line of subgrid locations [S ~> ppt]
+  real :: T25((5*HI%iscB+1):(5*(HI%iecB+2))) ! SGS temperature variance along a line of subgrid
+                                             ! locations [C2 ~> degC2]
+  real :: TS5((5*HI%iscB+1):(5*(HI%iecB+2))) ! SGS temp-salt covariance along a line of subgrid
+                                             ! locations [C S ~> degC ppt]
+  real :: S25((5*HI%iscB+1):(5*(HI%iecB+2))) ! SGS salinity variance along a line of subgrid locations [S2 ~> ppt2]
+  real :: p5((5*HI%iscB+1):(5*(HI%iecB+2)))  ! Pressures along a line of subgrid locations [R L2 T-2 ~> Pa]
+  real :: r5((5*HI%iscB+1):(5*(HI%iecB+2)))  ! Densities anomalies along a line of subgrid
+                                             ! locations [R ~> kg m-3]
+  real :: T15((15*HI%iscB+1):(15*(HI%iecB+1))) ! Temperatures at an array of subgrid locations [C ~> degC]
+  real :: S15((15*HI%iscB+1):(15*(HI%iecB+1))) ! Salinities at an array of subgrid locations [S ~> ppt]
+  real :: T215((15*HI%iscB+1):(15*(HI%iecB+1))) ! SGS temperature variance along a line of subgrid
+                                                ! locations [C2 ~> degC2]
+  real :: TS15((15*HI%iscB+1):(15*(HI%iecB+1))) ! SGS temp-salt covariance along a line of subgrid
+                                                ! locations [C S ~> degC ppt]
+  real :: S215((15*HI%iscB+1):(15*(HI%iecB+1))) ! SGS salinity variance along a line of subgrid
+                                                ! locations [S2 ~> ppt2]
+  real :: p15((15*HI%iscB+1):(15*(HI%iecB+1))) ! Pressures at an array of subgrid locations [R L2 T-2 ~> Pa]
+  real :: r15((15*HI%iscB+1):(15*(HI%iecB+1))) ! Densities at an array of subgrid locations [R ~> kg m-3]
   real :: wt_t(5), wt_b(5) ! Top and bottom weights [nondim]
   real :: rho_anom ! The integrated density anomaly [R ~> kg m-3]
   real :: w_left, w_right  ! Left and right weights [nondim]
@@ -790,6 +858,8 @@ subroutine int_density_dz_generic_ppm(k, tv, T_t, T_b, S_t, S_b, e, &
   real :: GxRho ! The gravitational acceleration times density [R L2 Z-1 T-2 ~> kg m-2 s-2]
   real :: I_Rho ! The inverse of the Boussinesq density [R-1 ~> m3 kg-1]
   real :: dz ! Layer thicknesses at tracer points [Z ~> m]
+  real :: dz_x(5,HI%iscB:HI%iecB) ! Layer thicknesses along an x-line of subgrid locations [Z ~> m]
+  real :: dz_y(5,HI%isc:HI%iec)   ! Layer thicknesses along a y-line of subgrid locations [Z ~> m]
   real :: massWeightToggle ! A non-dimensional toggle factor (0 or 1) [nondim]
   real :: Ttl, Tbl, Tml, Ttr, Tbr, Tmr ! Temperatures at the velocity cell corners [C ~> degC]
   real :: Stl, Sbl, Sml, Str, Sbr, Smr ! Salinities at the velocity cell corners [S ~> ppt]
@@ -801,9 +871,12 @@ subroutine int_density_dz_generic_ppm(k, tv, T_t, T_b, S_t, S_b, e, &
   real :: hWght  ! A topographically limited thickness weight [Z ~> m]
   real :: hL, hR ! Thicknesses to the left and right [Z ~> m]
   real :: iDenom ! The denominator of the thickness weight expressions [Z-2 ~> m-2]
-  integer :: Isq, Ieq, Jsq, Jeq, i, j, m, n
+  integer, dimension(2) :: EOSdom_h5  ! The 5-point h-point i-computational domain for the equation of state
+  integer, dimension(2) :: EOSdom_q15 ! The 3x5-point q-point i-computational domain for the equation of state
+  integer, dimension(2) :: EOSdom_h15 ! The 3x5-point h-point i-computational domain for the equation of state
+  integer :: Isq, Ieq, Jsq, Jeq, i, j, m, n, pos
   logical :: use_PPM ! If false, assume zero curvature in reconstruction, i.e. PLM
-  logical :: use_varT, use_varS, use_covarTS
+  logical :: use_varT, use_varS, use_covarTS ! Logicals for SGS variances fields
 
   Isq = HI%IscB ; Ieq = HI%IecB ; Jsq = HI%JscB ; Jeq = HI%JecB
 
@@ -824,226 +897,277 @@ subroutine int_density_dz_generic_ppm(k, tv, T_t, T_b, S_t, S_b, e, &
   use_covarTS = .false.
   use_varS = .false.
   if (use_stanley_eos) then
-     use_varT = associated(tv%varT)
-     use_covarTS = associated(tv%covarTS)
-     use_varS = associated(tv%varS)
+    use_varT = associated(tv%varT)
+    use_covarTS = associated(tv%covarTS)
+    use_varS = associated(tv%varS)
   endif
 
   T25(:) = 0.
   TS5(:) = 0.
   S25(:) = 0.
+  T215(:) = 0.
+  TS15(:) = 0.
+  S215(:) = 0.
 
   do n = 1, 5
     wt_t(n) = 0.25 * real(5-n)
     wt_b(n) = 1.0 - wt_t(n)
   enddo
 
+  ! Set the loop ranges for equation of state calculations at various points.
+  EOSdom_h5(1) = 1 ; EOSdom_h5(2) = 5*(Ieq-Isq+2)
+  EOSdom_q15(1) = 1 ; EOSdom_q15(2) = 15*(Ieq-Isq+1)
+  EOSdom_h15(1) = 1 ; EOSdom_h15(2) = 15*(HI%iec-HI%isc+1)
+
   ! 1. Compute vertical integrals
-  do j=Jsq,Jeq+1 ; do i=Isq,Ieq+1
-    if (use_PPM) then
-      ! Curvature coefficient of the parabolas
-      s6 = 3.0 * ( 2.0*tv%S(i,j,k) - ( S_t(i,j,k) + S_b(i,j,k) ) )
-      t6 = 3.0 * ( 2.0*tv%T(i,j,k) - ( T_t(i,j,k) + T_b(i,j,k) ) )
-    endif
-    dz = e(i,j,K) - e(i,j,K+1)
-    do n=1,5
-      p5(n) = -GxRho*((e(i,j,K) - z0pres) - 0.25*real(n-1)*dz)
-      ! Salinity and temperature points are reconstructed with PPM
-      S5(n) = wt_t(n) * S_t(i,j,k) + wt_b(n) * ( S_b(i,j,k) + s6 * wt_t(n) )
-      T5(n) = wt_t(n) * T_t(i,j,k) + wt_b(n) * ( T_b(i,j,k) + t6 * wt_t(n) )
+  do j=Jsq,Jeq+1
+    do i=Isq,Ieq+1
+      if (use_PPM) then
+        ! Curvature coefficient of the parabolas
+        s6 = 3.0 * ( 2.0*tv%S(i,j,k) - ( S_t(i,j,k) + S_b(i,j,k) ) )
+        t6 = 3.0 * ( 2.0*tv%T(i,j,k) - ( T_t(i,j,k) + T_b(i,j,k) ) )
+      endif
+      dz = e(i,j,K) - e(i,j,K+1)
+      do n=1,5
+        p5(I*5+n) = -GxRho*((e(i,j,K) - z0pres) - 0.25*real(n-1)*dz)
+        ! Salinity and temperature points are reconstructed with PPM
+        S5(I*5+n) = wt_t(n) * S_t(i,j,k) + wt_b(n) * ( S_b(i,j,k) + s6 * wt_t(n) )
+        T5(I*5+n) = wt_t(n) * T_t(i,j,k) + wt_b(n) * ( T_b(i,j,k) + t6 * wt_t(n) )
+      enddo
+      if (use_stanley_eos) then
+        if (use_varT) T25(I*5+1:I*5+5) = tv%varT(i,j,k)
+        if (use_covarTS) TS5(I*5+1:I*5+5) = tv%covarTS(i,j,k)
+        if (use_varS) S25(I*5+1:I*5+5) = tv%varS(i,j,k)
+      endif
     enddo
+
     if (use_stanley_eos) then
-      if (use_varT) T25(:) = tv%varT(i,j,k)
-      if (use_covarTS) TS5(:) = tv%covarTS(i,j,k)
-      if (use_varS) S25(:) = tv%varS(i,j,k)
-      call calculate_density(T5, S5, p5, T25, TS5, S25, r5, EOS, rho_ref=rho_ref)
+      call calculate_density(T5, S5, p5, T25, TS5, S25, r5, EOS, EOSdom_h5, rho_ref=rho_ref)
     else
-      call calculate_density(T5, S5, p5, r5, EOS, rho_ref=rho_ref)
+      call calculate_density(T5, S5, p5, r5, EOS, EOSdom_h5, rho_ref=rho_ref)
     endif
 
-    ! Use Boole's rule to estimate the pressure anomaly change.
-    rho_anom = C1_90*(7.0*(r5(1)+r5(5)) + 32.0*(r5(2)+r5(4)) + 12.0*r5(3))
-    dpa(i,j) = G_e*dz*rho_anom
-    if (present(intz_dpa)) then
-      ! Use a Boole's-rule-like fifth-order accurate estimate of
-      ! the double integral of the pressure anomaly.
-      intz_dpa(i,j) = 0.5*G_e*dz**2 * &
-                      (rho_anom - C1_90*(16.0*(r5(4)-r5(2)) + 7.0*(r5(5)-r5(1))) )
-    endif
-  enddo ; enddo ! end loops on j and i
+    do i=Isq,Ieq+1
+      dz = e(i,j,K) - e(i,j,K+1)
+      ! Use Boole's rule to estimate the pressure anomaly change.
+      rho_anom = C1_90*(7.0*(r5(i*5+1)+r5(i*5+5)) + 32.0*(r5(i*5+2)+r5(i*5+4)) + 12.0*r5(i*5+3))
+      dpa(i,j) = G_e*dz*rho_anom
+      if (present(intz_dpa)) then
+        ! Use a Boole's-rule-like fifth-order accurate estimate of
+        ! the double integral of the pressure anomaly.
+        intz_dpa(i,j) = 0.5*G_e*dz**2 * &
+                        (rho_anom - C1_90*(16.0*(r5(i*5+4)-r5(i*5+2)) + 7.0*(r5(i*5+5)-r5(i*5+1))) )
+      endif
+    enddo ! end loop on i
+  enddo ! end loop on j
 
   ! 2. Compute horizontal integrals in the x direction
-  if (present(intx_dpa)) then ; do j=HI%jsc,HI%jec ; do I=Isq,Ieq
-    ! Corner values of T and S
-    ! hWght is the distance measure by which the cell is violation of
-    ! hydrostatic consistency. For large hWght we bias the interpolation
-    ! of T,S along the top and bottom integrals, almost like thickness
-    ! weighting.
-    ! Note: To work in terrain following coordinates we could offset
-    ! this distance by the layer thickness to replicate other models.
-    hWght = massWeightToggle * &
-            max(0., -bathyT(i,j)-e(i+1,j,K), -bathyT(i+1,j)-e(i,j,K))
-    if (hWght > 0.) then
-      hL = (e(i,j,K) - e(i,j,K+1)) + dz_subroundoff
-      hR = (e(i+1,j,K) - e(i+1,j,K+1)) + dz_subroundoff
-      hWght = hWght * ( (hL-hR)/(hL+hR) )**2
-      iDenom = 1./( hWght*(hR + hL) + hL*hR )
-      Ttl = ( (hWght*hR)*T_t(i+1,j,k) + (hWght*hL + hR*hL)*T_t(i,j,k) ) * iDenom
-      Tbl = ( (hWght*hR)*T_b(i+1,j,k) + (hWght*hL + hR*hL)*T_b(i,j,k) ) * iDenom
-      Tml = ( (hWght*hR)*tv%T(i+1,j,k)+ (hWght*hL + hR*hL)*tv%T(i,j,k) ) * iDenom
-      Ttr = ( (hWght*hL)*T_t(i,j,k) + (hWght*hR + hR*hL)*T_t(i+1,j,k) ) * iDenom
-      Tbr = ( (hWght*hL)*T_b(i,j,k) + (hWght*hR + hR*hL)*T_b(i+1,j,k) ) * iDenom
-      Tmr = ( (hWght*hL)*tv%T(i,j,k) + (hWght*hR + hR*hL)*tv%T(i+1,j,k) ) * iDenom
-      Stl = ( (hWght*hR)*S_t(i+1,j,k) + (hWght*hL + hR*hL)*S_t(i,j,k) ) * iDenom
-      Sbl = ( (hWght*hR)*S_b(i+1,j,k) + (hWght*hL + hR*hL)*S_b(i,j,k) ) * iDenom
-      Sml = ( (hWght*hR)*tv%S(i+1,j,k) + (hWght*hL + hR*hL)*tv%S(i,j,k) ) * iDenom
-      Str = ( (hWght*hL)*S_t(i,j,k) + (hWght*hR + hR*hL)*S_t(i+1,j,k) ) * iDenom
-      Sbr = ( (hWght*hL)*S_b(i,j,k) + (hWght*hR + hR*hL)*S_b(i+1,j,k) ) * iDenom
-      Smr = ( (hWght*hL)*tv%S(i,j,k) + (hWght*hR + hR*hL)*tv%S(i+1,j,k) ) * iDenom
+  if (present(intx_dpa)) then ; do j=HI%jsc,HI%jec
+    do I=Isq,Ieq
+      ! Corner values of T and S
+      ! hWght is the distance measure by which the cell is violation of
+      ! hydrostatic consistency. For large hWght we bias the interpolation
+      ! of T,S along the top and bottom integrals, almost like thickness
+      ! weighting.
+      ! Note: To work in terrain following coordinates we could offset
+      ! this distance by the layer thickness to replicate other models.
+      hWght = massWeightToggle * &
+              max(0., -bathyT(i,j)-e(i+1,j,K), -bathyT(i+1,j)-e(i,j,K))
+      if (hWght > 0.) then
+        hL = (e(i,j,K) - e(i,j,K+1)) + dz_subroundoff
+        hR = (e(i+1,j,K) - e(i+1,j,K+1)) + dz_subroundoff
+        hWght = hWght * ( (hL-hR)/(hL+hR) )**2
+        iDenom = 1./( hWght*(hR + hL) + hL*hR )
+        Ttl = ( (hWght*hR)*T_t(i+1,j,k) + (hWght*hL + hR*hL)*T_t(i,j,k) ) * iDenom
+        Tbl = ( (hWght*hR)*T_b(i+1,j,k) + (hWght*hL + hR*hL)*T_b(i,j,k) ) * iDenom
+        Tml = ( (hWght*hR)*tv%T(i+1,j,k)+ (hWght*hL + hR*hL)*tv%T(i,j,k) ) * iDenom
+        Ttr = ( (hWght*hL)*T_t(i,j,k) + (hWght*hR + hR*hL)*T_t(i+1,j,k) ) * iDenom
+        Tbr = ( (hWght*hL)*T_b(i,j,k) + (hWght*hR + hR*hL)*T_b(i+1,j,k) ) * iDenom
+        Tmr = ( (hWght*hL)*tv%T(i,j,k) + (hWght*hR + hR*hL)*tv%T(i+1,j,k) ) * iDenom
+        Stl = ( (hWght*hR)*S_t(i+1,j,k) + (hWght*hL + hR*hL)*S_t(i,j,k) ) * iDenom
+        Sbl = ( (hWght*hR)*S_b(i+1,j,k) + (hWght*hL + hR*hL)*S_b(i,j,k) ) * iDenom
+        Sml = ( (hWght*hR)*tv%S(i+1,j,k) + (hWght*hL + hR*hL)*tv%S(i,j,k) ) * iDenom
+        Str = ( (hWght*hL)*S_t(i,j,k) + (hWght*hR + hR*hL)*S_t(i+1,j,k) ) * iDenom
+        Sbr = ( (hWght*hL)*S_b(i,j,k) + (hWght*hR + hR*hL)*S_b(i+1,j,k) ) * iDenom
+        Smr = ( (hWght*hL)*tv%S(i,j,k) + (hWght*hR + hR*hL)*tv%S(i+1,j,k) ) * iDenom
+      else
+        Ttl = T_t(i,j,k); Tbl = T_b(i,j,k); Ttr = T_t(i+1,j,k); Tbr = T_b(i+1,j,k)
+        Tml = tv%T(i,j,k); Tmr = tv%T(i+1,j,k)
+        Stl = S_t(i,j,k); Sbl = S_b(i,j,k); Str = S_t(i+1,j,k); Sbr = S_b(i+1,j,k)
+        Sml = tv%S(i,j,k); Smr = tv%S(i+1,j,k)
+      endif
+
+      do m=2,4
+        w_left = wt_t(m) ; w_right = wt_b(m)
+
+        ! Salinity and temperature points are linearly interpolated in
+        ! the horizontal. The subscript (1) refers to the top value in
+        ! the vertical profile while subscript (5) refers to the bottom
+        ! value in the vertical profile.
+        T_top = w_left*Ttl + w_right*Ttr
+        T_mn = w_left*Tml + w_right*Tmr
+        T_bot = w_left*Tbl + w_right*Tbr
+
+        S_top = w_left*Stl + w_right*Str
+        S_mn = w_left*Sml + w_right*Smr
+        S_bot = w_left*Sbl + w_right*Sbr
+
+        ! Pressure
+        dz_x(m,i) = w_left*(e(i,j,K) - e(i,j,K+1)) + w_right*(e(i+1,j,K) - e(i+1,j,K+1))
+
+        pos = i*15+(m-2)*5
+        p15(pos+1) = -GxRho*((w_left*e(i,j,K) + w_right*e(i+1,j,K)) - z0pres)
+        do n=2,5
+          p15(pos+n) = p15(pos+n-1) + GxRho*0.25*dz_x(m,i)
+        enddo
+
+        ! Parabolic reconstructions in the vertical for T and S
+        if (use_PPM) then
+          ! Coefficients of the parabolas
+          s6 = 3.0 * ( 2.0*S_mn - ( S_top + S_bot ) )
+          t6 = 3.0 * ( 2.0*T_mn - ( T_top + T_bot ) )
+        endif
+        do n=1,5
+          S15(pos+n) = wt_t(n) * S_top + wt_b(n) * ( S_bot + s6 * wt_t(n) )
+          T15(pos+n) = wt_t(n) * T_top + wt_b(n) * ( T_bot + t6 * wt_t(n) )
+        enddo
+        if (use_stanley_eos) then
+          if (use_varT) T215(pos+1:pos+5) = w_left*tv%varT(i,j,k) + w_right*tv%varT(i+1,j,k)
+          if (use_covarTS) TS15(pos+1:pos+5) = w_left*tv%covarTS(i,j,k) + w_right*tv%covarTS(i+1,j,k)
+          if (use_varS) S215(pos+1:pos+5) = w_left*tv%varS(i,j,k) + w_right*tv%varS(i+1,j,k)
+        endif
+        if (use_stanley_eos) then
+          call calculate_density(T5, S5, p5, T25, TS5, S25, r5, EOS, rho_ref=rho_ref)
+        else
+          call calculate_density(T5, S5, p5, r5, EOS, rho_ref=rho_ref)
+        endif
+      enddo
+    enddo
+
+    if (use_stanley_eos) then
+      call calculate_density(T15, S15, p15, T215, TS15, S215, r15, EOS, EOSdom_q15, rho_ref=rho_ref)
     else
-      Ttl = T_t(i,j,k); Tbl = T_b(i,j,k); Ttr = T_t(i+1,j,k); Tbr = T_b(i+1,j,k)
-      Tml = tv%T(i,j,k); Tmr = tv%T(i+1,j,k)
-      Stl = S_t(i,j,k); Sbl = S_b(i,j,k); Str = S_t(i+1,j,k); Sbr = S_b(i+1,j,k)
-      Sml = tv%S(i,j,k); Smr = tv%S(i+1,j,k)
+      call calculate_density(T15, S15, p15, r15, EOS, EOSdom_q15, rho_ref=rho_ref)
     endif
 
-    do m=2,4
-      w_left = wt_t(m) ; w_right = wt_b(m)
+    do I=Isq,Ieq
+      do m=2,4
+        pos = i*15+(m-2)*5
+        ! Use Boole's rule to estimate the pressure anomaly change.
+        intz(m) = G_e*dz_x(m,i)*( C1_90*( 7.0*(r15(pos+1)+r15(pos+5)) + &
+                                         32.0*(r15(pos+2)+r15(pos+4)) + &
+                                         12.0*r15(pos+3)) )
+      enddo ! m
+      intz(1) = dpa(i,j) ; intz(5) = dpa(i+1,j)
 
-      ! Salinity and temperature points are linearly interpolated in
-      ! the horizontal. The subscript (1) refers to the top value in
-      ! the vertical profile while subscript (5) refers to the bottom
-      ! value in the vertical profile.
-      T_top = w_left*Ttl + w_right*Ttr
-      T_mn = w_left*Tml + w_right*Tmr
-      T_bot = w_left*Tbl + w_right*Tbr
+      ! Use Boole's rule to integrate the bottom pressure anomaly values in x.
+      intx_dpa(I,j) = C1_90*(7.0*(intz(1)+intz(5)) + 32.0*(intz(2)+intz(4)) + 12.0*intz(3))
 
-      S_top = w_left*Stl + w_right*Str
-      S_mn = w_left*Sml + w_right*Smr
-      S_bot = w_left*Sbl + w_right*Sbr
-
-      ! Pressure
-      dz = w_left*(e(i,j,K) - e(i,j,K+1)) + w_right*(e(i+1,j,K) - e(i+1,j,K+1))
-      p5(1) = -GxRho*((w_left*e(i,j,K) + w_right*e(i+1,j,K)) - z0pres)
-      do n=2,5
-        p5(n) = p5(n-1) + GxRho*0.25*dz
-      enddo
-
-      ! Parabolic reconstructions in the vertical for T and S
-      if (use_PPM) then
-        ! Coefficients of the parabolas
-        s6 = 3.0 * ( 2.0*S_mn - ( S_top + S_bot ) )
-        t6 = 3.0 * ( 2.0*T_mn - ( T_top + T_bot ) )
-      endif
-      do n=1,5
-        S5(n) = wt_t(n) * S_top + wt_b(n) * ( S_bot + s6 * wt_t(n) )
-        T5(n) = wt_t(n) * T_top + wt_b(n) * ( T_bot + t6 * wt_t(n) )
-      enddo
-      if (use_stanley_eos) then
-        if (use_varT) T25(:) = w_left*tv%varT(i,j,k) + w_right*tv%varT(i+1,j,k)
-        if (use_covarTS) TS5(:) = w_left*tv%covarTS(i,j,k) + w_right*tv%covarTS(i+1,j,k)
-        if (use_varS) S25(:) = w_left*tv%varS(i,j,k) + w_right*tv%varS(i+1,j,k)
-        call calculate_density(T5, S5, p5, T25, TS5, S25, r5, EOS, rho_ref=rho_ref)
-      else
-        call calculate_density(T5, S5, p5, r5, EOS, rho_ref=rho_ref)
-      endif
-
-      ! Use Boole's rule to estimate the pressure anomaly change.
-      intz(m) = G_e*dz*( C1_90*(7.0*(r5(1)+r5(5)) + 32.0*(r5(2)+r5(4)) + 12.0*r5(3)) )
-    enddo ! m
-    intz(1) = dpa(i,j) ; intz(5) = dpa(i+1,j)
-
-    ! Use Boole's rule to integrate the bottom pressure anomaly values in x.
-    intx_dpa(I,j) = C1_90*(7.0*(intz(1)+intz(5)) + 32.0*(intz(2)+intz(4)) + 12.0*intz(3))
-
-  enddo ; enddo ; endif
+    enddo
+  enddo ; endif
 
   ! 3. Compute horizontal integrals in the y direction
-  if (present(inty_dpa)) then ; do J=Jsq,Jeq ; do i=HI%isc,HI%iec
-    ! Corner values of T and S
-    ! hWght is the distance measure by which the cell is violation of
-    ! hydrostatic consistency. For large hWght we bias the interpolation
-    ! of T,S along the top and bottom integrals, almost like thickness
-    ! weighting.
-    ! Note: To work in terrain following coordinates we could offset
-    ! this distance by the layer thickness to replicate other models.
-    hWght = massWeightToggle * &
-            max(0., -bathyT(i,j)-e(i,j+1,K), -bathyT(i,j+1)-e(i,j,K))
-    if (hWght > 0.) then
-      hL = (e(i,j,K) - e(i,j,K+1)) + dz_subroundoff
-      hR = (e(i,j+1,K) - e(i,j+1,K+1)) + dz_subroundoff
-      hWght = hWght * ( (hL-hR)/(hL+hR) )**2
-      iDenom = 1./( hWght*(hR + hL) + hL*hR )
-      Ttl = ( (hWght*hR)*T_t(i,j+1,k) + (hWght*hL + hR*hL)*T_t(i,j,k) ) * iDenom
-      Tbl = ( (hWght*hR)*T_b(i,j+1,k) + (hWght*hL + hR*hL)*T_b(i,j,k) ) * iDenom
-      Tml = ( (hWght*hR)*tv%T(i,j+1,k)+ (hWght*hL + hR*hL)*tv%T(i,j,k) ) * iDenom
-      Ttr = ( (hWght*hL)*T_t(i,j,k) + (hWght*hR + hR*hL)*T_t(i,j+1,k) ) * iDenom
-      Tbr = ( (hWght*hL)*T_b(i,j,k) + (hWght*hR + hR*hL)*T_b(i,j+1,k) ) * iDenom
-      Tmr = ( (hWght*hL)*tv%T(i,j,k) + (hWght*hR + hR*hL)*tv%T(i,j+1,k) ) * iDenom
-      Stl = ( (hWght*hR)*S_t(i,j+1,k) + (hWght*hL + hR*hL)*S_t(i,j,k) ) * iDenom
-      Sbl = ( (hWght*hR)*S_b(i,j+1,k) + (hWght*hL + hR*hL)*S_b(i,j,k) ) * iDenom
-      Sml = ( (hWght*hR)*tv%S(i,j+1,k)+ (hWght*hL + hR*hL)*tv%S(i,j,k) ) * iDenom
-      Str = ( (hWght*hL)*S_t(i,j,k) + (hWght*hR + hR*hL)*S_t(i,j+1,k) ) * iDenom
-      Sbr = ( (hWght*hL)*S_b(i,j,k) + (hWght*hR + hR*hL)*S_b(i,j+1,k) ) * iDenom
-      Smr = ( (hWght*hL)*tv%S(i,j,k) + (hWght*hR + hR*hL)*tv%S(i,j+1,k) ) * iDenom
+  if (present(inty_dpa)) then ; do J=Jsq,Jeq
+    do i=HI%isc,HI%iec
+      ! Corner values of T and S
+      ! hWght is the distance measure by which the cell is violation of
+      ! hydrostatic consistency. For large hWght we bias the interpolation
+      ! of T,S along the top and bottom integrals, almost like thickness
+      ! weighting.
+      ! Note: To work in terrain following coordinates we could offset
+      ! this distance by the layer thickness to replicate other models.
+      hWght = massWeightToggle * &
+              max(0., -bathyT(i,j)-e(i,j+1,K), -bathyT(i,j+1)-e(i,j,K))
+      if (hWght > 0.) then
+        hL = (e(i,j,K) - e(i,j,K+1)) + dz_subroundoff
+        hR = (e(i,j+1,K) - e(i,j+1,K+1)) + dz_subroundoff
+        hWght = hWght * ( (hL-hR)/(hL+hR) )**2
+        iDenom = 1./( hWght*(hR + hL) + hL*hR )
+        Ttl = ( (hWght*hR)*T_t(i,j+1,k) + (hWght*hL + hR*hL)*T_t(i,j,k) ) * iDenom
+        Tbl = ( (hWght*hR)*T_b(i,j+1,k) + (hWght*hL + hR*hL)*T_b(i,j,k) ) * iDenom
+        Tml = ( (hWght*hR)*tv%T(i,j+1,k)+ (hWght*hL + hR*hL)*tv%T(i,j,k) ) * iDenom
+        Ttr = ( (hWght*hL)*T_t(i,j,k) + (hWght*hR + hR*hL)*T_t(i,j+1,k) ) * iDenom
+        Tbr = ( (hWght*hL)*T_b(i,j,k) + (hWght*hR + hR*hL)*T_b(i,j+1,k) ) * iDenom
+        Tmr = ( (hWght*hL)*tv%T(i,j,k) + (hWght*hR + hR*hL)*tv%T(i,j+1,k) ) * iDenom
+        Stl = ( (hWght*hR)*S_t(i,j+1,k) + (hWght*hL + hR*hL)*S_t(i,j,k) ) * iDenom
+        Sbl = ( (hWght*hR)*S_b(i,j+1,k) + (hWght*hL + hR*hL)*S_b(i,j,k) ) * iDenom
+        Sml = ( (hWght*hR)*tv%S(i,j+1,k)+ (hWght*hL + hR*hL)*tv%S(i,j,k) ) * iDenom
+        Str = ( (hWght*hL)*S_t(i,j,k) + (hWght*hR + hR*hL)*S_t(i,j+1,k) ) * iDenom
+        Sbr = ( (hWght*hL)*S_b(i,j,k) + (hWght*hR + hR*hL)*S_b(i,j+1,k) ) * iDenom
+        Smr = ( (hWght*hL)*tv%S(i,j,k) + (hWght*hR + hR*hL)*tv%S(i,j+1,k) ) * iDenom
+      else
+        Ttl = T_t(i,j,k); Tbl = T_b(i,j,k); Ttr = T_t(i,j+1,k); Tbr = T_b(i,j+1,k)
+        Tml = tv%T(i,j,k); Tmr = tv%T(i,j+1,k)
+        Stl = S_t(i,j,k); Sbl = S_b(i,j,k); Str = S_t(i,j+1,k); Sbr = S_b(i,j+1,k)
+        Sml = tv%S(i,j,k); Smr = tv%S(i,j+1,k)
+      endif
+
+      do m=2,4
+        w_left = wt_t(m) ; w_right = wt_b(m)
+
+        ! Salinity and temperature points are linearly interpolated in
+        ! the horizontal. The subscript (1) refers to the top value in
+        ! the vertical profile while subscript (5) refers to the bottom
+        ! value in the vertical profile.
+        T_top = w_left*Ttl + w_right*Ttr
+        T_mn = w_left*Tml + w_right*Tmr
+        T_bot = w_left*Tbl + w_right*Tbr
+
+        S_top = w_left*Stl + w_right*Str
+        S_mn = w_left*Sml + w_right*Smr
+        S_bot = w_left*Sbl + w_right*Sbr
+
+        ! Pressure
+        dz_y(m,i) = w_left*(e(i,j,K) - e(i,j,K+1)) + w_right*(e(i,j+1,K) - e(i,j+1,K+1))
+
+        pos = i*15+(m-2)*5
+        p15(pos+1) = -GxRho*((w_left*e(i,j,K) + w_right*e(i,j+1,K)) - z0pres)
+        do n=2,5
+          p15(pos+n) = p15(pos+n-1) + GxRho*0.25*dz_y(m,i)
+        enddo
+
+        ! Parabolic reconstructions in the vertical for T and S
+        if (use_PPM) then
+          ! Coefficients of the parabolas
+          s6 = 3.0 * ( 2.0*S_mn - ( S_top + S_bot ) )
+          t6 = 3.0 * ( 2.0*T_mn - ( T_top + T_bot ) )
+        endif
+        do n=1,5
+          S15(pos+n) = wt_t(n) * S_top + wt_b(n) * ( S_bot + s6 * wt_t(n) )
+          T15(pos+n) = wt_t(n) * T_top + wt_b(n) * ( T_bot + t6 * wt_t(n) )
+        enddo
+
+        if (use_stanley_eos) then
+          if (use_varT) T215(pos+1:pos+5) = w_left*tv%varT(i,j,k) + w_right*tv%varT(i,j+1,k)
+          if (use_covarTS) TS15(pos+1:pos+5) = w_left*tv%covarTS(i,j,k) + w_right*tv%covarTS(i,j+1,k)
+          if (use_varS) S215(pos+1:pos+5) = w_left*tv%varS(i,j,k) + w_right*tv%varS(i,j+1,k)
+        endif
+      enddo
+    enddo
+
+    if (use_stanley_eos) then
+      call calculate_density(T15(15*HI%isc+1:), S15(15*HI%isc+1:), p15(15*HI%isc+1:), &
+                             T215(15*HI%isc+1:), TS15(15*HI%isc+1:), S215(15*HI%isc+1:), &
+                             r15(15*HI%isc+1:), EOS, EOSdom_h15, rho_ref=rho_ref)
     else
-      Ttl = T_t(i,j,k); Tbl = T_b(i,j,k); Ttr = T_t(i,j+1,k); Tbr = T_b(i,j+1,k)
-      Tml = tv%T(i,j,k); Tmr = tv%T(i,j+1,k)
-      Stl = S_t(i,j,k); Sbl = S_b(i,j,k); Str = S_t(i,j+1,k); Sbr = S_b(i,j+1,k)
-      Sml = tv%S(i,j,k); Smr = tv%S(i,j+1,k)
+      call calculate_density(T15(15*HI%isc+1:), S15(15*HI%isc+1:), p15(15*HI%isc+1:), &
+                             r15(15*HI%isc+1:), EOS, EOSdom_h15, rho_ref=rho_ref)
     endif
 
-    do m=2,4
-      w_left = wt_t(m) ; w_right = wt_b(m)
+    do i=HI%isc,HI%iec
+      do m=2,4
+        ! Use Boole's rule to estimate the pressure anomaly change.
+        pos = i*15+(m-2)*5
+        intz(m) = G_e*dz_y(m,i)*( C1_90*( 7.0*(r15(pos+1)+r15(pos+5)) + &
+                                         32.0*(r15(pos+2)+r15(pos+4)) + &
+                                         12.0*r15(pos+3)) )
+      enddo ! m
+      intz(1) = dpa(i,j) ; intz(5) = dpa(i,j+1)
 
-      ! Salinity and temperature points are linearly interpolated in
-      ! the horizontal. The subscript (1) refers to the top value in
-      ! the vertical profile while subscript (5) refers to the bottom
-      ! value in the vertical profile.
-      T_top = w_left*Ttl + w_right*Ttr
-      T_mn = w_left*Tml + w_right*Tmr
-      T_bot = w_left*Tbl + w_right*Tbr
-
-      S_top = w_left*Stl + w_right*Str
-      S_mn = w_left*Sml + w_right*Smr
-      S_bot = w_left*Sbl + w_right*Sbr
-
-      ! Pressure
-      dz = w_left*(e(i,j,K) - e(i,j,K+1)) + w_right*(e(i,j+1,K) - e(i,j+1,K+1))
-      p5(1) = -GxRho*((w_left*e(i,j,K) + w_right*e(i,j+1,K)) - z0pres)
-      do n=2,5
-        p5(n) = p5(n-1) + GxRho*0.25*dz
-      enddo
-
-      ! Parabolic reconstructions in the vertical for T and S
-      if (use_PPM) then
-        ! Coefficients of the parabolas
-        s6 = 3.0 * ( 2.0*S_mn - ( S_top + S_bot ) )
-        t6 = 3.0 * ( 2.0*T_mn - ( T_top + T_bot ) )
-      endif
-      do n=1,5
-        S5(n) = wt_t(n) * S_top + wt_b(n) * ( S_bot + s6 * wt_t(n) )
-        T5(n) = wt_t(n) * T_top + wt_b(n) * ( T_bot + t6 * wt_t(n) )
-      enddo
-
-      if (use_stanley_eos) then
-        if (use_varT) T25(:) = w_left*tv%varT(i,j,k) + w_right*tv%varT(i,j+1,k)
-        if (use_covarTS) TS5(:) = w_left*tv%covarTS(i,j,k) + w_right*tv%covarTS(i,j+1,k)
-        if (use_varS) S25(:) = w_left*tv%varS(i,j,k) + w_right*tv%varS(i,j+1,k)
-        call calculate_density(T5, S5, p5, T25, TS5, S25, r5, EOS, rho_ref=rho_ref)
-      else
-        call calculate_density(T5, S5, p5, r5, EOS, rho_ref=rho_ref)
-      endif
-
-      ! Use Boole's rule to estimate the pressure anomaly change.
-      intz(m) = G_e*dz*( C1_90*(7.0*(r5(1)+r5(5)) + 32.0*(r5(2)+r5(4)) + 12.0*r5(3)) )
-    enddo ! m
-    intz(1) = dpa(i,j) ; intz(5) = dpa(i,j+1)
-
-    ! Use Boole's rule to integrate the bottom pressure anomaly values in y.
-    inty_dpa(i,J) = C1_90*(7.0*(intz(1)+intz(5)) + 32.0*(intz(2)+intz(4)) + 12.0*intz(3))
-
-  enddo ; enddo ; endif
+      ! Use Boole's rule to integrate the bottom pressure anomaly values in y.
+      inty_dpa(i,J) = C1_90*(7.0*(intz(1)+intz(5)) + 32.0*(intz(2)+intz(4)) + 12.0*intz(3))
+    enddo
+  enddo ; endif
 
 end subroutine int_density_dz_generic_ppm
 
@@ -1161,12 +1285,19 @@ subroutine int_spec_vol_dp_generic_pcm(T, S, p_t, p_b, alpha_ref, HI, EOS, US, d
 ! series for log(1-eps/1+eps) that assumes that |eps| < 0.34.
 
   ! Local variables
-  real :: T5(5)      ! Temperatures at five quadrature points [C ~> degC]
-  real :: S5(5)      ! Salinities at five quadrature points [S ~> ppt]
-  real :: p5(5)      ! Pressures at five quadrature points [R L2 T-2 ~> Pa]
-  real :: a5(5)      ! Specific volumes at five quadrature points [R-1 ~> m3 kg-1]
+  real :: T5((5*HI%isd+1):(5*(HI%ied+2)))  ! Temperatures along a line of subgrid locations [C ~> degC]
+  real :: S5((5*HI%isd+1):(5*(HI%ied+2)))  ! Salinities along a line of subgrid locations [S ~> ppt]
+  real :: p5((5*HI%isd+1):(5*(HI%ied+2)))  ! Pressures along a line of subgrid locations [R L2 T-2 ~> Pa]
+  real :: a5((5*HI%isd+1):(5*(HI%ied+2)))  ! Specific volumes anomalies along a line of subgrid
+                                           ! locations [R-1 ~> m3 kg-3]
+  real :: T15((15*HI%isd+1):(15*(HI%ied+1))) ! Temperatures at an array of subgrid locations [C ~> degC]
+  real :: S15((15*HI%isd+1):(15*(HI%ied+1))) ! Salinities at an array of subgrid locations [S ~> ppt]
+  real :: p15((15*HI%isd+1):(15*(HI%ied+1))) ! Pressures at an array of subgrid locations [R L2 T-2 ~> Pa]
+  real :: a15((15*HI%isd+1):(15*(HI%ied+1))) ! Specific volumes at an array of subgrid locations [R ~> kg m-3]
   real :: alpha_anom ! The depth averaged specific density anomaly [R-1 ~> m3 kg-1]
   real :: dp         ! The pressure change through a layer [R L2 T-2 ~> Pa]
+  real :: dp_x(5,SZIB_(HI)) ! The pressure change through a layer along an x-line of subgrid locations [Z ~> m]
+  real :: dp_y(5,SZI_(HI))  ! The pressure change through a layer along a y-line of subgrid locations [Z ~> m]
   real :: hWght      ! A pressure-thickness below topography [R L2 T-2 ~> Pa]
   real :: hL, hR     ! Pressure-thicknesses of the columns to the left and right [R L2 T-2 ~> Pa]
   real :: iDenom     ! The inverse of the denominator in the weights [T4 R-2 L-4 ~> Pa-2]
@@ -1178,7 +1309,10 @@ subroutine int_spec_vol_dp_generic_pcm(T, S, p_t, p_b, alpha_ref, HI, EOS, US, d
                      ! 5 sub-column locations [L2 T-2 ~> m2 s-2]
   logical :: do_massWeight ! Indicates whether to do mass weighting.
   real, parameter :: C1_90 = 1.0/90.0  ! A rational constant [nondim]
-  integer :: Isq, Ieq, Jsq, Jeq, ish, ieh, jsh, jeh, i, j, m, n, halo
+  integer, dimension(2) :: EOSdom_h5  ! The 5-point h-point i-computational domain for the equation of state
+  integer, dimension(2) :: EOSdom_q15 ! The 3x5-point q-point i-computational domain for the equation of state
+  integer, dimension(2) :: EOSdom_h15 ! The 3x5-point h-point i-computational domain for the equation of state
+  integer :: Isq, Ieq, Jsq, Jeq, ish, ieh, jsh, jeh, i, j, m, n, pos, halo
 
   Isq = HI%IscB ; Ieq = HI%IecB ; Jsq = HI%JscB ; Jeq = HI%JecB
   halo = 0 ; if (present(halo_size)) halo = MAX(halo_size,0)
@@ -1195,110 +1329,146 @@ subroutine int_spec_vol_dp_generic_pcm(T, S, p_t, p_b, alpha_ref, HI, EOS, US, d
         "dP_neglect must be present if useMassWghtInterp is present and true.")
   endif ; endif
 
-  do j=jsh,jeh ; do i=ish,ieh
-    dp = p_b(i,j) - p_t(i,j)
-    do n=1,5
-      T5(n) = T(i,j) ; S5(n) = S(i,j)
-      p5(n) = p_b(i,j) - 0.25*real(n-1)*dp
-    enddo
+  ! Set the loop ranges for equation of state calculations at various points.
+  EOSdom_h5(1) = 1 ; EOSdom_h5(2) = 5*(ieh-ish+1)
+  EOSdom_q15(1) = 1 ; EOSdom_q15(2) = 15*(Ieq-Isq+1)
+  EOSdom_h15(1) = 1 ; EOSdom_h15(2) = 15*(HI%iec-HI%isc+1)
 
-    call calculate_spec_vol(T5, S5, p5, a5, EOS, spv_ref=alpha_ref)
-
-    ! Use Boole's rule to estimate the interface height anomaly change.
-    alpha_anom = C1_90*(7.0*(a5(1)+a5(5)) + 32.0*(a5(2)+a5(4)) + 12.0*a5(3))
-    dza(i,j) = dp*alpha_anom
-    ! Use a Boole's-rule-like fifth-order accurate estimate of the double integral of
-    ! the interface height anomaly.
-    if (present(intp_dza)) intp_dza(i,j) = 0.5*dp**2 * &
-          (alpha_anom - C1_90*(16.0*(a5(4)-a5(2)) + 7.0*(a5(5)-a5(1))) )
-  enddo ; enddo
-
-  if (present(intx_dza)) then ; do j=HI%jsc,HI%jec ; do I=Isq,Ieq
-    ! hWght is the distance measure by which the cell is violation of
-    ! hydrostatic consistency. For large hWght we bias the interpolation of
-    ! T & S along the top and bottom integrals, akin to thickness weighting.
-    hWght = 0.0
-    if (do_massWeight) &
-      hWght = max(0., bathyP(i,j)-p_t(i+1,j), bathyP(i+1,j)-p_t(i,j))
-    if (hWght > 0.) then
-      hL = (p_b(i,j) - p_t(i,j)) + dP_neglect
-      hR = (p_b(i+1,j) - p_t(i+1,j)) + dP_neglect
-      hWght = hWght * ( (hL-hR)/(hL+hR) )**2
-      iDenom = 1.0 / ( hWght*(hR + hL) + hL*hR )
-      hWt_LL = (hWght*hL + hR*hL) * iDenom ; hWt_LR = (hWght*hR) * iDenom
-      hWt_RR = (hWght*hR + hR*hL) * iDenom ; hWt_RL = (hWght*hL) * iDenom
-    else
-      hWt_LL = 1.0 ; hWt_LR = 0.0 ; hWt_RR = 1.0 ; hWt_RL = 0.0
-    endif
-
-    intp(1) = dza(i,j) ; intp(5) = dza(i+1,j)
-    do m=2,4
-      wt_L = 0.25*real(5-m) ; wt_R = 1.0-wt_L
-      wtT_L = wt_L*hWt_LL + wt_R*hWt_RL ; wtT_R = wt_L*hWt_LR + wt_R*hWt_RR
-
-      ! T, S, and p are interpolated in the horizontal.  The p interpolation
-      ! is linear, but for T and S it may be thickness weighted.
-      p5(1) = wt_L*p_b(i,j) + wt_R*p_b(i+1,j)
-      dp = wt_L*(p_b(i,j) - p_t(i,j)) + wt_R*(p_b(i+1,j) - p_t(i+1,j))
-      T5(1) = wtT_L*T(i,j) + wtT_R*T(i+1,j)
-      S5(1) = wtT_L*S(i,j) + wtT_R*S(i+1,j)
-
-      do n=2,5
-        T5(n) = T5(1) ; S5(n) = S5(1) ; p5(n) = p5(n-1) - 0.25*dp
+  do j=jsh,jeh
+    do i=ish,ieh
+      dp = p_b(i,j) - p_t(i,j)
+      pos = 5*i
+      do n=1,5
+        T5(pos+n) = T(i,j) ; S5(pos+n) = S(i,j)
+        p5(pos+n) = p_b(i,j) - 0.25*real(n-1)*dp
       enddo
-      call calculate_spec_vol(T5, S5, p5, a5, EOS, spv_ref=alpha_ref)
-
-    ! Use Boole's rule to estimate the interface height anomaly change.
-      intp(m) = dp*( C1_90*(7.0*(a5(1)+a5(5)) + 32.0*(a5(2)+a5(4)) + &
-                                12.0*a5(3)))
     enddo
-    ! Use Boole's rule to integrate the interface height anomaly values in x.
-    intx_dza(i,j) = C1_90*(7.0*(intp(1)+intp(5)) + 32.0*(intp(2)+intp(4)) + &
-                           12.0*intp(3))
-  enddo ; enddo ; endif
 
-  if (present(inty_dza)) then ; do J=Jsq,Jeq ; do i=HI%isc,HI%iec
-    ! hWght is the distance measure by which the cell is violation of
-    ! hydrostatic consistency. For large hWght we bias the interpolation of
-    ! T & S along the top and bottom integrals, akin to thickness weighting.
-    hWght = 0.0
-    if (do_massWeight) &
-      hWght = max(0., bathyP(i,j)-p_t(i,j+1), bathyP(i,j+1)-p_t(i,j))
-    if (hWght > 0.) then
-      hL = (p_b(i,j) - p_t(i,j)) + dP_neglect
-      hR = (p_b(i,j+1) - p_t(i,j+1)) + dP_neglect
-      hWght = hWght * ( (hL-hR)/(hL+hR) )**2
-      iDenom = 1.0 / ( hWght*(hR + hL) + hL*hR )
-      hWt_LL = (hWght*hL + hR*hL) * iDenom ; hWt_LR = (hWght*hR) * iDenom
-      hWt_RR = (hWght*hR + hR*hL) * iDenom ; hWt_RL = (hWght*hL) * iDenom
-    else
-      hWt_LL = 1.0 ; hWt_LR = 0.0 ; hWt_RR = 1.0 ; hWt_RL = 0.0
-    endif
+    call calculate_spec_vol(T5(5*ish+1:), S5(5*ish+1:), p5(5*ish+1:), a5(5*ish+1:), EOS, &
+                            EOSdom_h5, spv_ref=alpha_ref)
 
-    intp(1) = dza(i,j) ; intp(5) = dza(i,j+1)
-    do m=2,4
-      wt_L = 0.25*real(5-m) ; wt_R = 1.0-wt_L
-      wtT_L = wt_L*hWt_LL + wt_R*hWt_RL ; wtT_R = wt_L*hWt_LR + wt_R*hWt_RR
+    do i=ish,ieh
+      dp = p_b(i,j) - p_t(i,j)
+      ! Use Boole's rule to estimate the interface height anomaly change.
+      pos = 5*i
+      alpha_anom = C1_90*(7.0*(a5(pos+1)+a5(pos+5)) + 32.0*(a5(pos+2)+a5(pos+4)) + 12.0*a5(pos+3))
+      dza(i,j) = dp*alpha_anom
+      ! Use a Boole's-rule-like fifth-order accurate estimate of the double integral of
+      ! the interface height anomaly.
+      if (present(intp_dza)) intp_dza(i,j) = 0.5*dp**2 * &
+            (alpha_anom - C1_90*(16.0*(a5(pos+4)-a5(pos+2)) + 7.0*(a5(pos+5)-a5(pos+1))) )
+    enddo
+  enddo
 
-      ! T, S, and p are interpolated in the horizontal.  The p interpolation
-      ! is linear, but for T and S it may be thickness weighted.
-      p5(1) = wt_L*p_b(i,j) + wt_R*p_b(i,j+1)
-      dp = wt_L*(p_b(i,j) - p_t(i,j)) + wt_R*(p_b(i,j+1) - p_t(i,j+1))
-      T5(1) = wtT_L*T(i,j) + wtT_R*T(i,j+1)
-      S5(1) = wtT_L*S(i,j) + wtT_R*S(i,j+1)
-      do n=2,5
-        T5(n) = T5(1) ; S5(n) = S5(1) ; p5(n) = p5(n-1) - 0.25*dp
+  if (present(intx_dza)) then ; do j=HI%jsc,HI%jec
+    do I=Isq,Ieq
+      ! hWght is the distance measure by which the cell is violation of
+      ! hydrostatic consistency. For large hWght we bias the interpolation of
+      ! T & S along the top and bottom integrals, akin to thickness weighting.
+      hWght = 0.0
+      if (do_massWeight) &
+        hWght = max(0., bathyP(i,j)-p_t(i+1,j), bathyP(i+1,j)-p_t(i,j))
+      if (hWght > 0.) then
+        hL = (p_b(i,j) - p_t(i,j)) + dP_neglect
+        hR = (p_b(i+1,j) - p_t(i+1,j)) + dP_neglect
+        hWght = hWght * ( (hL-hR)/(hL+hR) )**2
+        iDenom = 1.0 / ( hWght*(hR + hL) + hL*hR )
+        hWt_LL = (hWght*hL + hR*hL) * iDenom ; hWt_LR = (hWght*hR) * iDenom
+        hWt_RR = (hWght*hR + hR*hL) * iDenom ; hWt_RL = (hWght*hL) * iDenom
+      else
+        hWt_LL = 1.0 ; hWt_LR = 0.0 ; hWt_RR = 1.0 ; hWt_RL = 0.0
+      endif
+
+      do m=2,4
+        wt_L = 0.25*real(5-m) ; wt_R = 1.0-wt_L
+        wtT_L = wt_L*hWt_LL + wt_R*hWt_RL ; wtT_R = wt_L*hWt_LR + wt_R*hWt_RR
+        pos = i*15+(m-2)*5
+
+        ! T, S, and p are interpolated in the horizontal.  The p interpolation
+        ! is linear, but for T and S it may be thickness weighted.
+        p15(pos+1) = wt_L*p_b(i,j) + wt_R*p_b(i+1,j)
+        dp_x(m,I) = wt_L*(p_b(i,j) - p_t(i,j)) + wt_R*(p_b(i+1,j) - p_t(i+1,j))
+        T15(pos+1) = wtT_L*T(i,j) + wtT_R*T(i+1,j)
+        S15(pos+1) = wtT_L*S(i,j) + wtT_R*S(i+1,j)
+
+        do n=2,5
+          T15(pos+n) = T15(pos+1) ; S15(pos+n) = S15(pos+1)
+          p15(pos+n) = p15(pos+n-1) - 0.25*dp_x(m,I)
+        enddo
       enddo
-      call calculate_spec_vol(T5, S5, p5, a5, EOS, spv_ref=alpha_ref)
-
-    ! Use Boole's rule to estimate the interface height anomaly change.
-      intp(m) = dp*( C1_90*(7.0*(a5(1)+a5(5)) + 32.0*(a5(2)+a5(4)) + &
-                                12.0*a5(3)))
     enddo
-    ! Use Boole's rule to integrate the interface height anomaly values in y.
-    inty_dza(i,j) = C1_90*(7.0*(intp(1)+intp(5)) + 32.0*(intp(2)+intp(4)) + &
-                           12.0*intp(3))
-  enddo ; enddo ; endif
+
+    call calculate_spec_vol(T15(15*Isq+1:), S15(15*Isq+1:), p15(15*Isq+1:), &
+                            a15(15*Isq+1:), EOS, EOSdom_q15, spv_ref=alpha_ref)
+
+    do I=Isq,Ieq
+      intp(1) = dza(i,j) ; intp(5) = dza(i+1,j)
+      ! Use Boole's rule to estimate the interface height anomaly change.
+      do m=2,4
+        pos = i*15+(m-2)*5
+        intp(m) = dp_x(m,I)*( C1_90*(7.0*(a15(pos+1)+a15(pos+5)) + 32.0*(a15(pos+2)+a15(pos+4)) + &
+                                  12.0*a15(pos+3)))
+      enddo
+      ! Use Boole's rule to integrate the interface height anomaly values in x.
+      intx_dza(i,j) = C1_90*(7.0*(intp(1)+intp(5)) + 32.0*(intp(2)+intp(4)) + &
+                             12.0*intp(3))
+    enddo
+  enddo ; endif
+
+  if (present(inty_dza)) then ; do J=Jsq,Jeq
+    do i=HI%isc,HI%iec
+      ! hWght is the distance measure by which the cell is violation of
+      ! hydrostatic consistency. For large hWght we bias the interpolation of
+      ! T & S along the top and bottom integrals, akin to thickness weighting.
+      hWght = 0.0
+      if (do_massWeight) &
+        hWght = max(0., bathyP(i,j)-p_t(i,j+1), bathyP(i,j+1)-p_t(i,j))
+      if (hWght > 0.) then
+        hL = (p_b(i,j) - p_t(i,j)) + dP_neglect
+        hR = (p_b(i,j+1) - p_t(i,j+1)) + dP_neglect
+        hWght = hWght * ( (hL-hR)/(hL+hR) )**2
+        iDenom = 1.0 / ( hWght*(hR + hL) + hL*hR )
+        hWt_LL = (hWght*hL + hR*hL) * iDenom ; hWt_LR = (hWght*hR) * iDenom
+        hWt_RR = (hWght*hR + hR*hL) * iDenom ; hWt_RL = (hWght*hL) * iDenom
+      else
+        hWt_LL = 1.0 ; hWt_LR = 0.0 ; hWt_RR = 1.0 ; hWt_RL = 0.0
+      endif
+
+      do m=2,4
+        wt_L = 0.25*real(5-m) ; wt_R = 1.0-wt_L
+        wtT_L = wt_L*hWt_LL + wt_R*hWt_RL ; wtT_R = wt_L*hWt_LR + wt_R*hWt_RR
+        pos = i*15+(m-2)*5
+
+        ! T, S, and p are interpolated in the horizontal.  The p interpolation
+        ! is linear, but for T and S it may be thickness weighted.
+        p15(pos+1) = wt_L*p_b(i,j) + wt_R*p_b(i,j+1)
+        dp_y(m,i) = wt_L*(p_b(i,j) - p_t(i,j)) + wt_R*(p_b(i,j+1) - p_t(i,j+1))
+        T15(pos+1) = wtT_L*T(i,j) + wtT_R*T(i,j+1)
+        S15(pos+1) = wtT_L*S(i,j) + wtT_R*S(i,j+1)
+        do n=2,5
+          T15(pos+n) = T15(pos+1) ; S15(pos+n) = S15(pos+1)
+          p15(pos+n) = p15(pos+n-1) - 0.25*dp_y(m,i)
+        enddo
+      enddo
+    enddo
+
+    call calculate_spec_vol(T15(15*HI%isc+1:), S15(15*HI%isc+1:), p15(15*HI%isc+1:), &
+                            a15(15*HI%isc+1:), EOS, EOSdom_h15, spv_ref=alpha_ref)
+
+    do i=HI%isc,HI%iec
+
+      intp(1) = dza(i,j) ; intp(5) = dza(i,j+1)
+      ! Use Boole's rule to estimate the interface height anomaly change.
+      do m=2,4
+        pos = i*15+(m-2)*5
+        intp(m) = dp_y(m,i)*( C1_90*(7.0*(a15(pos+1)+a15(pos+5)) + 32.0*(a15(pos+2)+a15(pos+4)) + &
+                                  12.0*a15(pos+3)))
+      enddo
+      ! Use Boole's rule to integrate the interface height anomaly values in y.
+      inty_dza(i,j) = C1_90*(7.0*(intp(1)+intp(5)) + 32.0*(intp(2)+intp(4)) + &
+                             12.0*intp(3))
+    enddo
+  enddo ; endif
 
 end subroutine int_spec_vol_dp_generic_pcm
 
@@ -1358,14 +1528,15 @@ subroutine int_spec_vol_dp_generic_plm(T_t, T_b, S_t, S_b, p_t, p_b, alpha_ref, 
 ! Boole's rule to do the horizontal integrals, and from a truncation in the
 ! series for log(1-eps/1+eps) that assumes that |eps| < 0.34.
 
-  real :: T5(5)      ! Temperatures at five quadrature points [C ~> degC]
-  real :: S5(5)      ! Salinities at five quadrature points [S ~> ppt]
-  real :: p5(5)      ! Pressures at five quadrature points [R L2 T-2 ~> Pa]
-  real :: a5(5)      ! Specific volumes at five quadrature points [R-1 ~> m3 kg-1]
-  real :: T15(15)    ! Temperatures at fifteen interior quadrature points [C ~> degC]
-  real :: S15(15)    ! Salinities at fifteen interior quadrature points [S ~> ppt]
-  real :: p15(15)    ! Pressures at fifteen quadrature points [R L2 T-2 ~> Pa]
-  real :: a15(15)    ! Specific volumes at fifteen quadrature points [R-1 ~> m3 kg-1]
+  real :: T5((5*HI%iscB+1):(5*(HI%iecB+2)))  ! Temperatures along a line of subgrid locations [C ~> degC]
+  real :: S5((5*HI%iscB+1):(5*(HI%iecB+2)))  ! Salinities along a line of subgrid locations [S ~> ppt]
+  real :: p5((5*HI%iscB+1):(5*(HI%iecB+2)))  ! Pressures along a line of subgrid locations [R L2 T-2 ~> Pa]
+  real :: a5((5*HI%iscB+1):(5*(HI%iecB+2)))  ! Specific volumes anomalies along a line of subgrid
+                                             ! locations [R-1 ~> m3 kg-3]
+  real :: T15((15*HI%iscB+1):(15*(HI%iecB+1))) ! Temperatures at an array of subgrid locations [C ~> degC]
+  real :: S15((15*HI%iscB+1):(15*(HI%iecB+1))) ! Salinities at an array of subgrid locations [S ~> ppt]
+  real :: p15((15*HI%iscB+1):(15*(HI%iecB+1))) ! Pressures at an array of subgrid locations [R L2 T-2 ~> Pa]
+  real :: a15((15*HI%iscB+1):(15*(HI%iecB+1))) ! Specific volumes at an array of subgrid locations [R ~> kg m-3]
   real :: wt_t(5), wt_b(5) ! Weights of top and bottom values at quadrature points [nondim]
   real :: T_top, T_bot ! Horizontally interpolated temperature at the cell top and bottom [C ~> degC]
   real :: S_top, S_bot ! Horizontally interpolated salinity at the cell top and bottom [S ~> ppt]
@@ -1373,7 +1544,7 @@ subroutine int_spec_vol_dp_generic_plm(T_t, T_b, S_t, S_b, p_t, p_b, alpha_ref, 
 
   real :: alpha_anom ! The depth averaged specific density anomaly [R-1 ~> m3 kg-1]
   real :: dp         ! The pressure change through a layer [R L2 T-2 ~> Pa]
-  real :: dp_90(2:4) ! The pressure change through a layer divided by 90 [R L2 T-2 ~> Pa]
+  real :: dp_90(2:4,SZIB_(HI)) ! The pressure change through a layer divided by 90 [R L2 T-2 ~> Pa]
   real :: hWght      ! A pressure-thickness below topography [R L2 T-2 ~> Pa]
   real :: hL, hR     ! Pressure-thicknesses of the columns to the left and right [R L2 T-2 ~> Pa]
   real :: iDenom     ! The inverse of the denominator in the weights [T4 R-2 L-4 ~> Pa-2]
@@ -1385,6 +1556,9 @@ subroutine int_spec_vol_dp_generic_plm(T_t, T_b, S_t, S_b, p_t, p_b, alpha_ref, 
                      ! 5 sub-column locations [L2 T-2 ~> m2 s-2]
   real, parameter :: C1_90 = 1.0/90.0  ! A rational constant [nondim]
   logical :: do_massWeight ! Indicates whether to do mass weighting.
+  integer, dimension(2) :: EOSdom_h5  ! The 5-point h-point i-computational domain for the equation of state
+  integer, dimension(2) :: EOSdom_q15 ! The 3x5-point q-point i-computational domain for the equation of state
+  integer, dimension(2) :: EOSdom_h15 ! The 3x5-point h-point i-computational domain for the equation of state
   integer :: Isq, Ieq, Jsq, Jeq, i, j, m, n, pos
 
   Isq = HI%IscB ; Ieq = HI%IecB ; Jsq = HI%JscB ; Jeq = HI%JecB
@@ -1397,140 +1571,157 @@ subroutine int_spec_vol_dp_generic_plm(T_t, T_b, S_t, S_b, p_t, p_b, alpha_ref, 
     wt_b(n) = 1.0 - wt_t(n)
   enddo
 
-  ! 1. Compute vertical integrals
-  do j=Jsq,Jeq+1 ; do i=Isq,Ieq+1
-    dp = p_b(i,j) - p_t(i,j)
-    do n=1,5 ! T, S and p are linearly interpolated in the vertical.
-      p5(n) = wt_t(n) * p_t(i,j) + wt_b(n) * p_b(i,j)
-      S5(n) = wt_t(n) * S_t(i,j) + wt_b(n) * S_b(i,j)
-      T5(n) = wt_t(n) * T_t(i,j) + wt_b(n) * T_b(i,j)
-    enddo
-    call calculate_spec_vol(T5, S5, p5, a5, EOS, spv_ref=alpha_ref)
+  ! Set the loop ranges for equation of state calculations at various points.
+  EOSdom_h5(1) = 1 ; EOSdom_h5(2) = 5*(Ieq-Isq+2)
+  EOSdom_q15(1) = 1 ; EOSdom_q15(2) = 15*(Ieq-Isq+1)
+  EOSdom_h15(1) = 1 ; EOSdom_h15(2) = 15*(HI%iec-HI%isc+1)
 
-    ! Use Boole's rule to estimate the interface height anomaly change.
-    alpha_anom = C1_90*((7.0*(a5(1)+a5(5)) + 32.0*(a5(2)+a5(4))) + 12.0*a5(3))
-    dza(i,j) = dp*alpha_anom
-    ! Use a Boole's-rule-like fifth-order accurate estimate of the double integral of
-    ! the interface height anomaly.
-    if (present(intp_dza)) intp_dza(i,j) = 0.5*dp**2 * &
-          (alpha_anom - C1_90*(16.0*(a5(4)-a5(2)) + 7.0*(a5(5)-a5(1))) )
-  enddo ; enddo
+  ! 1. Compute vertical integrals
+  do j=Jsq,Jeq+1
+    do i=Isq,Ieq+1
+      do n=1,5 ! T, S and p are linearly interpolated in the vertical.
+        p5(i*5+n) = wt_t(n) * p_t(i,j) + wt_b(n) * p_b(i,j)
+        S5(i*5+n) = wt_t(n) * S_t(i,j) + wt_b(n) * S_b(i,j)
+        T5(i*5+n) = wt_t(n) * T_t(i,j) + wt_b(n) * T_b(i,j)
+      enddo
+    enddo
+    call calculate_spec_vol(T5, S5, p5, a5, EOS, EOSdom_h5, spv_ref=alpha_ref)
+    do i=Isq,Ieq+1
+      ! Use Boole's rule to estimate the interface height anomaly change.
+      dp = p_b(i,j) - p_t(i,j)
+      alpha_anom = C1_90*((7.0*(a5(i*5+1)+a5(i*5+5)) + 32.0*(a5(i*5+2)+a5(i*5+4))) + 12.0*a5(i*5+3))
+      dza(i,j) = dp*alpha_anom
+      ! Use a Boole's-rule-like fifth-order accurate estimate of the double integral of
+      ! the interface height anomaly.
+      if (present(intp_dza)) intp_dza(i,j) = 0.5*dp**2 * &
+            (alpha_anom - C1_90*(16.0*(a5(i*5+4)-a5(i*5+2)) + 7.0*(a5(i*5+5)-a5(i*5+1))) )
+    enddo
+  enddo
 
   ! 2. Compute horizontal integrals in the x direction
-  if (present(intx_dza)) then ; do j=HI%jsc,HI%jec ; do I=Isq,Ieq
-    ! hWght is the distance measure by which the cell is violation of
-    ! hydrostatic consistency. For large hWght we bias the interpolation
-    ! of T,S along the top and bottom integrals, almost like thickness
-    ! weighting. Note: To work in terrain following coordinates we could
-    ! offset this distance by the layer thickness to replicate other models.
-    hWght = 0.0
-    if (do_massWeight) &
-      hWght =  max(0., bathyP(i,j)-p_t(i+1,j), bathyP(i+1,j)-p_t(i,j))
-    if (hWght > 0.) then
-      hL = (p_b(i,j) - p_t(i,j)) + dP_neglect
-      hR = (p_b(i+1,j) - p_t(i+1,j)) + dP_neglect
-      hWght = hWght * ( (hL-hR)/(hL+hR) )**2
-      iDenom = 1.0 / ( hWght*(hR + hL) + hL*hR )
-      hWt_LL = (hWght*hL + hR*hL) * iDenom ; hWt_LR = (hWght*hR) * iDenom
-      hWt_RR = (hWght*hR + hR*hL) * iDenom ; hWt_RL = (hWght*hL) * iDenom
-    else
-      hWt_LL = 1.0 ; hWt_LR = 0.0 ; hWt_RR = 1.0 ; hWt_RL = 0.0
-    endif
+  if (present(intx_dza)) then ; do j=HI%jsc,HI%jec
+    do I=Isq,Ieq
+      ! hWght is the distance measure by which the cell is violation of
+      ! hydrostatic consistency. For large hWght we bias the interpolation
+      ! of T,S along the top and bottom integrals, almost like thickness
+      ! weighting. Note: To work in terrain following coordinates we could
+      ! offset this distance by the layer thickness to replicate other models.
+      hWght = 0.0
+      if (do_massWeight) &
+        hWght =  max(0., bathyP(i,j)-p_t(i+1,j), bathyP(i+1,j)-p_t(i,j))
+      if (hWght > 0.) then
+        hL = (p_b(i,j) - p_t(i,j)) + dP_neglect
+        hR = (p_b(i+1,j) - p_t(i+1,j)) + dP_neglect
+        hWght = hWght * ( (hL-hR)/(hL+hR) )**2
+        iDenom = 1.0 / ( hWght*(hR + hL) + hL*hR )
+        hWt_LL = (hWght*hL + hR*hL) * iDenom ; hWt_LR = (hWght*hR) * iDenom
+        hWt_RR = (hWght*hR + hR*hL) * iDenom ; hWt_RL = (hWght*hL) * iDenom
+      else
+        hWt_LL = 1.0 ; hWt_LR = 0.0 ; hWt_RR = 1.0 ; hWt_RL = 0.0
+      endif
 
-    do m=2,4
-      wt_L = 0.25*real(5-m) ; wt_R = 1.0-wt_L
-      wtT_L = wt_L*hWt_LL + wt_R*hWt_RL ; wtT_R = wt_L*hWt_LR + wt_R*hWt_RR
+      do m=2,4
+        wt_L = 0.25*real(5-m) ; wt_R = 1.0-wt_L
+        wtT_L = wt_L*hWt_LL + wt_R*hWt_RL ; wtT_R = wt_L*hWt_LR + wt_R*hWt_RR
 
-      ! T, S, and p are interpolated in the horizontal.  The p interpolation
-      ! is linear, but for T and S it may be thickness weighted.
-      P_top = wt_L*p_t(i,j) + wt_R*p_t(i+1,j)
-      P_bot = wt_L*p_b(i,j) + wt_R*p_b(i+1,j)
-      T_top = wtT_L*T_t(i,j) + wtT_R*T_t(i+1,j)
-      T_bot = wtT_L*T_b(i,j) + wtT_R*T_b(i+1,j)
-      S_top = wtT_L*S_t(i,j) + wtT_R*S_t(i+1,j)
-      S_bot = wtT_L*S_b(i,j) + wtT_R*S_b(i+1,j)
-      dp_90(m) = C1_90*(P_bot - P_top)
+        ! T, S, and p are interpolated in the horizontal.  The p interpolation
+        ! is linear, but for T and S it may be thickness weighted.
+        P_top = wt_L*p_t(i,j) + wt_R*p_t(i+1,j)
+        P_bot = wt_L*p_b(i,j) + wt_R*p_b(i+1,j)
+        T_top = wtT_L*T_t(i,j) + wtT_R*T_t(i+1,j)
+        T_bot = wtT_L*T_b(i,j) + wtT_R*T_b(i+1,j)
+        S_top = wtT_L*S_t(i,j) + wtT_R*S_t(i+1,j)
+        S_bot = wtT_L*S_b(i,j) + wtT_R*S_b(i+1,j)
+        dp_90(m,I) = C1_90*(P_bot - P_top)
 
-      ! Salinity, temperature and pressure with linear interpolation in the vertical.
-      pos = (m-2)*5
-      do n=1,5
-        p15(pos+n) = wt_t(n) * P_top + wt_b(n) * P_bot
-        S15(pos+n) = wt_t(n) * S_top + wt_b(n) * S_bot
-        T15(pos+n) = wt_t(n) * T_top + wt_b(n) * T_bot
+        ! Salinity, temperature and pressure with linear interpolation in the vertical.
+        pos = i*15+(m-2)*5
+        do n=1,5
+          p15(pos+n) = wt_t(n) * P_top + wt_b(n) * P_bot
+          S15(pos+n) = wt_t(n) * S_top + wt_b(n) * S_bot
+          T15(pos+n) = wt_t(n) * T_top + wt_b(n) * T_bot
+        enddo
       enddo
     enddo
 
-    call calculate_spec_vol(T15, S15, p15, a15, EOS, spv_ref=alpha_ref)
+    call calculate_spec_vol(T15, S15, p15, a15, EOS, EOSdom_q15, spv_ref=alpha_ref)
 
-    intp(1) = dza(i,j) ; intp(5) = dza(i+1,j)
-    do m=2,4
-      ! Use Boole's rule to estimate the interface height anomaly change.
-      ! The integrals at the ends of the segment are already known.
-      pos = (m-2)*5
-      intp(m) = dp_90(m)*((7.0*(a15(pos+1)+a15(pos+5)) + &
-                          32.0*(a15(pos+2)+a15(pos+4))) + 12.0*a15(pos+3))
+    do I=Isq,Ieq
+      intp(1) = dza(i,j) ; intp(5) = dza(i+1,j)
+      do m=2,4
+        ! Use Boole's rule to estimate the interface height anomaly change.
+        ! The integrals at the ends of the segment are already known.
+        pos = I*15+(m-2)*5
+        intp(m) = dp_90(m,I)*((7.0*(a15(pos+1)+a15(pos+5)) + &
+                               32.0*(a15(pos+2)+a15(pos+4))) + 12.0*a15(pos+3))
+      enddo
+      ! Use Boole's rule to integrate the interface height anomaly values in x.
+      intx_dza(I,j) = C1_90*((7.0*(intp(1)+intp(5)) + 32.0*(intp(2)+intp(4))) + &
+                             12.0*intp(3))
     enddo
-    ! Use Boole's rule to integrate the interface height anomaly values in x.
-    intx_dza(I,j) = C1_90*((7.0*(intp(1)+intp(5)) + 32.0*(intp(2)+intp(4))) + &
-                           12.0*intp(3))
-  enddo ; enddo ; endif
+  enddo ; endif
 
   ! 3. Compute horizontal integrals in the y direction
-  if (present(inty_dza)) then ; do J=Jsq,Jeq ; do i=HI%isc,HI%iec
-    ! hWght is the distance measure by which the cell is violation of
-    ! hydrostatic consistency. For large hWght we bias the interpolation
-    ! of T,S along the top and bottom integrals, like thickness weighting.
-    hWght = 0.0
-    if (do_massWeight) &
-      hWght = max(0., bathyP(i,j)-p_t(i,j+1), bathyP(i,j+1)-p_t(i,j))
-    if (hWght > 0.) then
-      hL = (p_b(i,j) - p_t(i,j)) + dP_neglect
-      hR = (p_b(i,j+1) - p_t(i,j+1)) + dP_neglect
-      hWght = hWght * ( (hL-hR)/(hL+hR) )**2
-      iDenom = 1.0 / ( hWght*(hR + hL) + hL*hR )
-      hWt_LL = (hWght*hL + hR*hL) * iDenom ; hWt_LR = (hWght*hR) * iDenom
-      hWt_RR = (hWght*hR + hR*hL) * iDenom ; hWt_RL = (hWght*hL) * iDenom
-    else
-      hWt_LL = 1.0 ; hWt_LR = 0.0 ; hWt_RR = 1.0 ; hWt_RL = 0.0
-    endif
+  if (present(inty_dza)) then ; do J=Jsq,Jeq
+    do i=HI%isc,HI%iec
+      ! hWght is the distance measure by which the cell is violation of
+      ! hydrostatic consistency. For large hWght we bias the interpolation
+      ! of T,S along the top and bottom integrals, like thickness weighting.
+      hWght = 0.0
+      if (do_massWeight) &
+        hWght = max(0., bathyP(i,j)-p_t(i,j+1), bathyP(i,j+1)-p_t(i,j))
+      if (hWght > 0.) then
+        hL = (p_b(i,j) - p_t(i,j)) + dP_neglect
+        hR = (p_b(i,j+1) - p_t(i,j+1)) + dP_neglect
+        hWght = hWght * ( (hL-hR)/(hL+hR) )**2
+        iDenom = 1.0 / ( hWght*(hR + hL) + hL*hR )
+        hWt_LL = (hWght*hL + hR*hL) * iDenom ; hWt_LR = (hWght*hR) * iDenom
+        hWt_RR = (hWght*hR + hR*hL) * iDenom ; hWt_RL = (hWght*hL) * iDenom
+      else
+        hWt_LL = 1.0 ; hWt_LR = 0.0 ; hWt_RR = 1.0 ; hWt_RL = 0.0
+      endif
 
-    do m=2,4
-      wt_L = 0.25*real(5-m) ; wt_R = 1.0-wt_L
-      wtT_L = wt_L*hWt_LL + wt_R*hWt_RL ; wtT_R = wt_L*hWt_LR + wt_R*hWt_RR
+      do m=2,4
+        wt_L = 0.25*real(5-m) ; wt_R = 1.0-wt_L
+        wtT_L = wt_L*hWt_LL + wt_R*hWt_RL ; wtT_R = wt_L*hWt_LR + wt_R*hWt_RR
 
-      ! T, S, and p are interpolated in the horizontal.  The p interpolation
-      ! is linear, but for T and S it may be thickness weighted.
-      P_top = wt_L*p_t(i,j) + wt_R*p_t(i,j+1)
-      P_bot = wt_L*p_b(i,j) + wt_R*p_b(i,j+1)
-      T_top = wtT_L*T_t(i,j) + wtT_R*T_t(i,j+1)
-      T_bot = wtT_L*T_b(i,j) + wtT_R*T_b(i,j+1)
-      S_top = wtT_L*S_t(i,j) + wtT_R*S_t(i,j+1)
-      S_bot = wtT_L*S_b(i,j) + wtT_R*S_b(i,j+1)
-      dp_90(m) = C1_90*(P_bot - P_top)
+        ! T, S, and p are interpolated in the horizontal.  The p interpolation
+        ! is linear, but for T and S it may be thickness weighted.
+        P_top = wt_L*p_t(i,j) + wt_R*p_t(i,j+1)
+        P_bot = wt_L*p_b(i,j) + wt_R*p_b(i,j+1)
+        T_top = wtT_L*T_t(i,j) + wtT_R*T_t(i,j+1)
+        T_bot = wtT_L*T_b(i,j) + wtT_R*T_b(i,j+1)
+        S_top = wtT_L*S_t(i,j) + wtT_R*S_t(i,j+1)
+        S_bot = wtT_L*S_b(i,j) + wtT_R*S_b(i,j+1)
+        dp_90(m,i) = C1_90*(P_bot - P_top)
 
-      ! Salinity, temperature and pressure with linear interpolation in the vertical.
-      pos = (m-2)*5
-      do n=1,5
-        p15(pos+n) = wt_t(n) * P_top + wt_b(n) * P_bot
-        S15(pos+n) = wt_t(n) * S_top + wt_b(n) * S_bot
-        T15(pos+n) = wt_t(n) * T_top + wt_b(n) * T_bot
+        ! Salinity, temperature and pressure with linear interpolation in the vertical.
+        pos = i*15+(m-2)*5
+        do n=1,5
+          p15(pos+n) = wt_t(n) * P_top + wt_b(n) * P_bot
+          S15(pos+n) = wt_t(n) * S_top + wt_b(n) * S_bot
+          T15(pos+n) = wt_t(n) * T_top + wt_b(n) * T_bot
+        enddo
       enddo
     enddo
 
-    call calculate_spec_vol(T15, S15, p15, a15, EOS, spv_ref=alpha_ref)
+    call calculate_spec_vol(T15(15*HI%isc+1:), S15(15*HI%isc+1:), p15(15*HI%isc+1:), &
+                            a15(15*HI%isc+1:), EOS, EOSdom_h15, spv_ref=alpha_ref)
 
-    intp(1) = dza(i,j) ; intp(5) = dza(i,j+1)
-    do m=2,4
-      ! Use Boole's rule to estimate the interface height anomaly change.
-      ! The integrals at the ends of the segment are already known.
-      pos = (m-2)*5
-      intp(m) = dp_90(m) * ((7.0*(a15(pos+1)+a15(pos+5)) + &
-                            32.0*(a15(pos+2)+a15(pos+4))) + 12.0*a15(pos+3))
+    do i=HI%isc,HI%iec
+      intp(1) = dza(i,j) ; intp(5) = dza(i,j+1)
+      do m=2,4
+        ! Use Boole's rule to estimate the interface height anomaly change.
+        ! The integrals at the ends of the segment are already known.
+        pos = i*15+(m-2)*5
+        intp(m) = dp_90(m,i) * ((7.0*(a15(pos+1)+a15(pos+5)) + &
+                                 32.0*(a15(pos+2)+a15(pos+4))) + 12.0*a15(pos+3))
+      enddo
+      ! Use Boole's rule to integrate the interface height anomaly values in x.
+      inty_dza(i,J) = C1_90*((7.0*(intp(1)+intp(5)) + 32.0*(intp(2)+intp(4))) + &
+                             12.0*intp(3))
     enddo
-    ! Use Boole's rule to integrate the interface height anomaly values in x.
-    inty_dza(i,J) = C1_90*((7.0*(intp(1)+intp(5)) + 32.0*(intp(2)+intp(4))) + &
-                           12.0*intp(3))
-  enddo ; enddo ; endif
+  enddo ; endif
 
 end subroutine int_spec_vol_dp_generic_plm
 

--- a/src/core/MOM_density_integrals.F90
+++ b/src/core/MOM_density_integrals.F90
@@ -1753,7 +1753,7 @@ subroutine find_depth_of_pressure_in_cell(T_t, T_b, S_t, S_b, z_t, z_b, P_t, P_t
   real :: F_guess, F_l, F_r  ! Fractional positions [nondim]
   real :: GxRho ! The product of the gravitational acceleration and reference density [R L2 Z-1 T-2 ~> Pa m-1]
   real :: Pa, Pa_left, Pa_right, Pa_tol ! Pressure anomalies, P = integral of g*(rho-rho_ref) dz [R L2 T-2 ~> Pa]
-  integer :: m  ! A counter for how many iterations have been done in the while loop [nondim]
+  integer :: m  ! A counter for how many iterations have been done in the while loop
   character(len=240) :: msg
 
   GxRho = G_e * rho_ref
@@ -1785,9 +1785,9 @@ subroutine find_depth_of_pressure_in_cell(T_t, T_b, S_t, S_b, z_t, z_b, P_t, P_t
   do while ( abs(Pa) > Pa_tol )
 
     m = m + 1
-    if (m > 30) then !Call an error, because convergence to the tolerance has not been achieved
+    if (m > 30) then ! Call an error, because convergence to the tolerance has not been achieved
      write(msg,*) Pa_left,Pa,Pa_right,P_t-P_tgt,P_b-P_tgt
-     call MOM_error(FATAL, 'find_depth_of_pressure_in_cell completes too many iterations: /n'//msg)
+     call MOM_error(FATAL, 'find_depth_of_pressure_in_cell completes too many iterations: '//msg)
     endif
     z_out = z_t + ( z_b - z_t ) * F_guess
     Pa = frac_dp_at_pos(T_t, T_b, S_t, S_b, z_t, z_b, rho_ref, G_e, F_guess, EOS) - ( P_tgt - P_t )

--- a/src/core/MOM_density_integrals.F90
+++ b/src/core/MOM_density_integrals.F90
@@ -1753,6 +1753,7 @@ subroutine find_depth_of_pressure_in_cell(T_t, T_b, S_t, S_b, z_t, z_b, P_t, P_t
   real :: F_guess, F_l, F_r  ! Fractional positions [nondim]
   real :: GxRho ! The product of the gravitational acceleration and reference density [R L2 Z-1 T-2 ~> Pa m-1]
   real :: Pa, Pa_left, Pa_right, Pa_tol ! Pressure anomalies, P = integral of g*(rho-rho_ref) dz [R L2 T-2 ~> Pa]
+  integer :: m  ! A counter for how many iterations have been done in the while loop [nondim]
   character(len=240) :: msg
 
   GxRho = G_e * rho_ref
@@ -1780,8 +1781,14 @@ subroutine find_depth_of_pressure_in_cell(T_t, T_b, S_t, S_b, z_t, z_b, P_t, P_t
 
   F_guess = F_l - Pa_left / (Pa_right - Pa_left) * (F_r - F_l)
   Pa = Pa_right - Pa_left ! To get into iterative loop
+  m = 0 ! Reset the counter for the loop to be zero
   do while ( abs(Pa) > Pa_tol )
 
+    m = m + 1
+    if (m > 30) then !Call an error, because convergence to the tolerance has not been achieved
+     write(msg,*) Pa_left,Pa,Pa_right,P_t-P_tgt,P_b-P_tgt
+     call MOM_error(FATAL, 'find_depth_of_pressure_in_cell completes too many iterations: /n'//msg)
+    endif
     z_out = z_t + ( z_b - z_t ) * F_guess
     Pa = frac_dp_at_pos(T_t, T_b, S_t, S_b, z_t, z_b, rho_ref, G_e, F_guess, EOS) - ( P_tgt - P_t )
 

--- a/src/core/MOM_dynamics_split_RK2.F90
+++ b/src/core/MOM_dynamics_split_RK2.F90
@@ -851,7 +851,7 @@ subroutine step_MOM_dyn_split_RK2(u_inst, v_inst, h, tv, visc, Time_local, dt, f
   call horizontal_viscosity(u_av, v_av, h_av, CS%diffu, CS%diffv, &
                             MEKE, Varmix, G, GV, US, CS%hor_visc, &
                             OBC=CS%OBC, BT=CS%barotropic_CSp, TD=thickness_diffuse_CSp, &
-                            ADp=CS%ADp)
+                            ADp=CS%ADp, hu_cont=CS%BT_cont%h_u, hv_cont=CS%BT_cont%h_v)
   call cpu_clock_end(id_clock_horvisc)
   if (showCallTree) call callTree_wayPoint("done with horizontal_viscosity (step_MOM_dyn_split_RK2)")
 
@@ -1518,7 +1518,8 @@ subroutine initialize_dyn_split_RK2(u, v, h, uh, vh, eta, Time, G, GV, US, param
   if (.not. query_initialized(CS%diffu, "diffu", restart_CS) .or. &
       .not. query_initialized(CS%diffv, "diffv", restart_CS)) then
     call horizontal_viscosity(u, v, h, CS%diffu, CS%diffv, MEKE, VarMix, G, GV, US, CS%hor_visc, &
-                              OBC=CS%OBC, BT=CS%barotropic_CSp, TD=thickness_diffuse_CSp)
+                              OBC=CS%OBC, BT=CS%barotropic_CSp, TD=thickness_diffuse_CSp, &
+                              hu_cont=CS%BT_cont%h_u, hv_cont=CS%BT_cont%h_v)
     call set_initialized(CS%diffu, "diffu", restart_CS)
     call set_initialized(CS%diffv, "diffv", restart_CS)
   endif

--- a/src/core/MOM_dynamics_split_RK2.F90
+++ b/src/core/MOM_dynamics_split_RK2.F90
@@ -71,9 +71,6 @@ use MOM_vert_friction,         only : updateCFLtruncationValue, vertFPmix
 use MOM_verticalGrid,          only : verticalGrid_type, get_thickness_units
 use MOM_verticalGrid,          only : get_flux_units, get_tr_flux_units
 use MOM_wave_interface,        only : wave_parameters_CS, Stokes_PGF
-use MOM_CVMix_KPP,             only : KPP_get_BLD, KPP_CS
-use MOM_energetic_PBL,         only : energetic_PBL_get_MLD, energetic_PBL_CS
-use MOM_diabatic_driver,       only : diabatic_CS, extract_diabatic_member
 
 implicit none ; private
 
@@ -139,8 +136,6 @@ type, public :: MOM_dyn_split_RK2_CS ; private
   real ALLOCABLE_, dimension(NIMEM_,NJMEM_,NKMEM_)      :: pbce   !< pbce times eta gives the baroclinic pressure
                                                                   !! anomaly in each layer due to free surface height
                                                                   !! anomalies [L2 H-1 T-2 ~> m s-2 or m4 kg-1 s-2].
-  type(KPP_CS),           pointer :: KPP_CSp => NULL() !< KPP control structure needed to ge
-  type(energetic_PBL_CS), pointer :: energetic_PBL_CSp => NULL()  !< ePBL control structure
 
   real, pointer, dimension(:,:) :: taux_bot => NULL() !< frictional x-bottom stress from the ocean
                                                       !! to the seafloor [R L Z T-2 ~> Pa]
@@ -717,9 +712,7 @@ subroutine step_MOM_dyn_split_RK2(u_inst, v_inst, h, tv, visc, Time_local, dt, f
 
   if (CS%fpmix) then
     hbl(:,:) = 0.0
-    if (ASSOCIATED(CS%KPP_CSp)) call KPP_get_BLD(CS%KPP_CSp, hbl, G, US, m_to_BLD_units=GV%m_to_H)
-    if (ASSOCIATED(CS%energetic_PBL_CSp)) &
-      call energetic_PBL_get_MLD(CS%energetic_PBL_CSp, hbl, G, US, m_to_MLD_units=GV%m_to_H)
+    if (associated(visc%h_ML)) hbl(:,:) = visc%h_ML(:,:)
     call vertFPmix(up, vp, uold, vold, hbl, h, forces, &
                    dt_pred, G, GV, US, CS%vertvisc_CSp, CS%OBC)
     call vertvisc(up, vp, h, forces, visc, dt_pred, CS%OBC, CS%ADp, CS%CDp, G, &

--- a/src/core/MOM_dynamics_split_RK2.F90
+++ b/src/core/MOM_dynamics_split_RK2.F90
@@ -840,7 +840,7 @@ subroutine step_MOM_dyn_split_RK2(u_inst, v_inst, h, tv, visc, Time_local, dt, f
   if (CS%debug) then
     call MOM_state_chksum("Predictor ", up, vp, hp, uh, vh, G, GV, US, symmetric=sym)
     call uvchksum("Predictor avg [uv]", u_av, v_av, G%HI, haloshift=1, symmetric=sym, scale=US%L_T_to_m_s)
-    call hchksum(h_av, "Predictor avg h", G%HI, haloshift=0, scale=GV%H_to_MKS)
+    call hchksum(h_av, "Predictor avg h", G%HI, haloshift=2, scale=GV%H_to_MKS)
   ! call MOM_state_chksum("Predictor avg ", u_av, v_av, h_av, uh, vh, G, GV, US)
     call check_redundant("Predictor up ", up, vp, G, unscale=US%L_T_to_m_s)
     call check_redundant("Predictor uh ", uh, vh, G, unscale=GV%H_to_MKS*US%L_to_m**2*US%s_to_T)
@@ -849,7 +849,7 @@ subroutine step_MOM_dyn_split_RK2(u_inst, v_inst, h, tv, visc, Time_local, dt, f
 ! diffu = horizontal viscosity terms (u_av)
   call cpu_clock_begin(id_clock_horvisc)
   call horizontal_viscosity(u_av, v_av, h_av, CS%diffu, CS%diffv, &
-                            MEKE, Varmix, G, GV, US, CS%hor_visc, &
+                            MEKE, Varmix, G, GV, US, CS%hor_visc, tv, dt, &
                             OBC=CS%OBC, BT=CS%barotropic_CSp, TD=thickness_diffuse_CSp, &
                             ADp=CS%ADp, hu_cont=CS%BT_cont%h_u, hv_cont=CS%BT_cont%h_v)
   call cpu_clock_end(id_clock_horvisc)
@@ -1296,7 +1296,7 @@ end subroutine remap_dyn_split_RK2_aux_vars
 
 !> This subroutine initializes all of the variables that are used by this
 !! dynamic core, including diagnostics and the cpu clocks.
-subroutine initialize_dyn_split_RK2(u, v, h, uh, vh, eta, Time, G, GV, US, param_file, &
+subroutine initialize_dyn_split_RK2(u, v, h, tv, uh, vh, eta, Time, G, GV, US, param_file, &
                       diag, CS, restart_CS, dt, Accel_diag, Cont_diag, MIS, &
                       VarMix, MEKE, thickness_diffuse_CSp,                  &
                       OBC, update_OBC_CSp, ALE_CSp, set_visc, &
@@ -1310,6 +1310,7 @@ subroutine initialize_dyn_split_RK2(u, v, h, uh, vh, eta, Time, G, GV, US, param
                                     intent(inout) :: v          !< merid velocity [L T-1 ~> m s-1]
   real, dimension(SZI_(G),SZJ_(G),SZK_(GV)),  &
                                     intent(inout) :: h          !< layer thickness [H ~> m or kg m-2]
+  type(thermo_var_ptrs),            intent(in)    :: tv         !< Thermodynamic type
   real, dimension(SZIB_(G),SZJ_(G),SZK_(GV)), &
                             target, intent(inout) :: uh    !< zonal volume/mass transport [H L2 T-1 ~> m3 s-1 or kg s-1]
   real, dimension(SZI_(G),SZJB_(G),SZK_(GV)), &
@@ -1518,7 +1519,7 @@ subroutine initialize_dyn_split_RK2(u, v, h, uh, vh, eta, Time, G, GV, US, param
   if (.not. query_initialized(CS%diffu, "diffu", restart_CS) .or. &
       .not. query_initialized(CS%diffv, "diffv", restart_CS)) then
     call horizontal_viscosity(u, v, h, CS%diffu, CS%diffv, MEKE, VarMix, G, GV, US, CS%hor_visc, &
-                              OBC=CS%OBC, BT=CS%barotropic_CSp, TD=thickness_diffuse_CSp, &
+                              tv, dt, OBC=CS%OBC, BT=CS%barotropic_CSp, TD=thickness_diffuse_CSp, &
                               hu_cont=CS%BT_cont%h_u, hv_cont=CS%BT_cont%h_v)
     call set_initialized(CS%diffu, "diffu", restart_CS)
     call set_initialized(CS%diffv, "diffv", restart_CS)

--- a/src/core/MOM_dynamics_split_RK2b.F90
+++ b/src/core/MOM_dynamics_split_RK2b.F90
@@ -141,6 +141,12 @@ type, public :: MOM_dyn_split_RK2b_CS ; private
   real ALLOCABLE_, dimension(NIMEM_,NJMEM_,NKMEM_)      :: pbce   !< pbce times eta gives the baroclinic pressure
                                                                   !! anomaly in each layer due to free surface height
                                                                   !! anomalies [L2 H-1 T-2 ~> m s-2 or m4 kg-1 s-2].
+  real ALLOCABLE_, dimension(NIMEMB_PTR_,NJMEM_)        :: du_av_inst !< The barotropic zonal velocity increment
+                                                                  !! between filtered and instantaneous velocities
+                                                                  !! [L T-1 ~> m s-1]
+  real ALLOCABLE_, dimension(NIMEM_,NJMEMB_PTR_)        :: dv_av_inst !< The barotropic meridional velocity increment
+                                                                  !! between filtered and instantaneous velocities
+                                                                  !! [L T-1 ~> m s-1]
   type(KPP_CS),           pointer :: KPP_CSp => NULL() !< KPP control structure needed to ge
   type(energetic_PBL_CS), pointer :: energetic_PBL_CSp => NULL()  !< ePBL control structure
 
@@ -157,12 +163,6 @@ type, public :: MOM_dyn_split_RK2b_CS ; private
                                   !! barotropic solver.
   logical :: calc_dtbt            !< If true, calculate the barotropic time-step
                                   !! dynamically.
-  logical :: store_CAu            !< If true, store the Coriolis and advective accelerations at the
-                                  !! end of the timestep for use in the next predictor step.
-  logical :: CAu_pred_stored      !< If true, the Coriolis and advective accelerations at the
-                                  !! end of the timestep have been stored for use in the next
-                                  !! predictor step.  This is used to accomodate various generations
-                                  !! of restart files.
   logical :: calculate_SAL        !< If true, calculate self-attraction and loading.
   logical :: use_tides            !< If true, tidal forcing is enabled.
   logical :: remap_aux            !< If true, apply ALE remapping to all of the auxiliary 3-D
@@ -181,7 +181,7 @@ type, public :: MOM_dyn_split_RK2b_CS ; private
   logical :: module_is_initialized = .false. !< Record whether this module has been initialized.
 
   !>@{ Diagnostic IDs
-  integer :: id_uold   = -1, id_vold   = -1
+  !  integer :: id_uold   = -1, id_vold   = -1
   integer :: id_uh     = -1, id_vh     = -1
   integer :: id_umo    = -1, id_vmo    = -1
   integer :: id_umo_2d = -1, id_vmo_2d = -1
@@ -253,13 +253,14 @@ type, public :: MOM_dyn_split_RK2b_CS ; private
   !> A pointer to the update_OBC control structure
   type(update_OBC_CS),    pointer :: update_OBC_CSp => NULL()
 
-  type(group_pass_type) :: pass_eta  !< Structure for group halo pass
+  type(group_pass_type) :: pass_eta    !< Structure for group halo pass
   type(group_pass_type) :: pass_visc_rem  !< Structure for group halo pass
-  type(group_pass_type) :: pass_uvp  !< Structure for group halo pass
+  type(group_pass_type) :: pass_uvp    !< Structure for group halo pass
   type(group_pass_type) :: pass_hp_uv  !< Structure for group halo pass
-  type(group_pass_type) :: pass_uv  !< Structure for group halo pass
-  type(group_pass_type) :: pass_h  !< Structure for group halo pass
-  type(group_pass_type) :: pass_av_uvh  !< Structure for group halo pass
+  type(group_pass_type) :: pass_h_av   !< Structure for group halo pass
+  type(group_pass_type) :: pass_uv     !< Structure for group halo pass
+  type(group_pass_type) :: pass_h      !< Structure for group halo pass
+  type(group_pass_type) :: pass_av_uvh !< Structure for group halo pass
 
 end type MOM_dyn_split_RK2b_CS
 
@@ -275,22 +276,22 @@ integer :: id_clock_Cor, id_clock_pres, id_clock_vertvisc
 integer :: id_clock_horvisc, id_clock_mom_update
 integer :: id_clock_continuity, id_clock_thick_diff
 integer :: id_clock_btstep, id_clock_btcalc, id_clock_btforce
-integer :: id_clock_pass, id_clock_pass_init
+integer :: id_clock_pass
 !>@}
 
 contains
 
 !> RK2 splitting for time stepping MOM adiabatic dynamics
-subroutine step_MOM_dyn_split_RK2b(u_inst, v_inst, h, tv, visc, Time_local, dt, forces, &
+subroutine step_MOM_dyn_split_RK2b(u_av, v_av, h, tv, visc, Time_local, dt, forces, &
                                    p_surf_begin, p_surf_end, uh, vh, uhtr, vhtr, eta_av, &
                                    G, GV, US, CS, calc_dtbt, VarMix, MEKE, thickness_diffuse_CSp, pbv, Waves)
   type(ocean_grid_type),             intent(inout) :: G            !< Ocean grid structure
   type(verticalGrid_type),           intent(in)    :: GV           !< Ocean vertical grid structure
   type(unit_scale_type),             intent(in)    :: US           !< A dimensional unit scaling type
   real, dimension(SZIB_(G),SZJ_(G),SZK_(GV)), &
-                             target, intent(inout) :: u_inst       !< Zonal velocity [L T-1 ~> m s-1]
+                             target, intent(inout) :: u_av         !< Zonal velocity [L T-1 ~> m s-1]
   real, dimension(SZI_(G),SZJB_(G),SZK_(GV)), &
-                             target, intent(inout) :: v_inst       !< Meridional velocity [L T-1 ~> m s-1]
+                             target, intent(inout) :: v_av         !< Meridional velocity [L T-1 ~> m s-1]
   real, dimension(SZI_(G),SZJ_(G),SZK_(GV)), &
                                      intent(inout) :: h            !< Layer thickness [H ~> m or kg m-2]
   type(thermo_var_ptrs),             intent(in)    :: tv           !< Thermodynamic type
@@ -330,6 +331,7 @@ subroutine step_MOM_dyn_split_RK2b(u_inst, v_inst, h, tv, visc, Time_local, dt, 
   real, dimension(SZIB_(G),SZJ_(G),SZK_(GV)) :: up  ! Predicted zonal velocity [L T-1 ~> m s-1].
   real, dimension(SZI_(G),SZJB_(G),SZK_(GV)) :: vp  ! Predicted meridional velocity [L T-1 ~> m s-1].
   real, dimension(SZI_(G),SZJ_(G),SZK_(GV))  :: hp  ! Predicted thickness [H ~> m or kg m-2].
+
   real, dimension(SZI_(G),SZJ_(G),SZK_(GV))  :: dz  ! Distance between the interfaces around a layer [Z ~> m]
   real, dimension(SZIB_(G),SZJ_(G),SZK_(GV)) :: ueffA   ! Effective Area of U-Faces [H L ~> m2]
   real, dimension(SZI_(G),SZJB_(G),SZK_(GV)) :: veffA   ! Effective Area of V-Faces [H L ~> m2]
@@ -339,6 +341,11 @@ subroutine step_MOM_dyn_split_RK2b(u_inst, v_inst, h, tv, visc, Time_local, dt, 
   real, dimension(SZI_(G),SZJB_(G),SZK_(GV)) :: v_bc_accel ! The summed meridional baroclinic accelerations
                                                         ! of each layer calculated by the non-barotropic
                                                         ! part of the model [L T-2 ~> m s-2]
+
+  real, dimension(SZIB_(G),SZJ_(G),SZK_(GV)), target :: u_inst ! Instantaneous zonal velocity [L T-1 ~> m s-1].
+  real, dimension(SZI_(G),SZJB_(G),SZK_(GV)), target :: v_inst ! Instantaneous meridional velocity [L T-1 ~> m s-1].
+  real, dimension(SZI_(G),SZJ_(G),SZK_(GV))  :: h_av ! The average of the layer thicknesses at the beginning
+                                                     ! and end of a time step [H ~> m or kg m-2]
 
   real, dimension(SZIB_(G),SZJ_(G),SZK_(GV)), target :: uh_in ! The zonal mass transports that would be
                                 ! obtained using the initial velocities [H L2 T-1 ~> m3 s-1 or kg s-1]
@@ -378,11 +385,7 @@ subroutine step_MOM_dyn_split_RK2b(u_inst, v_inst, h, tv, visc, Time_local, dt, 
     u_ptr => NULL(), &   ! A pointer to a zonal velocity [L T-1 ~> m s-1]
     v_ptr => NULL(), &   ! A pointer to a meridional velocity [L T-1 ~> m s-1]
     uh_ptr => NULL(), &  ! A pointer to a zonal volume or mass transport [H L2 T-1 ~> m3 s-1 or kg s-1]
-    vh_ptr => NULL(), &  ! A pointer to a meridional volume or mass transport [H L2 T-1 ~> m3 s-1 or kg s-1]
-    ! These pointers are just used as shorthand for CS%u_av, CS%v_av, and CS%h_av.
-    u_av, & ! The zonal velocity time-averaged over a time step [L T-1 ~> m s-1].
-    v_av, & ! The meridional velocity time-averaged over a time step [L T-1 ~> m s-1].
-    h_av    ! The layer thickness time-averaged over a time step [H ~> m or kg m-2].
+    vh_ptr => NULL()     ! A pointer to a meridional volume or mass transport [H L2 T-1 ~> m3 s-1 or kg s-1]
 
   real, dimension(SZI_(G),SZJ_(G)) :: hbl       ! Boundary layer depth from Cvmix [H ~> m or kg m-2]
   real :: dt_pred   ! The time step for the predictor part of the baroclinic time stepping [T ~> s].
@@ -400,7 +403,8 @@ subroutine step_MOM_dyn_split_RK2b(u_inst, v_inst, h, tv, visc, Time_local, dt, 
 
   is  = G%isc  ; ie  = G%iec  ; js  = G%jsc  ; je  = G%jec ; nz = GV%ke
   Isq = G%IscB ; Ieq = G%IecB ; Jsq = G%JscB ; Jeq = G%JecB
-  u_av => CS%u_av ; v_av => CS%v_av ; h_av => CS%h_av ; eta => CS%eta
+
+  eta => CS%eta
 
   Idt_bc = 1.0 / dt
 
@@ -409,19 +413,16 @@ subroutine step_MOM_dyn_split_RK2b(u_inst, v_inst, h, tv, visc, Time_local, dt, 
   showCallTree = callTree_showQuery()
   if (showCallTree) call callTree_enter("step_MOM_dyn_split_RK2b(), MOM_dynamics_split_RK2b.F90")
 
-  !$OMP parallel do default(shared)
-  do k=1,nz
-    do j=G%jsd,G%jed   ; do i=G%isdB,G%iedB ;  up(i,j,k) = 0.0 ; enddo ; enddo
-    do j=G%jsdB,G%jedB ; do i=G%isd,G%ied   ;  vp(i,j,k) = 0.0 ; enddo ; enddo
-    do j=G%jsd,G%jed   ; do i=G%isd,G%ied   ;  hp(i,j,k) = h(i,j,k) ; enddo ; enddo
-  enddo
+  ! Fill in some halo points for arrays that will have halo updates.
+  hp(:,:,:) = h(:,:,:)
+  up(:,:,:) = 0.0 ; vp(:,:,:) = 0.0 ; u_inst(:,:,:) = 0.0 ; v_inst(:,:,:) = 0.0
 
   ! Update CFL truncation value as function of time
   call updateCFLtruncationValue(Time_local, CS%vertvisc_CSp, US)
 
   if (CS%debug) then
-    call MOM_state_chksum("Start predictor ", u_inst, v_inst, h, uh, vh, G, GV, US, symmetric=sym)
-    call check_redundant("Start predictor u ", u_inst, v_inst, G, unscale=US%L_T_to_m_s)
+    call MOM_state_chksum("Start predictor ", u_av, v_av, h, uh, vh, G, GV, US, symmetric=sym)
+    call check_redundant("Start predictor u ", u_av, v_av, G, unscale=US%L_T_to_m_s)
     call check_redundant("Start predictor uh ", uh, vh, G, unscale=GV%H_to_MKS*US%L_to_m**2*US%s_to_T)
   endif
 
@@ -476,9 +477,25 @@ subroutine step_MOM_dyn_split_RK2b(u_inst, v_inst, h, tv, visc, Time_local, dt, 
   call create_group_pass(CS%pass_h, h, G%Domain, halo=max(2,cont_stencil))
   call create_group_pass(CS%pass_av_uvh, u_av, v_av, G%Domain, halo=max(2,obc_stencil))
   call create_group_pass(CS%pass_av_uvh, uh(:,:,:), vh(:,:,:), G%Domain, halo=max(2,obc_stencil))
+
+  call create_group_pass(CS%pass_h_av, hp, G%Domain, halo=2)
+  call create_group_pass(CS%pass_h_av, uh(:,:,:), vh(:,:,:), G%Domain, halo=max(2,obc_stencil))
+
   call cpu_clock_end(id_clock_pass)
   !--- end set up for group halo pass
 
+  if (associated(CS%OBC)) then ; if (CS%OBC%update_OBC) then
+    call update_OBC_data(CS%OBC, G, GV, US, tv, h, CS%update_OBC_CSp, Time_local)
+  endif ; endif
+
+  ! This calculates the transports and averaged thicknesses that will be used for the
+  ! predictor version of the Coriolis scheme.
+  call cpu_clock_begin(id_clock_continuity)
+  call continuity(u_av, v_av, h, hp, uh, vh, dt, G, GV, US, CS%continuity_CSp, CS%OBC, pbv)
+  call cpu_clock_end(id_clock_continuity)
+
+  if (G%nonblocking_updates) &
+    call start_group_pass(CS%pass_h_av, G%Domain, clock=id_clock_pass)
 
 ! PFu = d/dx M(h,T,S)
 ! pbce = dM/deta
@@ -500,7 +517,7 @@ subroutine step_MOM_dyn_split_RK2b(u_inst, v_inst, h, tv, visc, Time_local, dt, 
     if (Use_Stokes_PGF) Use_Stokes_PGF = Waves%Stokes_PGF
     if (Use_Stokes_PGF) then
       call thickness_to_dz(h, tv, dz, G, GV, US, halo_size=1)
-      call Stokes_PGF(G, GV, US, dz, u_inst, v_inst, CS%PFu_Stokes, CS%PFv_Stokes, Waves)
+      call Stokes_PGF(G, GV, US, dz, u_av, v_av, CS%PFu_Stokes, CS%PFv_Stokes, Waves)
 
       ! We are adding Stokes_PGF to hydrostatic PGF here.  The diag PFu/PFv
       ! will therefore report the sum total PGF and we avoid other
@@ -523,25 +540,37 @@ subroutine step_MOM_dyn_split_RK2b(u_inst, v_inst, h, tv, visc, Time_local, dt, 
   call disable_averaging(CS%diag)
   if (showCallTree) call callTree_wayPoint("done with PressureForce (step_MOM_dyn_split_RK2b)")
 
-  if (associated(CS%OBC)) then ; if (CS%OBC%update_OBC) then
-    call update_OBC_data(CS%OBC, G, GV, US, tv, h, CS%update_OBC_CSp, Time_local)
-  endif ; endif
   if (associated(CS%OBC) .and. CS%debug_OBC) &
     call open_boundary_zero_normal_flow(CS%OBC, G, GV, CS%PFu, CS%PFv)
 
-  if (G%nonblocking_updates) &
+  if (G%nonblocking_updates) then
+    call complete_group_pass(CS%pass_h_av, G%Domain, clock=id_clock_pass)
     call start_group_pass(CS%pass_eta, G%Domain, clock=id_clock_pass)
+  else
+    call do_group_pass(CS%pass_h_av, G%Domain, clock=id_clock_pass)
+  endif
+
+  !$OMP parallel do default(shared)
+  do k=1,nz ; do j=js-2,je+2 ; do i=is-2,ie+2
+    h_av(i,j,k) = 0.5*(hp(i,j,k) + h(i,j,k))
+  enddo ; enddo ; enddo
+
+  ! Calculate a predictor-step estimate of the Coriolis and momentum advection terms
+  ! and horizontal viscous accelerations.
 
 ! CAu = -(f+zeta_av)/h_av vh + d/dx KE_av
-  if (.not.CS%CAu_pred_stored) then
-    ! Calculate a predictor-step estimate of the Coriolis and momentum advection terms,
-    ! if it was not already stored from the end of the previous time step.
-    call cpu_clock_begin(id_clock_Cor)
-    call CorAdCalc(u_av, v_av, h_av, uh, vh, CS%CAu_pred, CS%CAv_pred, CS%OBC, CS%AD_pred, &
-                   G, GV, US, CS%CoriolisAdv, pbv, Waves=Waves)
-    call cpu_clock_end(id_clock_Cor)
-    if (showCallTree) call callTree_wayPoint("done with CorAdCalc (step_MOM_dyn_split_RK2b)")
-  endif
+  call cpu_clock_begin(id_clock_Cor)
+  call CorAdCalc(u_av, v_av, h_av, uh, vh, CS%CAu_pred, CS%CAv_pred, CS%OBC, CS%AD_pred, &
+                 G, GV, US, CS%CoriolisAdv, pbv, Waves=Waves)
+  call cpu_clock_end(id_clock_Cor)
+  if (showCallTree) call callTree_wayPoint("done with predictor CorAdCalc (step_MOM_dyn_split_RK2b)")
+
+! diffu = horizontal viscosity terms (u_av)
+  call cpu_clock_begin(id_clock_horvisc)
+  call horizontal_viscosity(u_av, v_av, h_av, CS%diffu, CS%diffv, MEKE, Varmix, G, GV, US, CS%hor_visc, &
+                            OBC=CS%OBC, BT=CS%barotropic_CSp, TD=thickness_diffuse_CSp, ADp=CS%AD_pred)
+  call cpu_clock_end(id_clock_horvisc)
+  if (showCallTree) call callTree_wayPoint("done with predictor horizontal_viscosity (step_MOM_dyn_split_RK2b)")
 
 ! u_bc_accel = CAu + PFu + diffu(u[n-1])
   call cpu_clock_begin(id_clock_btforce)
@@ -573,15 +602,15 @@ subroutine step_MOM_dyn_split_RK2b(u_inst, v_inst, h, tv, visc, Time_local, dt, 
   !$OMP parallel do default(shared)
   do k=1,nz
     do j=js,je ; do I=Isq,Ieq
-      up(I,j,k) = G%mask2dCu(I,j) * (u_inst(I,j,k) + dt * u_bc_accel(I,j,k))
+      up(I,j,k) = G%mask2dCu(I,j) * (u_av(I,j,k) + dt * u_bc_accel(I,j,k))
     enddo ; enddo
     do J=Jsq,Jeq ; do i=is,ie
-      vp(i,J,k) = G%mask2dCv(i,J) * (v_inst(i,J,k) + dt * v_bc_accel(i,J,k))
+      vp(i,J,k) = G%mask2dCv(i,J) * (v_av(i,J,k) + dt * v_bc_accel(i,J,k))
     enddo ; enddo
   enddo
 
   call enable_averages(dt, Time_local, CS%diag)
-  call set_viscous_ML(u_inst, v_inst, h, tv, forces, visc, dt, G, GV, US, CS%set_visc_CSp)
+  call set_viscous_ML(u_av, v_av, h, tv, forces, visc, dt, G, GV, US, CS%set_visc_CSp)
   call disable_averaging(CS%diag)
 
   if (CS%debug) then
@@ -622,6 +651,17 @@ subroutine step_MOM_dyn_split_RK2b(u_inst, v_inst, h, tv, visc, Time_local, dt, 
   if (G%nonblocking_updates) &
     call complete_group_pass(CS%pass_visc_rem, G%Domain, clock=id_clock_pass)
 
+  ! Reconstruct u_inst and v_inst from u_av and v_av.
+  call cpu_clock_begin(id_clock_mom_update)
+  do k=1,nz ; do j=js,je ; do I=Isq,Ieq
+    u_inst(I,j,k) = u_av(I,j,k) - CS%du_av_inst(I,j) * CS%visc_rem_u(I,j,k)
+  enddo ; enddo ; enddo
+  do k=1,nz ; do J=Jsq,Jeq ; do i=is,ie
+    v_inst(i,J,k) = v_av(i,J,k) - CS%dv_av_inst(i,j) * CS%visc_rem_v(i,J,k)
+  enddo ; enddo ; enddo
+  call cpu_clock_end(id_clock_mom_update)
+  call do_group_pass(CS%pass_uv, G%Domain, clock=id_clock_pass)
+
 ! u_accel_bt = layer accelerations due to barotropic solver
   call cpu_clock_begin(id_clock_continuity)
   call continuity(u_inst, v_inst, h, hp, uh_in, vh_in, dt, G, GV, US, CS%continuity_CSp, CS%OBC, pbv, &
@@ -647,10 +687,10 @@ subroutine step_MOM_dyn_split_RK2b(u_inst, v_inst, h, tv, visc, Time_local, dt, 
   if (showCallTree) call callTree_leave("btstep()")
   call cpu_clock_end(id_clock_btstep)
 
-! up = u + dt_pred*( u_bc_accel + u_accel_bt )
   dt_pred = dt * CS%be
   call cpu_clock_begin(id_clock_mom_update)
 
+! up = u + dt_pred*( u_bc_accel + u_accel_bt )
   !$OMP parallel do default(shared)
   do k=1,nz
     do J=Jsq,Jeq ; do i=is,ie
@@ -685,16 +725,16 @@ subroutine step_MOM_dyn_split_RK2b(u_inst, v_inst, h, tv, visc, Time_local, dt, 
     call uvchksum("0 before vertvisc: [uv]p", up, vp, G%HI,haloshift=0, symmetric=sym, scale=US%L_T_to_m_s)
   endif
 
-  if (CS%fpmix) then
-    uold(:,:,:) = 0.0
-    vold(:,:,:) = 0.0
-    do k=1,nz ; do j=js,je ; do I=Isq,Ieq
-      uold(I,j,k) = up(I,j,k)
-    enddo ; enddo ; enddo
-    do k=1,nz ; do J=Jsq,Jeq ; do i=is,ie
-      vold(i,J,k) = vp(i,J,k)
-    enddo ; enddo ; enddo
-  endif
+  !  if (CS%fpmix) then
+  !    uold(:,:,:) = 0.0
+  !    vold(:,:,:) = 0.0
+  !    do k=1,nz ; do j=js,je ; do I=Isq,Ieq
+  !      uold(I,j,k) = up(I,j,k)
+  !    enddo ; enddo ; enddo
+  !    do k=1,nz ; do J=Jsq,Jeq ; do i=is,ie
+  !      vold(i,J,k) = vp(i,J,k)
+  !    enddo ; enddo ; enddo
+  !  endif
 
   call thickness_to_dz(h, tv, dz, G, GV, US, halo_size=1)
   call vertvisc_coef(up, vp, h, dz, forces, visc, tv, dt_pred, G, GV, US, CS%vertvisc_CSp, &
@@ -702,16 +742,16 @@ subroutine step_MOM_dyn_split_RK2b(u_inst, v_inst, h, tv, visc, Time_local, dt, 
   call vertvisc(up, vp, h, forces, visc, dt_pred, CS%OBC, CS%AD_pred, CS%CDp, G, &
                 GV, US, CS%vertvisc_CSp, CS%taux_bot, CS%tauy_bot, waves=waves)
 
-  if (CS%fpmix) then
-    hbl(:,:) = 0.0
-    if (ASSOCIATED(CS%KPP_CSp)) call KPP_get_BLD(CS%KPP_CSp, hbl, G, US, m_to_BLD_units=GV%m_to_H)
-    if (ASSOCIATED(CS%energetic_PBL_CSp)) &
-      call energetic_PBL_get_MLD(CS%energetic_PBL_CSp, hbl, G, US, m_to_MLD_units=GV%m_to_H)
-    call vertFPmix(up, vp, uold, vold, hbl, h, forces, &
-                   dt_pred, G, GV, US, CS%vertvisc_CSp, CS%OBC)
-    call vertvisc(up, vp, h, forces, visc, dt_pred, CS%OBC, CS%ADp, CS%CDp, G, &
-                GV, US, CS%vertvisc_CSp, CS%taux_bot, CS%tauy_bot, waves=waves)
-  endif
+  !  if (CS%fpmix) then
+  !    hbl(:,:) = 0.0
+  !    if (ASSOCIATED(CS%KPP_CSp)) call KPP_get_BLD(CS%KPP_CSp, hbl, G, US, m_to_BLD_units=GV%m_to_H)
+  !    if (ASSOCIATED(CS%energetic_PBL_CSp)) &
+  !      call energetic_PBL_get_MLD(CS%energetic_PBL_CSp, hbl, G, US, m_to_MLD_units=GV%m_to_H)
+  !    call vertFPmix(up, vp, uold, vold, hbl, h, forces, &
+  !                   dt_pred, G, GV, US, CS%vertvisc_CSp, CS%OBC)
+  !    call vertvisc(up, vp, h, forces, visc, dt_pred, CS%OBC, CS%ADp, CS%CDp, G, &
+  !                GV, US, CS%vertvisc_CSp, CS%taux_bot, CS%tauy_bot, waves=waves)
+  !  endif
 
   if (showCallTree) call callTree_wayPoint("done with vertvisc (step_MOM_dyn_split_RK2b)")
   if (G%nonblocking_updates) then
@@ -796,7 +836,7 @@ subroutine step_MOM_dyn_split_RK2b(u_inst, v_inst, h, tv, visc, Time_local, dt, 
       if (Use_Stokes_PGF) Use_Stokes_PGF = Waves%Stokes_PGF
       if (Use_Stokes_PGF) then
         call thickness_to_dz(h, tv, dz, G, GV, US, halo_size=1)
-        call Stokes_PGF(G, GV, US, dz, u_inst, v_inst, CS%PFu_Stokes, CS%PFv_Stokes, Waves)
+        call Stokes_PGF(G, GV, US, dz, u_av, v_av, CS%PFu_Stokes, CS%PFv_Stokes, Waves)
         if (.not.Waves%Passive_Stokes_PGF) then
           do k=1,nz
             do j=js,je ; do I=Isq,Ieq
@@ -835,10 +875,8 @@ subroutine step_MOM_dyn_split_RK2b(u_inst, v_inst, h, tv, visc, Time_local, dt, 
 
 ! diffu = horizontal viscosity terms (u_av)
   call cpu_clock_begin(id_clock_horvisc)
-  call horizontal_viscosity(u_av, v_av, h_av, CS%diffu, CS%diffv, &
-                            MEKE, Varmix, G, GV, US, CS%hor_visc, &
-                            OBC=CS%OBC, BT=CS%barotropic_CSp, TD=thickness_diffuse_CSp, &
-                            ADp=CS%ADp)
+  call horizontal_viscosity(u_av, v_av, h_av, CS%diffu, CS%diffv, MEKE, Varmix, G, GV, US, CS%hor_visc, &
+                            OBC=CS%OBC, BT=CS%barotropic_CSp, TD=thickness_diffuse_CSp, ADp=CS%ADp)
   call cpu_clock_end(id_clock_horvisc)
   if (showCallTree) call callTree_wayPoint("done with horizontal_viscosity (step_MOM_dyn_split_RK2b)")
 
@@ -931,28 +969,28 @@ subroutine step_MOM_dyn_split_RK2b(u_inst, v_inst, h, tv, visc, Time_local, dt, 
   ! u_av <- u_av + dt d/dz visc d/dz u_av
   call cpu_clock_begin(id_clock_vertvisc)
 
-  if (CS%fpmix) then
-    uold(:,:,:) = 0.0
-    vold(:,:,:) = 0.0
-    do k=1,nz ; do j=js,je ; do I=Isq,Ieq
-      uold(I,j,k) = u_inst(I,j,k)
-    enddo ; enddo ; enddo
-    do k=1,nz ; do J=Jsq,Jeq ; do i=is,ie
-      vold(i,J,k) = v_inst(i,J,k)
-    enddo ; enddo ; enddo
-  endif
+  !  if (CS%fpmix) then
+  !    uold(:,:,:) = 0.0
+  !    vold(:,:,:) = 0.0
+  !    do k=1,nz ; do j=js,je ; do I=Isq,Ieq
+  !      uold(I,j,k) = u_inst(I,j,k)
+  !    enddo ; enddo ; enddo
+  !    do k=1,nz ; do J=Jsq,Jeq ; do i=is,ie
+  !      vold(i,J,k) = v_inst(i,J,k)
+  !    enddo ; enddo ; enddo
+  !  endif
 
   call thickness_to_dz(h, tv, dz, G, GV, US, halo_size=1)
   call vertvisc_coef(u_inst, v_inst, h, dz, forces, visc, tv, dt, G, GV, US, CS%vertvisc_CSp, CS%OBC, VarMix)
   call vertvisc(u_inst, v_inst, h, forces, visc, dt, CS%OBC, CS%ADp, CS%CDp, G, GV, US, &
-                CS%vertvisc_CSp, CS%taux_bot, CS%tauy_bot,waves=waves)
+                CS%vertvisc_CSp, CS%taux_bot, CS%tauy_bot, waves=waves)
 
-  if (CS%fpmix) then
-    call vertFPmix(u_inst, v_inst, uold, vold, hbl, h, forces, dt, &
-                   G, GV, US, CS%vertvisc_CSp, CS%OBC)
-    call vertvisc(u_inst, v_inst, h, forces, visc, dt, CS%OBC, CS%ADp, CS%CDp, G, GV, US, &
-                  CS%vertvisc_CSp, CS%taux_bot, CS%tauy_bot, waves=waves)
-  endif
+  !  if (CS%fpmix) then
+  !    call vertFPmix(u_inst, v_inst, uold, vold, hbl, h, forces, dt, &
+  !                   G, GV, US, CS%vertvisc_CSp, CS%OBC)
+  !    call vertvisc(u_inst, v_inst, h, forces, visc, dt, CS%OBC, CS%ADp, CS%CDp, G, GV, US, &
+  !                  CS%vertvisc_CSp, CS%taux_bot, CS%tauy_bot, waves=waves)
+  !  endif
 
   if (G%nonblocking_updates) then
     call cpu_clock_end(id_clock_vertvisc)
@@ -980,8 +1018,19 @@ subroutine step_MOM_dyn_split_RK2b(u_inst, v_inst, h, tv, visc, Time_local, dt, 
   ! h  = h + dt * div . uh
   ! u_av and v_av adjusted so their mass transports match uhbt and vhbt.
   call cpu_clock_begin(id_clock_continuity)
+
   call continuity(u_inst, v_inst, h, h, uh, vh, dt, G, GV, US, CS%continuity_CSp, CS%OBC, pbv, &
-                  CS%uhbt, CS%vhbt, CS%visc_rem_u, CS%visc_rem_v, u_av, v_av)
+                  CS%uhbt, CS%vhbt, CS%visc_rem_u, CS%visc_rem_v, u_av, v_av, &
+                  du_cor=CS%du_av_inst, dv_cor=CS%dv_av_inst)
+
+  ! This tests the ability to readjust the instantaneous velocity, and here it changes answers only at roundoff.
+  ! do k=1,nz ; do j=js,je ; do I=Isq,Ieq
+  !   u_inst(I,j,k) = u_av(I,j,k) - CS%du_av_inst(I,j) * CS%visc_rem_u(I,j,k)
+  ! enddo ; enddo ; enddo
+  ! do k=1,nz ; do J=Jsq,Jeq ; do i=is,ie
+  !   v_inst(i,J,k) = v_av(i,J,k) - CS%dv_av_inst(i,J) * CS%visc_rem_v(i,J,k)
+  ! enddo ; enddo ; enddo
+
   call cpu_clock_end(id_clock_continuity)
   call do_group_pass(CS%pass_h, G%Domain, clock=id_clock_pass)
   ! Whenever thickness changes let the diag manager know, target grids
@@ -996,10 +1045,10 @@ subroutine step_MOM_dyn_split_RK2b(u_inst, v_inst, h, tv, visc, Time_local, dt, 
   endif
 
   if (associated(CS%OBC)) then
-    call radiation_open_bdry_conds(CS%OBC, u_inst, u_old_rad_OBC, v_inst, v_old_rad_OBC, G, GV, US, dt)
+    call radiation_open_bdry_conds(CS%OBC, u_av, u_old_rad_OBC, v_av, v_old_rad_OBC, G, GV, US, dt)
   endif
 
-! h_av = (h_in + h_out)/2 . Going in to this line, h_av = h_in.
+  ! h_av = (h_in + h_out)/2 . Going in to this line, h_av = h_in.
   !$OMP parallel do default(shared)
   do k=1,nz ; do j=js-2,je+2 ; do i=is-2,ie+2
     h_av(i,j,k) = 0.5*(h_av(i,j,k) + h(i,j,k))
@@ -1018,26 +1067,10 @@ subroutine step_MOM_dyn_split_RK2b(u_inst, v_inst, h, tv, visc, Time_local, dt, 
     enddo ; enddo
   enddo
 
-  if (CS%store_CAu) then
-    ! Calculate a predictor-step estimate of the Coriolis and momentum advection terms
-    ! for use in the next time step, possibly after it has been vertically remapped.
-    call cpu_clock_begin(id_clock_Cor)
-    call disable_averaging(CS%diag)  ! These calculations should not be used for diagnostics.
-    ! CAu = -(f+zeta_av)/h_av vh + d/dx KE_av
-    call CorAdCalc(u_av, v_av, h_av, uh, vh, CS%CAu_pred, CS%CAv_pred, CS%OBC, CS%AD_pred, &
-                   G, GV, US, CS%CoriolisAdv, pbv, Waves=Waves)
-    CS%CAu_pred_stored = .true.
-    call enable_averages(dt, Time_local, CS%diag) ! Reenable the averaging
-    call cpu_clock_end(id_clock_Cor)
-    if (showCallTree) call callTree_wayPoint("done with CorAdCalc (step_MOM_dyn_split_RK2b)")
-  else
-    CS%CAu_pred_stored = .false.
-  endif
-
-  if (CS%fpmix) then
-    if (CS%id_uold > 0) call post_data(CS%id_uold, uold, CS%diag)
-    if (CS%id_vold > 0) call post_data(CS%id_vold, vold, CS%diag)
-  endif
+  !  if (CS%fpmix) then
+  !    if (CS%id_uold > 0) call post_data(CS%id_uold, uold, CS%diag)
+  !    if (CS%id_vold > 0) call post_data(CS%id_vold, vold, CS%diag)
+  !  endif
 
   ! The time-averaged free surface height has already been set by the last call to btstep.
 
@@ -1063,7 +1096,7 @@ subroutine step_MOM_dyn_split_RK2b(u_inst, v_inst, h, tv, visc, Time_local, dt, 
   if (CS%id_ueffA > 0) then
     ueffA(:,:,:) = 0
     do k=1,nz ; do j=js,je ; do I=Isq,Ieq
-      if (abs(up(I,j,k)) > 0.) ueffA(I,j,k) = uh(I,j,k) / up(I,j,k)
+      if (abs(u_av(I,j,k)) > 0.) ueffA(I,j,k) = uh(I,j,k) / u_av(I,j,k)
     enddo ; enddo ; enddo
     call post_data(CS%id_ueffA, ueffA, CS%diag)
   endif
@@ -1071,7 +1104,7 @@ subroutine step_MOM_dyn_split_RK2b(u_inst, v_inst, h, tv, visc, Time_local, dt, 
   if (CS%id_veffA > 0) then
     veffA(:,:,:) = 0
     do k=1,nz ; do J=Jsq,Jeq ; do i=is,ie
-      if (abs(vp(i,J,k)) > 0.) veffA(i,J,k) = vh(i,J,k) / vp(i,J,k)
+      if (abs(v_av(i,J,k)) > 0.) veffA(i,J,k) = vh(i,J,k) / v_av(i,J,k)
     enddo ; enddo ; enddo
     call post_data(CS%id_veffA, veffA, CS%diag)
   endif
@@ -1186,19 +1219,13 @@ subroutine register_restarts_dyn_split_RK2b(HI, GV, US, param_file, CS, restart_
   ALLOC_(CS%CAv_pred(isd:ied,JsdB:JedB,nz)) ; CS%CAv_pred(:,:,:)   = 0.0
   ALLOC_(CS%PFu(IsdB:IedB,jsd:jed,nz))   ; CS%PFu(:,:,:)   = 0.0
   ALLOC_(CS%PFv(isd:ied,JsdB:JedB,nz))   ; CS%PFv(:,:,:)   = 0.0
+  ALLOC_(CS%du_av_inst(IsdB:IedB,jsd:jed)) ; CS%du_av_inst(:,:) = 0.0
+  ALLOC_(CS%dv_av_inst(isd:ied,JsdB:JedB)) ; CS%dv_av_inst(:,:) = 0.0
 
   ALLOC_(CS%eta(isd:ied,jsd:jed))       ; CS%eta(:,:)    = 0.0
-  ALLOC_(CS%u_av(IsdB:IedB,jsd:jed,nz)) ; CS%u_av(:,:,:) = 0.0
-  ALLOC_(CS%v_av(isd:ied,JsdB:JedB,nz)) ; CS%v_av(:,:,:) = 0.0
-  ALLOC_(CS%h_av(isd:ied,jsd:jed,nz))   ; CS%h_av(:,:,:) = GV%Angstrom_H
 
   thickness_units = get_thickness_units(GV)
   flux_units = get_flux_units(GV)
-
-  call get_param(param_file, mdl, "STORE_CORIOLIS_ACCEL", CS%store_CAu, &
-                 "If true, calculate the Coriolis accelerations at the end of each "//&
-                 "timestep for use in the predictor step of the next split RK2 timestep.", &
-                 default=.true., do_not_log=.true.)
 
   if (GV%Boussinesq) then
     call register_restart_field(CS%eta, "sfc", .false., restart_CS, &
@@ -1208,32 +1235,13 @@ subroutine register_restarts_dyn_split_RK2b(HI, GV, US, param_file, CS, restart_
              longname="Bottom Pressure", units=thickness_units, conversion=GV%H_to_mks)
   endif
 
-  ! These are needed, either to calculate CAu and CAv or to calculate the velocity anomalies in
-  ! the barotropic solver's Coriolis terms.
-  vd(1) = var_desc("u2", "m s-1", "Auxiliary Zonal velocity", 'u', 'L')
-  vd(2) = var_desc("v2", "m s-1", "Auxiliary Meridional velocity", 'v', 'L')
-  call register_restart_pair(CS%u_av, CS%v_av, vd(1), vd(2), .false., restart_CS, &
+  ! These are needed to reconstruct the phase in the barotorpic solution.
+  vd(1) = var_desc("du_avg_inst", "m s-1", &
+                   "Barotropic velocity increment between instantaneous and filtered zonal velocities", 'u', '1')
+  vd(2) = var_desc("dv_avg_inst", "m s-1", &
+                   "Barotropic velocity increment between instantaneous and filtered meridional velocities", 'v', '1')
+  call register_restart_pair(CS%du_av_inst, CS%dv_av_inst, vd(1), vd(2), .false., restart_CS, &
                              conversion=US%L_T_to_m_s)
-
-  if (CS%store_CAu) then
-    vd(1) = var_desc("CAu", "m s-2", "Zonal Coriolis and advactive acceleration", 'u', 'L')
-    vd(2) = var_desc("CAv", "m s-2", "Meridional Coriolis and advactive  acceleration", 'v', 'L')
-    call register_restart_pair(CS%CAu_pred, CS%CAv_pred, vd(1), vd(2), .false., restart_CS, &
-                               conversion=US%L_T2_to_m_s2)
-  else
-    call register_restart_field(CS%h_av, "h2", .false., restart_CS, &
-           longname="Auxiliary Layer Thickness", units=thickness_units, conversion=GV%H_to_mks)
-
-    vd(1) = var_desc("uh", flux_units, "Zonal thickness flux", 'u', 'L')
-    vd(2) = var_desc("vh", flux_units, "Meridional thickness flux", 'v', 'L')
-    call register_restart_pair(uh, vh, vd(1), vd(2), .false., restart_CS, &
-                               conversion=GV%H_to_MKS*US%L_to_m**2*US%s_to_T)
-  endif
-
-  vd(1) = var_desc("diffu", "m s-2", "Zonal horizontal viscous acceleration", 'u', 'L')
-  vd(2) = var_desc("diffv", "m s-2", "Meridional horizontal viscous acceleration", 'v', 'L')
-  call register_restart_pair(CS%diffu, CS%diffv, vd(1), vd(2), .false., restart_CS, &
-                             conversion=US%L_T2_to_m_s2)
 
   call register_barotropic_restarts(HI, GV, US, param_file, CS%barotropic_CSp, restart_CS)
 
@@ -1259,16 +1267,7 @@ subroutine remap_dyn_split_RK2b_aux_vars(G, GV, CS, h_old_u, h_old_v, h_new_u, h
                                                               !! velocity points [H ~> m or kg m-2]
   type(ALE_CS),                     pointer       :: ALE_CSp  !< ALE control structure to use when remapping
 
-  if (.not.CS%remap_aux) return
-
-  if (CS%store_CAu) then
-    call ALE_remap_velocities(ALE_CSp, G, GV, h_old_u, h_old_v, h_new_u, h_new_v, CS%u_av, CS%v_av)
-    call pass_vector(CS%u_av, CS%v_av, G%Domain, complete=.false.)
-    call ALE_remap_velocities(ALE_CSp, G, GV, h_old_u, h_old_v, h_new_u, h_new_v, CS%CAu_pred, CS%CAv_pred)
-    call pass_vector(CS%CAu_pred, CS%CAv_pred, G%Domain, complete=.true.)
-  endif
-
-  call ALE_remap_velocities(ALE_CSp, G, GV, h_old_u, h_old_v, h_new_u, h_new_v, CS%diffu, CS%diffv)
+  return
 
 end subroutine remap_dyn_split_RK2b_aux_vars
 
@@ -1328,7 +1327,6 @@ subroutine initialize_dyn_split_RK2b(u, v, h, uh, vh, eta, Time, G, GV, US, para
   ! This include declares and sets the variable "version".
 # include "version_variable.h"
   character(len=48) :: thickness_units, flux_units, eta_rest_name
-  type(group_pass_type) :: pass_av_h_uvh
   logical :: debug_truncations
   logical :: read_uv, read_h2
 
@@ -1374,20 +1372,15 @@ subroutine initialize_dyn_split_RK2b(u, v, h, uh, vh, eta, Time, G, GV, US, para
   call get_param(param_file, mdl, "SPLIT_BOTTOM_STRESS", CS%split_bottom_stress, &
                  "If true, provide the bottom stress calculated by the "//&
                  "vertical viscosity to the barotropic solver.", default=.false.)
-  call get_param(param_file, mdl, "STORE_CORIOLIS_ACCEL", CS%store_CAu, &
-                 "If true, calculate the Coriolis accelerations at the end of each "//&
-                 "timestep for use in the predictor step of the next split RK2 timestep.", &
-                 default=.true.)
-  call get_param(param_file, mdl, "FPMIX", CS%fpmix, &
-                 "If true, apply profiles of momentum flux magnitude and direction.", &
-                 default=.false.)
+  ! call get_param(param_file, mdl, "FPMIX", CS%fpmix, &
+  !                "If true, apply profiles of momentum flux magnitude and direction.", &
+  !                default=.false.)
+  CS%fpmix = .false.
   call get_param(param_file, mdl, "REMAP_AUXILIARY_VARS", CS%remap_aux, &
                  "If true, apply ALE remapping to all of the auxiliary 3-dimensional "//&
                  "variables that are needed to reproduce across restarts, similarly to "//&
                  "what is already being done with the primary state variables.  "//&
                  "The default should be changed to true.", default=.false., do_not_log=.true.)
-  if (CS%remap_aux .and. .not.CS%store_CAu) call MOM_error(FATAL, &
-      "REMAP_AUXILIARY_VARS requires that STORE_CORIOLIS_ACCEL = True.")
   call get_param(param_file, mdl, "DEBUG", CS%debug, &
                  "If true, write out verbose debugging data.", &
                  default=.false., debuggingParam=.true.)
@@ -1419,8 +1412,6 @@ subroutine initialize_dyn_split_RK2b(u, v, h, uh, vh, eta, Time, G, GV, US, para
   MIS%pbce       => CS%pbce
   MIS%u_accel_bt => CS%u_accel_bt
   MIS%v_accel_bt => CS%v_accel_bt
-  MIS%u_av       => CS%u_av
-  MIS%v_av       => CS%v_av
 
   CS%ADp           => Accel_diag
   CS%CDp           => Cont_diag
@@ -1446,9 +1437,6 @@ subroutine initialize_dyn_split_RK2b(u, v, h, uh, vh, eta, Time, G, GV, US, para
 !  Accel_diag%pbce => CS%pbce
 !  Accel_diag%u_accel_bt => CS%u_accel_bt ; Accel_diag%v_accel_bt => CS%v_accel_bt
 !  Accel_diag%u_av => CS%u_av ; Accel_diag%v_av => CS%v_av
-
-  id_clock_pass_init = cpu_clock_id('(Ocean init message passing)', &
-                                     grain=CLOCK_ROUTINE)
 
   call continuity_init(Time, G, GV, US, param_file, diag, CS%continuity_CSp)
   cont_stencil = continuity_stencil(CS%continuity_CSp)
@@ -1493,87 +1481,6 @@ subroutine initialize_dyn_split_RK2b(u, v, h, uh, vh, eta, Time, G, GV, US, para
   call barotropic_init(u, v, h, CS%eta, Time, G, GV, US, param_file, diag, &
                        CS%barotropic_CSp, restart_CS, calc_dtbt, CS%BT_cont, &
                        CS%SAL_CSp)
-
-  if (.not. query_initialized(CS%diffu, "diffu", restart_CS) .or. &
-      .not. query_initialized(CS%diffv, "diffv", restart_CS)) then
-    call horizontal_viscosity(u, v, h, CS%diffu, CS%diffv, MEKE, VarMix, G, GV, US, CS%hor_visc, &
-                              OBC=CS%OBC, BT=CS%barotropic_CSp, TD=thickness_diffuse_CSp)
-    call set_initialized(CS%diffu, "diffu", restart_CS)
-    call set_initialized(CS%diffv, "diffv", restart_CS)
-  endif
-
-  if (.not. query_initialized(CS%u_av, "u2", restart_CS) .or. &
-      .not. query_initialized(CS%v_av, "v2", restart_CS)) then
-    do k=1,nz ; do j=jsd,jed ; do I=IsdB,IedB ; CS%u_av(I,j,k) = u(I,j,k) ; enddo ; enddo ; enddo
-    do k=1,nz ; do J=JsdB,JedB ; do i=isd,ied ; CS%v_av(i,J,k) = v(i,J,k) ; enddo ; enddo ; enddo
-    call set_initialized(CS%u_av, "u2", restart_CS)
-    call set_initialized(CS%v_av, "v2", restart_CS)
-  endif
-
-  if (CS%store_CAu) then
-    if (query_initialized(CS%CAu_pred, "CAu", restart_CS) .and. &
-        query_initialized(CS%CAv_pred, "CAv", restart_CS)) then
-      CS%CAu_pred_stored = .true.
-    else
-      call only_read_from_restarts(uh, vh, 'uh', 'vh', G, restart_CS, stagger=CGRID_NE, &
-                   filename=dirs%input_filename, directory=dirs%restart_input_dir, &
-                   success=read_uv, scale=US%m_to_L**2*US%T_to_s/GV%H_to_mks)
-      call only_read_from_restarts('h2', CS%h_av, G, restart_CS, &
-                   filename=dirs%input_filename, directory=dirs%restart_input_dir, &
-                   success=read_h2, scale=1.0/GV%H_to_mks)
-      if (read_uv .and. read_h2) then
-        call pass_var(CS%h_av, G%Domain, clock=id_clock_pass_init)
-      else
-        do k=1,nz ; do j=jsd,jed ; do i=isd,ied ; h_tmp(i,j,k) = h(i,j,k) ; enddo ; enddo ; enddo
-        call continuity(CS%u_av, CS%v_av, h, h_tmp, uh, vh, dt, G, GV, US, CS%continuity_CSp, CS%OBC, pbv)
-        call pass_var(h_tmp, G%Domain, clock=id_clock_pass_init)
-        do k=1,nz ; do j=jsd,jed ; do i=isd,ied
-          CS%h_av(i,j,k) = 0.5*(h(i,j,k) + h_tmp(i,j,k))
-        enddo ; enddo ; enddo
-      endif
-      call pass_vector(CS%u_av, CS%v_av, G%Domain, halo=2, clock=id_clock_pass_init, complete=.false.)
-      call pass_vector(uh, vh, G%Domain, halo=2, clock=id_clock_pass_init, complete=.true.)
-      call CorAdCalc(CS%u_av, CS%v_av, CS%h_av, uh, vh, CS%CAu_pred, CS%CAv_pred, CS%OBC, CS%ADp, &
-                     G, GV, US, CS%CoriolisAdv, pbv) !, Waves=Waves)
-      CS%CAu_pred_stored = .true.
-    endif
-  else
-    CS%CAu_pred_stored = .false.
-    ! This call is just here to initialize uh and vh.
-    if (.not. query_initialized(uh, "uh", restart_CS) .or. &
-        .not. query_initialized(vh, "vh", restart_CS)) then
-      do k=1,nz ; do j=jsd,jed ; do i=isd,ied ; h_tmp(i,j,k) = h(i,j,k) ; enddo ; enddo ; enddo
-      call continuity(u, v, h, h_tmp, uh, vh, dt, G, GV, US, CS%continuity_CSp, CS%OBC, pbv)
-      call pass_var(h_tmp, G%Domain, clock=id_clock_pass_init)
-      do k=1,nz ; do j=jsd,jed ; do i=isd,ied
-        CS%h_av(i,j,k) = 0.5*(h(i,j,k) + h_tmp(i,j,k))
-      enddo ; enddo ; enddo
-      call set_initialized(uh, "uh", restart_CS)
-      call set_initialized(vh, "vh", restart_CS)
-      call set_initialized(CS%h_av, "h2", restart_CS)
-      ! Try reading the CAu and CAv fields from the restart file, in case this restart file is
-      ! using a newer format.
-      call only_read_from_restarts(CS%CAu_pred, CS%CAv_pred, "CAu", "CAv", G, restart_CS, &
-                   stagger=CGRID_NE, filename=dirs%input_filename, directory=dirs%restart_input_dir, &
-                   success=read_uv, scale=US%m_s_to_L_T*US%T_to_s)
-      CS%CAu_pred_stored = read_uv
-    else
-      if (.not. query_initialized(CS%h_av, "h2", restart_CS)) then
-        CS%h_av(:,:,:) = h(:,:,:)
-        call set_initialized(CS%h_av, "h2", restart_CS)
-      endif
-    endif
-  endif
-  call cpu_clock_begin(id_clock_pass_init)
-  call create_group_pass(pass_av_h_uvh, CS%u_av, CS%v_av, G%Domain, halo=2)
-  if (CS%CAu_pred_stored) then
-    call create_group_pass(pass_av_h_uvh, CS%CAu_pred, CS%CAv_pred, G%Domain, halo=2)
-  else
-    call create_group_pass(pass_av_h_uvh, CS%h_av, G%Domain, halo=2)
-    call create_group_pass(pass_av_h_uvh, uh, vh, G%Domain, halo=2)
-  endif
-  call do_group_pass(pass_av_h_uvh, G%Domain)
-  call cpu_clock_end(id_clock_pass_init)
 
   flux_units = get_flux_units(GV)
   thickness_units = get_thickness_units(GV)
@@ -1800,11 +1707,11 @@ subroutine end_dyn_split_RK2b(CS)
   if (associated(CS%taux_bot)) deallocate(CS%taux_bot)
   if (associated(CS%tauy_bot)) deallocate(CS%tauy_bot)
   DEALLOC_(CS%uhbt) ; DEALLOC_(CS%vhbt)
+  DEALLOC_(CS%du_av_inst) ; DEALLOC_(CS%dv_av_inst)
   DEALLOC_(CS%u_accel_bt) ; DEALLOC_(CS%v_accel_bt)
   DEALLOC_(CS%visc_rem_u) ; DEALLOC_(CS%visc_rem_v)
 
   DEALLOC_(CS%eta) ; DEALLOC_(CS%eta_PF) ; DEALLOC_(CS%pbce)
-  DEALLOC_(CS%h_av) ; DEALLOC_(CS%u_av) ; DEALLOC_(CS%v_av)
 
   call dealloc_BT_cont_type(CS%BT_cont)
   deallocate(CS%AD_pred)

--- a/src/core/MOM_dynamics_split_RK2b.F90
+++ b/src/core/MOM_dynamics_split_RK2b.F90
@@ -1,0 +1,1842 @@
+!> Time step the adiabatic dynamic core of MOM using RK2 method with greater use of the
+!! time-filtered velocities and less inheritance of tedencies from the previous step in the
+!! predictor step than in the original MOM_dyanmics_split_RK2.
+module MOM_dynamics_split_RK2b
+
+! This file is part of MOM6. See LICENSE.md for the license.
+
+use MOM_variables,    only : vertvisc_type, thermo_var_ptrs, porous_barrier_type
+use MOM_variables,    only : BT_cont_type, alloc_bt_cont_type, dealloc_bt_cont_type
+use MOM_variables,    only : accel_diag_ptrs, ocean_internal_state, cont_diag_ptrs
+use MOM_forcing_type, only : mech_forcing
+
+use MOM_checksum_packages, only : MOM_thermo_chksum, MOM_state_chksum, MOM_accel_chksum
+use MOM_cpu_clock,         only : cpu_clock_id, cpu_clock_begin, cpu_clock_end
+use MOM_cpu_clock,         only : CLOCK_COMPONENT, CLOCK_SUBCOMPONENT
+use MOM_cpu_clock,         only : CLOCK_MODULE_DRIVER, CLOCK_MODULE, CLOCK_ROUTINE
+use MOM_diag_mediator,     only : diag_mediator_init, enable_averages
+use MOM_diag_mediator,     only : disable_averaging, post_data, safe_alloc_ptr
+use MOM_diag_mediator,     only : post_product_u, post_product_sum_u
+use MOM_diag_mediator,     only : post_product_v, post_product_sum_v
+use MOM_diag_mediator,     only : register_diag_field, register_static_field
+use MOM_diag_mediator,     only : set_diag_mediator_grid, diag_ctrl, diag_update_remap_grids
+use MOM_domains,           only : To_South, To_West, To_All, CGRID_NE, SCALAR_PAIR
+use MOM_domains,           only : To_North, To_East, Omit_Corners
+use MOM_domains,           only : create_group_pass, do_group_pass, group_pass_type
+use MOM_domains,           only : start_group_pass, complete_group_pass, pass_var, pass_vector
+use MOM_debugging,         only : hchksum, uvchksum
+use MOM_error_handler,     only : MOM_error, MOM_mesg, FATAL, WARNING, is_root_pe
+use MOM_error_handler,     only : MOM_set_verbosity, callTree_showQuery
+use MOM_error_handler,     only : callTree_enter, callTree_leave, callTree_waypoint
+use MOM_file_parser,       only : get_param, log_version, param_file_type
+use MOM_get_input,         only : directories
+use MOM_io,                only : vardesc, var_desc, EAST_FACE, NORTH_FACE
+use MOM_restart,           only : register_restart_field, register_restart_pair
+use MOM_restart,           only : query_initialized, set_initialized, save_restart
+use MOM_restart,           only : only_read_from_restarts
+use MOM_restart,           only : restart_init, is_new_run, MOM_restart_CS
+use MOM_time_manager,      only : time_type, time_type_to_real, operator(+)
+use MOM_time_manager,      only : operator(-), operator(>), operator(*), operator(/)
+
+use MOM_ALE,                   only : ALE_CS, ALE_remap_velocities
+use MOM_barotropic,            only : barotropic_init, btstep, btcalc, bt_mass_source
+use MOM_barotropic,            only : register_barotropic_restarts, set_dtbt, barotropic_CS
+use MOM_barotropic,            only : barotropic_end
+use MOM_boundary_update,       only : update_OBC_data, update_OBC_CS
+use MOM_continuity,            only : continuity, continuity_CS
+use MOM_continuity,            only : continuity_init, continuity_stencil
+use MOM_CoriolisAdv,           only : CorAdCalc, CoriolisAdv_CS
+use MOM_CoriolisAdv,           only : CoriolisAdv_init, CoriolisAdv_end
+use MOM_debugging,             only : check_redundant
+use MOM_grid,                  only : ocean_grid_type
+use MOM_hor_index,             only : hor_index_type
+use MOM_hor_visc,              only : horizontal_viscosity, hor_visc_CS
+use MOM_hor_visc,              only : hor_visc_init, hor_visc_end
+use MOM_interface_heights,     only : thickness_to_dz, find_col_avg_SpV
+use MOM_lateral_mixing_coeffs, only : VarMix_CS
+use MOM_MEKE_types,            only : MEKE_type
+use MOM_open_boundary,         only : ocean_OBC_type, radiation_open_bdry_conds
+use MOM_open_boundary,         only : open_boundary_zero_normal_flow, open_boundary_query
+use MOM_open_boundary,         only : open_boundary_test_extern_h, update_OBC_ramp
+use MOM_PressureForce,         only : PressureForce, PressureForce_CS
+use MOM_PressureForce,         only : PressureForce_init
+use MOM_set_visc,              only : set_viscous_ML, set_visc_CS
+use MOM_thickness_diffuse,     only : thickness_diffuse_CS
+use MOM_self_attr_load,        only : SAL_CS
+use MOM_self_attr_load,        only : SAL_init, SAL_end
+use MOM_tidal_forcing,         only : tidal_forcing_CS
+use MOM_tidal_forcing,         only : tidal_forcing_init, tidal_forcing_end
+use MOM_unit_scaling,          only : unit_scale_type
+use MOM_vert_friction,         only : vertvisc, vertvisc_coef, vertvisc_remnant
+use MOM_vert_friction,         only : vertvisc_init, vertvisc_end, vertvisc_CS
+use MOM_vert_friction,         only : updateCFLtruncationValue, vertFPmix
+use MOM_verticalGrid,          only : verticalGrid_type, get_thickness_units
+use MOM_verticalGrid,          only : get_flux_units, get_tr_flux_units
+use MOM_wave_interface,        only: wave_parameters_CS, Stokes_PGF
+use MOM_CVMix_KPP,             only : KPP_get_BLD, KPP_CS
+use MOM_energetic_PBL,         only : energetic_PBL_get_MLD, energetic_PBL_CS
+use MOM_diabatic_driver,       only : diabatic_CS, extract_diabatic_member
+
+implicit none ; private
+
+#include <MOM_memory.h>
+
+!> MOM_dynamics_split_RK2b module control structure
+type, public :: MOM_dyn_split_RK2b_CS ; private
+  real ALLOCABLE_, dimension(NIMEMB_PTR_,NJMEM_,NKMEM_) :: &
+    CAu, &    !< CAu = f*v - u.grad(u) [L T-2 ~> m s-2]
+    CAu_pred, & !< The predictor step value of CAu = f*v - u.grad(u) [L T-2 ~> m s-2]
+    PFu, &    !< PFu = -dM/dx [L T-2 ~> m s-2]
+    PFu_Stokes, & !< PFu_Stokes = -d/dx int_r (u_L*duS/dr) [L T-2 ~> m s-2]
+    diffu     !< Zonal acceleration due to convergence of the along-isopycnal stress tensor [L T-2 ~> m s-2]
+
+  real ALLOCABLE_, dimension(NIMEM_,NJMEMB_PTR_,NKMEM_) :: &
+    CAv, &    !< CAv = -f*u - u.grad(v) [L T-2 ~> m s-2]
+    CAv_pred, & !< The predictor step value of CAv = -f*u - u.grad(v) [L T-2 ~> m s-2]
+    PFv, &    !< PFv = -dM/dy [L T-2 ~> m s-2]
+    PFv_Stokes, & !< PFv_Stokes = -d/dy int_r (v_L*dvS/dr) [L T-2 ~> m s-2]
+    diffv     !< Meridional acceleration due to convergence of the along-isopycnal stress tensor [L T-2 ~> m s-2]
+
+  real ALLOCABLE_, dimension(NIMEMB_PTR_,NJMEM_,NKMEM_) :: visc_rem_u
+              !< Both the fraction of the zonal momentum originally in a
+              !! layer that remains after a time-step of viscosity, and the
+              !! fraction of a time-step worth of a barotropic acceleration
+              !! that a layer experiences after viscosity is applied [nondim].
+              !! Nondimensional between 0 (at the bottom) and 1 (far above).
+  real ALLOCABLE_, dimension(NIMEMB_PTR_,NJMEM_,NKMEM_) :: u_accel_bt
+              !< The zonal layer accelerations due to the difference between
+              !! the barotropic accelerations and the baroclinic accelerations
+              !! that were fed into the barotopic calculation [L T-2 ~> m s-2]
+  real ALLOCABLE_, dimension(NIMEM_,NJMEMB_PTR_,NKMEM_) :: visc_rem_v
+              !< Both the fraction of the meridional momentum originally in
+              !! a layer that remains after a time-step of viscosity, and the
+              !! fraction of a time-step worth of a barotropic acceleration
+              !! that a layer experiences after viscosity is applied [nondim].
+              !! Nondimensional between 0 (at the bottom) and 1 (far above).
+  real ALLOCABLE_, dimension(NIMEM_,NJMEMB_PTR_,NKMEM_) :: v_accel_bt
+              !< The meridional layer accelerations due to the difference between
+              !! the barotropic accelerations and the baroclinic accelerations
+              !! that were fed into the barotopic calculation [L T-2 ~> m s-2]
+
+  ! The following variables are only used with the split time stepping scheme.
+  real ALLOCABLE_, dimension(NIMEM_,NJMEM_)             :: eta    !< Instantaneous free surface height (in Boussinesq
+                                                                  !! mode) or column mass anomaly (in non-Boussinesq
+                                                                  !! mode) [H ~> m or kg m-2]
+  real ALLOCABLE_, dimension(NIMEMB_PTR_,NJMEM_,NKMEM_) :: u_av   !< layer x-velocity with vertical mean replaced by
+                                                                  !! time-mean barotropic velocity over a baroclinic
+                                                                  !! timestep [L T-1 ~> m s-1]
+  real ALLOCABLE_, dimension(NIMEM_,NJMEMB_PTR_,NKMEM_) :: v_av   !< layer y-velocity with vertical mean replaced by
+                                                                  !! time-mean barotropic velocity over a baroclinic
+                                                                  !! timestep [L T-1 ~> m s-1]
+  real ALLOCABLE_, dimension(NIMEM_,NJMEM_,NKMEM_)      :: h_av   !< arithmetic mean of two successive layer
+                                                                  !! thicknesses [H ~> m or kg m-2]
+  real ALLOCABLE_, dimension(NIMEM_,NJMEM_)             :: eta_PF !< instantaneous SSH used in calculating PFu and
+                                                                  !! PFv [H ~> m or kg m-2]
+  real ALLOCABLE_, dimension(NIMEMB_PTR_,NJMEM_)        :: uhbt   !< average x-volume or mass flux determined by the
+                                                                  !! barotropic solver [H L2 T-1 ~> m3 s-1 or kg s-1].
+                                                                  !! uhbt is roughly equal to the vertical sum of uh.
+  real ALLOCABLE_, dimension(NIMEM_,NJMEMB_PTR_)        :: vhbt   !< average y-volume or mass flux determined by the
+                                                                  !! barotropic solver [H L2 T-1 ~> m3 s-1 or kg s-1].
+                                                                  !! vhbt is roughly equal to vertical sum of vh.
+  real ALLOCABLE_, dimension(NIMEM_,NJMEM_,NKMEM_)      :: pbce   !< pbce times eta gives the baroclinic pressure
+                                                                  !! anomaly in each layer due to free surface height
+                                                                  !! anomalies [L2 H-1 T-2 ~> m s-2 or m4 kg-1 s-2].
+  type(KPP_CS),           pointer :: KPP_CSp => NULL() !< KPP control structure needed to ge
+  type(energetic_PBL_CS), pointer :: energetic_PBL_CSp => NULL()  !< ePBL control structure
+
+  real, pointer, dimension(:,:) :: taux_bot => NULL() !< frictional x-bottom stress from the ocean
+                                                      !! to the seafloor [R L Z T-2 ~> Pa]
+  real, pointer, dimension(:,:) :: tauy_bot => NULL() !< frictional y-bottom stress from the ocean
+                                                      !! to the seafloor [R L Z T-2 ~> Pa]
+  type(BT_cont_type), pointer   :: BT_cont  => NULL() !<  A structure with elements that describe the
+                                                      !! effective summed open face areas as a function
+                                                      !! of barotropic flow.
+
+  logical :: split_bottom_stress  !< If true, provide the bottom stress
+                                  !! calculated by the vertical viscosity to the
+                                  !! barotropic solver.
+  logical :: calc_dtbt            !< If true, calculate the barotropic time-step
+                                  !! dynamically.
+  logical :: store_CAu            !< If true, store the Coriolis and advective accelerations at the
+                                  !! end of the timestep for use in the next predictor step.
+  logical :: CAu_pred_stored      !< If true, the Coriolis and advective accelerations at the
+                                  !! end of the timestep have been stored for use in the next
+                                  !! predictor step.  This is used to accomodate various generations
+                                  !! of restart files.
+  logical :: calculate_SAL        !< If true, calculate self-attraction and loading.
+  logical :: use_tides            !< If true, tidal forcing is enabled.
+  logical :: remap_aux            !< If true, apply ALE remapping to all of the auxiliary 3-D
+                                  !! variables that are needed to reproduce across restarts,
+                                  !! similarly to what is done with the primary state variables.
+
+  real    :: be      !< A nondimensional number from 0.5 to 1 that controls
+                     !! the backward weighting of the time stepping scheme [nondim]
+  real    :: begw    !< A nondimensional number from 0 to 1 that controls
+                     !! the extent to which the treatment of gravity waves
+                     !! is forward-backward (0) or simulated backward
+                     !! Euler (1) [nondim].  0 is often used.
+  logical :: debug   !< If true, write verbose checksums for debugging purposes.
+  logical :: debug_OBC !< If true, do debugging calls for open boundary conditions.
+  logical :: fpmix = .false.                 !< If true, applies profiles of momentum flux magnitude and direction.
+  logical :: module_is_initialized = .false. !< Record whether this module has been initialized.
+
+  !>@{ Diagnostic IDs
+  integer :: id_uold   = -1, id_vold   = -1
+  integer :: id_uh     = -1, id_vh     = -1
+  integer :: id_umo    = -1, id_vmo    = -1
+  integer :: id_umo_2d = -1, id_vmo_2d = -1
+  integer :: id_PFu    = -1, id_PFv    = -1
+  integer :: id_CAu    = -1, id_CAv    = -1
+  integer :: id_ueffA = -1, id_veffA = -1
+  ! integer :: id_hf_PFu    = -1, id_hf_PFv    = -1
+  integer :: id_h_PFu    = -1, id_h_PFv    = -1
+  integer :: id_hf_PFu_2d = -1, id_hf_PFv_2d = -1
+  integer :: id_intz_PFu_2d = -1, id_intz_PFv_2d = -1
+  integer :: id_PFu_visc_rem = -1, id_PFv_visc_rem = -1
+  ! integer :: id_hf_CAu    = -1, id_hf_CAv    = -1
+  integer :: id_h_CAu    = -1, id_h_CAv    = -1
+  integer :: id_hf_CAu_2d = -1, id_hf_CAv_2d = -1
+  integer :: id_intz_CAu_2d = -1, id_intz_CAv_2d = -1
+  integer :: id_CAu_visc_rem = -1, id_CAv_visc_rem = -1
+  integer :: id_deta_dt = -1
+
+  ! Split scheme only.
+  integer :: id_uav        = -1, id_vav        = -1
+  integer :: id_u_BT_accel = -1, id_v_BT_accel = -1
+  ! integer :: id_hf_u_BT_accel    = -1, id_hf_v_BT_accel    = -1
+  integer :: id_h_u_BT_accel    = -1, id_h_v_BT_accel    = -1
+  integer :: id_hf_u_BT_accel_2d = -1, id_hf_v_BT_accel_2d = -1
+  integer :: id_intz_u_BT_accel_2d = -1, id_intz_v_BT_accel_2d = -1
+  integer :: id_u_BT_accel_visc_rem    = -1, id_v_BT_accel_visc_rem    = -1
+  !>@}
+
+  type(diag_ctrl), pointer       :: diag => NULL() !< A structure that is used to regulate the
+                                         !! timing of diagnostic output.
+  type(accel_diag_ptrs), pointer :: ADp => NULL()  !< A structure pointing to the various
+                                         !! accelerations in the momentum equations,
+                                         !! which can later be used to calculate
+                                         !! derived diagnostics like energy budgets.
+  type(accel_diag_ptrs), pointer :: AD_pred => NULL() !< A structure pointing to the various
+                                         !! predictor step accelerations in the momentum equations,
+                                         !! which can be used to debug truncations.
+  type(cont_diag_ptrs), pointer  :: CDp => NULL()  !< A structure with pointers to various
+                                         !! terms in the continuity equations,
+                                         !! which can later be used to calculate
+                                         !! derived diagnostics like energy budgets.
+
+  ! The remainder of the structure points to child subroutines' control structures.
+  !> A pointer to the horizontal viscosity control structure
+  type(hor_visc_CS) :: hor_visc
+  !> A pointer to the continuity control structure
+  type(continuity_CS) :: continuity_CSp
+  !> The CoriolisAdv control structure
+  type(CoriolisAdv_CS) :: CoriolisAdv
+  !> A pointer to the PressureForce control structure
+  type(PressureForce_CS) :: PressureForce_CSp
+  !> A pointer to a structure containing interface height diffusivities
+  type(vertvisc_CS),      pointer :: vertvisc_CSp      => NULL()
+  !> A pointer to the set_visc control structure
+  type(set_visc_CS),      pointer :: set_visc_CSp      => NULL()
+  !> A pointer to the barotropic stepping control structure
+  type(barotropic_CS) :: barotropic_CSp
+  !> A pointer to the SAL control structure
+  type(SAL_CS) :: SAL_CSp
+  !> A pointer to the tidal forcing control structure
+  type(tidal_forcing_CS) :: tides_CSp
+  !> A pointer to the ALE control structure.
+  type(ALE_CS), pointer :: ALE_CSp => NULL()
+
+  type(ocean_OBC_type),   pointer :: OBC => NULL() !< A pointer to an open boundary
+     !! condition type that specifies whether, where, and  what open boundary
+     !! conditions are used.  If no open BCs are used, this pointer stays
+     !! nullified.  Flather OBCs use open boundary_CS as well.
+  !> A pointer to the update_OBC control structure
+  type(update_OBC_CS),    pointer :: update_OBC_CSp => NULL()
+
+  type(group_pass_type) :: pass_eta  !< Structure for group halo pass
+  type(group_pass_type) :: pass_visc_rem  !< Structure for group halo pass
+  type(group_pass_type) :: pass_uvp  !< Structure for group halo pass
+  type(group_pass_type) :: pass_hp_uv  !< Structure for group halo pass
+  type(group_pass_type) :: pass_uv  !< Structure for group halo pass
+  type(group_pass_type) :: pass_h  !< Structure for group halo pass
+  type(group_pass_type) :: pass_av_uvh  !< Structure for group halo pass
+
+end type MOM_dyn_split_RK2b_CS
+
+
+public step_MOM_dyn_split_RK2b
+public register_restarts_dyn_split_RK2b
+public initialize_dyn_split_RK2b
+public remap_dyn_split_RK2b_aux_vars
+public end_dyn_split_RK2b
+
+!>@{ CPU time clock IDs
+integer :: id_clock_Cor, id_clock_pres, id_clock_vertvisc
+integer :: id_clock_horvisc, id_clock_mom_update
+integer :: id_clock_continuity, id_clock_thick_diff
+integer :: id_clock_btstep, id_clock_btcalc, id_clock_btforce
+integer :: id_clock_pass, id_clock_pass_init
+!>@}
+
+contains
+
+!> RK2 splitting for time stepping MOM adiabatic dynamics
+subroutine step_MOM_dyn_split_RK2b(u_inst, v_inst, h, tv, visc, Time_local, dt, forces, &
+                                   p_surf_begin, p_surf_end, uh, vh, uhtr, vhtr, eta_av, &
+                                   G, GV, US, CS, calc_dtbt, VarMix, MEKE, thickness_diffuse_CSp, pbv, Waves)
+  type(ocean_grid_type),             intent(inout) :: G            !< Ocean grid structure
+  type(verticalGrid_type),           intent(in)    :: GV           !< Ocean vertical grid structure
+  type(unit_scale_type),             intent(in)    :: US           !< A dimensional unit scaling type
+  real, dimension(SZIB_(G),SZJ_(G),SZK_(GV)), &
+                             target, intent(inout) :: u_inst       !< Zonal velocity [L T-1 ~> m s-1]
+  real, dimension(SZI_(G),SZJB_(G),SZK_(GV)), &
+                             target, intent(inout) :: v_inst       !< Meridional velocity [L T-1 ~> m s-1]
+  real, dimension(SZI_(G),SZJ_(G),SZK_(GV)), &
+                                     intent(inout) :: h            !< Layer thickness [H ~> m or kg m-2]
+  type(thermo_var_ptrs),             intent(in)    :: tv           !< Thermodynamic type
+  type(vertvisc_type),               intent(inout) :: visc         !< Vertical visc, bottom drag, and related
+  type(time_type),                   intent(in)    :: Time_local   !< Model time at end of time step
+  real,                              intent(in)    :: dt           !< Baroclinic dynamics time step [T ~> s]
+  type(mech_forcing),                intent(in)    :: forces       !< A structure with the driving mechanical forces
+  real, dimension(:,:),              pointer       :: p_surf_begin !< Surface pressure at the start of this dynamic
+                                                                   !! time step [R L2 T-2 ~> Pa]
+  real, dimension(:,:),              pointer       :: p_surf_end   !< Surface pressure at the end of this dynamic
+                                                                   !! time step [R L2 T-2 ~> Pa]
+  real, dimension(SZIB_(G),SZJ_(G),SZK_(GV)), &
+                             target, intent(inout) :: uh           !< Zonal volume or mass transport
+                                                                   !! [H L2 T-1 ~> m3 s-1 or kg s-1]
+  real, dimension(SZI_(G),SZJB_(G),SZK_(GV)), &
+                             target, intent(inout) :: vh           !< Meridional volume or mass transport
+                                                                   !! [H L2 T-1 ~> m3 s-1 or kg s-1]
+  real, dimension(SZIB_(G),SZJ_(G),SZK_(GV)), &
+                                     intent(inout) :: uhtr         !< Accumulated zonal volume or mass transport
+                                                                   !! since last tracer advection [H L2 ~> m3 or kg]
+  real, dimension(SZI_(G),SZJB_(G),SZK_(GV)), &
+                                     intent(inout) :: vhtr         !< Accumulated meridional volume or mass transport
+                                                                   !! since last tracer advection [H L2 ~> m3 or kg]
+  real, dimension(SZI_(G),SZJ_(G)),  intent(out)   :: eta_av       !< Free surface height or column mass
+                                                                   !! averaged over time step [H ~> m or kg m-2]
+  type(MOM_dyn_split_RK2b_CS),       pointer       :: CS           !< Module control structure
+  logical,                           intent(in)    :: calc_dtbt    !< If true, recalculate the barotropic time step
+  type(VarMix_CS),                   intent(inout) :: VarMix       !< Variable mixing control structure
+  type(MEKE_type),                   intent(inout) :: MEKE         !< MEKE fields
+  type(thickness_diffuse_CS),        intent(inout) :: thickness_diffuse_CSp !< Pointer to a structure containing
+                                                                   !! interface height diffusivities
+  type(porous_barrier_type),         intent(in)    :: pbv          !< porous barrier fractional cell metrics
+  type(wave_parameters_CS), optional, pointer      :: Waves        !< A pointer to a structure containing
+                                                                   !! fields related to the surface wave conditions
+
+  ! local variables
+  real, dimension(SZIB_(G),SZJ_(G),SZK_(GV)) :: up  ! Predicted zonal velocity [L T-1 ~> m s-1].
+  real, dimension(SZI_(G),SZJB_(G),SZK_(GV)) :: vp  ! Predicted meridional velocity [L T-1 ~> m s-1].
+  real, dimension(SZI_(G),SZJ_(G),SZK_(GV))  :: hp  ! Predicted thickness [H ~> m or kg m-2].
+  real, dimension(SZI_(G),SZJ_(G),SZK_(GV))  :: dz  ! Distance between the interfaces around a layer [Z ~> m]
+  real, dimension(SZIB_(G),SZJ_(G),SZK_(GV)) :: ueffA   ! Effective Area of U-Faces [H L ~> m2]
+  real, dimension(SZI_(G),SZJB_(G),SZK_(GV)) :: veffA   ! Effective Area of V-Faces [H L ~> m2]
+  real, dimension(SZIB_(G),SZJ_(G),SZK_(GV)) :: u_bc_accel ! The summed zonal baroclinic accelerations
+                                                        ! of each layer calculated by the non-barotropic
+                                                        ! part of the model [L T-2 ~> m s-2]
+  real, dimension(SZI_(G),SZJB_(G),SZK_(GV)) :: v_bc_accel ! The summed meridional baroclinic accelerations
+                                                        ! of each layer calculated by the non-barotropic
+                                                        ! part of the model [L T-2 ~> m s-2]
+
+  real, dimension(SZIB_(G),SZJ_(G),SZK_(GV)), target :: uh_in ! The zonal mass transports that would be
+                                ! obtained using the initial velocities [H L2 T-1 ~> m3 s-1 or kg s-1]
+  real, dimension(SZI_(G),SZJB_(G),SZK_(GV)), target :: vh_in ! The meridional mass transports that would be
+                                ! obtained using the initial velocities [H L2 T-1 ~> m3 s-1 or kg s-1]
+
+  real, dimension(SZI_(G),SZJ_(G)) :: eta_pred ! The predictor value of the free surface height
+                                               ! or column mass [H ~> m or kg m-2]
+  real, dimension(SZI_(G),SZJ_(G)) :: SpV_avg  ! The column averaged specific volume [R-1 ~> m3 kg-1]
+  real, dimension(SZI_(G),SZJ_(G)) :: deta_dt  ! A diagnostic of the time derivative of the free surface
+                                               ! height or column mass [H T-1 ~> m s-1 or kg m-2 s-1]
+
+  real, dimension(SZIB_(G),SZJ_(G),SZK_(GV)) :: u_old_rad_OBC ! The starting zonal velocities, which are
+                                ! saved for use in the Flather open boundary condition code [L T-1 ~> m s-1]
+  real, dimension(SZI_(G),SZJB_(G),SZK_(GV)) :: v_old_rad_OBC ! The starting meridional velocities, which are
+                                ! saved for use in the Flather open boundary condition code [L T-1 ~> m s-1]
+
+  ! GMM, TODO: make these allocatable?
+  real, dimension(SZIB_(G),SZJ_(G),SZK_(GV)) :: uold ! u-velocity before vert_visc is applied, for fpmix
+                                                     !                                      [L T-1 ~> m s-1]
+  real, dimension(SZI_(G),SZJB_(G),SZK_(GV)) :: vold ! v-velocity before vert_visc is applied, for fpmix
+                                                     !                                      [L T-1 ~> m s-1]
+  real :: pres_to_eta ! A factor that converts pressures to the units of eta
+                      ! [H T2 R-1 L-2 ~> m Pa-1 or kg m-2 Pa-1]
+  real, pointer, dimension(:,:) :: &
+    p_surf => NULL(), &         ! A pointer to the surface pressure [R L2 T-2 ~> Pa]
+    eta_PF_start => NULL(), &   ! The value of eta that corresponds to the starting pressure
+                                ! for the barotropic solver [H ~> m or kg m-2]
+    taux_bot => NULL(), &       ! A pointer to the zonal bottom stress in some cases [R L Z T-2 ~> Pa]
+    tauy_bot => NULL(), &       ! A pointer to the meridional bottom stress in some cases [R L Z T-2 ~> Pa]
+    ! This pointer is just used as shorthand for CS%eta.
+    eta => NULL()               ! A pointer to the instantaneous free surface height (in Boussinesq
+                                ! mode) or column mass anomaly (in non-Boussinesq mode) [H ~> m or kg m-2]
+
+  real, pointer, dimension(:,:,:) :: &
+    ! These pointers are used to alter which fields are passed to btstep with various options:
+    u_ptr => NULL(), &   ! A pointer to a zonal velocity [L T-1 ~> m s-1]
+    v_ptr => NULL(), &   ! A pointer to a meridional velocity [L T-1 ~> m s-1]
+    uh_ptr => NULL(), &  ! A pointer to a zonal volume or mass transport [H L2 T-1 ~> m3 s-1 or kg s-1]
+    vh_ptr => NULL(), &  ! A pointer to a meridional volume or mass transport [H L2 T-1 ~> m3 s-1 or kg s-1]
+    ! These pointers are just used as shorthand for CS%u_av, CS%v_av, and CS%h_av.
+    u_av, & ! The zonal velocity time-averaged over a time step [L T-1 ~> m s-1].
+    v_av, & ! The meridional velocity time-averaged over a time step [L T-1 ~> m s-1].
+    h_av    ! The layer thickness time-averaged over a time step [H ~> m or kg m-2].
+
+  real, dimension(SZI_(G),SZJ_(G)) :: hbl       ! Boundary layer depth from Cvmix [H ~> m or kg m-2]
+  real :: dt_pred   ! The time step for the predictor part of the baroclinic time stepping [T ~> s].
+  real :: Idt_bc    ! Inverse of the baroclinic timestep [T-1 ~> s-1]
+  logical :: dyn_p_surf
+  logical :: BT_cont_BT_thick ! If true, use the BT_cont_type to estimate the
+                              ! relative weightings of the layers in calculating
+                              ! the barotropic accelerations.
+  logical :: Use_Stokes_PGF ! If true, add Stokes PGF to hydrostatic PGF
+  !---For group halo pass
+  logical :: showCallTree, sym
+
+  integer :: i, j, k, is, ie, js, je, Isq, Ieq, Jsq, Jeq, nz
+  integer :: cont_stencil, obc_stencil
+
+  is  = G%isc  ; ie  = G%iec  ; js  = G%jsc  ; je  = G%jec ; nz = GV%ke
+  Isq = G%IscB ; Ieq = G%IecB ; Jsq = G%JscB ; Jeq = G%JecB
+  u_av => CS%u_av ; v_av => CS%v_av ; h_av => CS%h_av ; eta => CS%eta
+
+  Idt_bc = 1.0 / dt
+
+  sym = G%Domain%symmetric  ! switch to include symmetric domain in checksums
+
+  showCallTree = callTree_showQuery()
+  if (showCallTree) call callTree_enter("step_MOM_dyn_split_RK2b(), MOM_dynamics_split_RK2b.F90")
+
+  !$OMP parallel do default(shared)
+  do k=1,nz
+    do j=G%jsd,G%jed   ; do i=G%isdB,G%iedB ;  up(i,j,k) = 0.0 ; enddo ; enddo
+    do j=G%jsdB,G%jedB ; do i=G%isd,G%ied   ;  vp(i,j,k) = 0.0 ; enddo ; enddo
+    do j=G%jsd,G%jed   ; do i=G%isd,G%ied   ;  hp(i,j,k) = h(i,j,k) ; enddo ; enddo
+  enddo
+
+  ! Update CFL truncation value as function of time
+  call updateCFLtruncationValue(Time_local, CS%vertvisc_CSp, US)
+
+  if (CS%debug) then
+    call MOM_state_chksum("Start predictor ", u_inst, v_inst, h, uh, vh, G, GV, US, symmetric=sym)
+    call check_redundant("Start predictor u ", u_inst, v_inst, G, unscale=US%L_T_to_m_s)
+    call check_redundant("Start predictor uh ", uh, vh, G, unscale=GV%H_to_MKS*US%L_to_m**2*US%s_to_T)
+  endif
+
+  dyn_p_surf = associated(p_surf_begin) .and. associated(p_surf_end)
+  if (dyn_p_surf) then
+    p_surf => p_surf_end
+    call safe_alloc_ptr(eta_PF_start,G%isd,G%ied,G%jsd,G%jed)
+    eta_PF_start(:,:) = 0.0
+  else
+    p_surf => forces%p_surf
+  endif
+
+  if (associated(CS%OBC)) then
+    if (CS%debug_OBC) call open_boundary_test_extern_h(G, GV, CS%OBC, h)
+
+    ! Update OBC ramp value as function of time
+    call update_OBC_ramp(Time_local, CS%OBC, US)
+
+    do k=1,nz ; do j=G%jsd,G%jed ; do I=G%IsdB,G%IedB
+      u_old_rad_OBC(I,j,k) = u_av(I,j,k)
+    enddo ; enddo ; enddo
+    do k=1,nz ; do J=G%JsdB,G%JedB ; do i=G%isd,G%ied
+      v_old_rad_OBC(i,J,k) = v_av(i,J,k)
+    enddo ; enddo ; enddo
+  endif
+
+  BT_cont_BT_thick = .false.
+  if (associated(CS%BT_cont)) BT_cont_BT_thick = &
+    (allocated(CS%BT_cont%h_u) .and. allocated(CS%BT_cont%h_v))
+
+  if (CS%split_bottom_stress) then
+    taux_bot => CS%taux_bot ; tauy_bot => CS%tauy_bot
+  endif
+
+  !--- begin set up for group halo pass
+
+  cont_stencil = continuity_stencil(CS%continuity_CSp)
+  obc_stencil = 2
+  if (associated(CS%OBC)) then
+    if (CS%OBC%oblique_BCs_exist_globally) obc_stencil = 3
+  endif
+  call cpu_clock_begin(id_clock_pass)
+  call create_group_pass(CS%pass_eta, eta, G%Domain, halo=1)
+  call create_group_pass(CS%pass_visc_rem, CS%visc_rem_u, CS%visc_rem_v, G%Domain, &
+                         To_All+SCALAR_PAIR, CGRID_NE, halo=max(1,cont_stencil))
+  call create_group_pass(CS%pass_uvp, up, vp, G%Domain, halo=max(1,cont_stencil))
+  call create_group_pass(CS%pass_hp_uv, hp, G%Domain, halo=2)
+  call create_group_pass(CS%pass_hp_uv, u_av, v_av, G%Domain, halo=max(2,obc_stencil))
+  call create_group_pass(CS%pass_hp_uv, uh(:,:,:), vh(:,:,:), G%Domain, halo=max(2,obc_stencil))
+
+  call create_group_pass(CS%pass_uv, u_inst, v_inst, G%Domain, halo=max(2,cont_stencil))
+  call create_group_pass(CS%pass_h, h, G%Domain, halo=max(2,cont_stencil))
+  call create_group_pass(CS%pass_av_uvh, u_av, v_av, G%Domain, halo=max(2,obc_stencil))
+  call create_group_pass(CS%pass_av_uvh, uh(:,:,:), vh(:,:,:), G%Domain, halo=max(2,obc_stencil))
+  call cpu_clock_end(id_clock_pass)
+  !--- end set up for group halo pass
+
+
+! PFu = d/dx M(h,T,S)
+! pbce = dM/deta
+  if (CS%begw == 0.0) call enable_averages(dt, Time_local, CS%diag)
+  call cpu_clock_begin(id_clock_pres)
+  call PressureForce(h, tv, CS%PFu, CS%PFv, G, GV, US, CS%PressureForce_CSp, &
+                     CS%ALE_CSp, p_surf, CS%pbce, CS%eta_PF)
+  if (dyn_p_surf) then
+    pres_to_eta = 1.0 / (GV%g_Earth * GV%H_to_RZ)
+    !$OMP parallel do default(shared)
+    do j=Jsq,Jeq+1 ; do i=Isq,Ieq+1
+      eta_PF_start(i,j) = CS%eta_PF(i,j) - pres_to_eta * (p_surf_begin(i,j) - p_surf_end(i,j))
+    enddo ; enddo
+  endif
+  ! Stokes shear force contribution to pressure gradient
+  Use_Stokes_PGF = present(Waves)
+  if (Use_Stokes_PGF) then
+    Use_Stokes_PGF = associated(Waves)
+    if (Use_Stokes_PGF) Use_Stokes_PGF = Waves%Stokes_PGF
+    if (Use_Stokes_PGF) then
+      call thickness_to_dz(h, tv, dz, G, GV, US, halo_size=1)
+      call Stokes_PGF(G, GV, US, dz, u_inst, v_inst, CS%PFu_Stokes, CS%PFv_Stokes, Waves)
+
+      ! We are adding Stokes_PGF to hydrostatic PGF here.  The diag PFu/PFv
+      ! will therefore report the sum total PGF and we avoid other
+      ! modifications in the code.  The PFu_Stokes is output within the waves routines.
+      if (.not.Waves%Passive_Stokes_PGF) then
+        do k=1,nz
+          do j=js,je ; do I=Isq,Ieq
+            CS%PFu(I,j,k) = CS%PFu(I,j,k) + CS%PFu_Stokes(I,j,k)
+          enddo ; enddo
+        enddo
+        do k=1,nz
+          do J=Jsq,Jeq ; do i=is,ie
+             CS%PFv(i,J,k) = CS%PFv(i,J,k) + CS%PFv_Stokes(i,J,k)
+          enddo ; enddo
+        enddo
+      endif
+    endif
+  endif
+  call cpu_clock_end(id_clock_pres)
+  call disable_averaging(CS%diag)
+  if (showCallTree) call callTree_wayPoint("done with PressureForce (step_MOM_dyn_split_RK2b)")
+
+  if (associated(CS%OBC)) then ; if (CS%OBC%update_OBC) then
+    call update_OBC_data(CS%OBC, G, GV, US, tv, h, CS%update_OBC_CSp, Time_local)
+  endif ; endif
+  if (associated(CS%OBC) .and. CS%debug_OBC) &
+    call open_boundary_zero_normal_flow(CS%OBC, G, GV, CS%PFu, CS%PFv)
+
+  if (G%nonblocking_updates) &
+    call start_group_pass(CS%pass_eta, G%Domain, clock=id_clock_pass)
+
+! CAu = -(f+zeta_av)/h_av vh + d/dx KE_av
+  if (.not.CS%CAu_pred_stored) then
+    ! Calculate a predictor-step estimate of the Coriolis and momentum advection terms,
+    ! if it was not already stored from the end of the previous time step.
+    call cpu_clock_begin(id_clock_Cor)
+    call CorAdCalc(u_av, v_av, h_av, uh, vh, CS%CAu_pred, CS%CAv_pred, CS%OBC, CS%AD_pred, &
+                   G, GV, US, CS%CoriolisAdv, pbv, Waves=Waves)
+    call cpu_clock_end(id_clock_Cor)
+    if (showCallTree) call callTree_wayPoint("done with CorAdCalc (step_MOM_dyn_split_RK2b)")
+  endif
+
+! u_bc_accel = CAu + PFu + diffu(u[n-1])
+  call cpu_clock_begin(id_clock_btforce)
+  !$OMP parallel do default(shared)
+  do k=1,nz
+    do j=js,je ; do I=Isq,Ieq
+      u_bc_accel(I,j,k) = (CS%CAu_pred(I,j,k) + CS%PFu(I,j,k)) + CS%diffu(I,j,k)
+    enddo ; enddo
+    do J=Jsq,Jeq ; do i=is,ie
+      v_bc_accel(i,J,k) = (CS%CAv_pred(i,J,k) + CS%PFv(i,J,k)) + CS%diffv(i,J,k)
+    enddo ; enddo
+  enddo
+  if (associated(CS%OBC)) then
+    call open_boundary_zero_normal_flow(CS%OBC, G, GV, u_bc_accel, v_bc_accel)
+  endif
+  call cpu_clock_end(id_clock_btforce)
+
+  if (CS%debug) then
+    call MOM_accel_chksum("pre-btstep accel", CS%CAu_pred, CS%CAv_pred, CS%PFu, CS%PFv, &
+                          CS%diffu, CS%diffv, G, GV, US, CS%pbce, u_bc_accel, v_bc_accel, &
+                          symmetric=sym)
+    call check_redundant("pre-btstep CS%CA ", CS%CAu_pred, CS%CAv_pred, G, unscale=US%L_T2_to_m_s2)
+    call check_redundant("pre-btstep CS%PF ", CS%PFu, CS%PFv, G, unscale=US%L_T2_to_m_s2)
+    call check_redundant("pre-btstep CS%diff ", CS%diffu, CS%diffv, G, unscale=US%L_T2_to_m_s2)
+    call check_redundant("pre-btstep u_bc_accel ", u_bc_accel, v_bc_accel, G, unscale=US%L_T2_to_m_s2)
+  endif
+
+  call cpu_clock_begin(id_clock_vertvisc)
+  !$OMP parallel do default(shared)
+  do k=1,nz
+    do j=js,je ; do I=Isq,Ieq
+      up(I,j,k) = G%mask2dCu(I,j) * (u_inst(I,j,k) + dt * u_bc_accel(I,j,k))
+    enddo ; enddo
+    do J=Jsq,Jeq ; do i=is,ie
+      vp(i,J,k) = G%mask2dCv(i,J) * (v_inst(i,J,k) + dt * v_bc_accel(i,J,k))
+    enddo ; enddo
+  enddo
+
+  call enable_averages(dt, Time_local, CS%diag)
+  call set_viscous_ML(u_inst, v_inst, h, tv, forces, visc, dt, G, GV, US, CS%set_visc_CSp)
+  call disable_averaging(CS%diag)
+
+  if (CS%debug) then
+    call uvchksum("before vertvisc: up", up, vp, G%HI, haloshift=0, symmetric=sym, scale=US%L_T_to_m_s)
+  endif
+  call thickness_to_dz(h, tv, dz, G, GV, US, halo_size=1)
+  call vertvisc_coef(up, vp, h, dz, forces, visc, tv, dt, G, GV, US, CS%vertvisc_CSp, CS%OBC, VarMix)
+  call vertvisc_remnant(visc, CS%visc_rem_u, CS%visc_rem_v, dt, G, GV, US, CS%vertvisc_CSp)
+  call cpu_clock_end(id_clock_vertvisc)
+  if (showCallTree) call callTree_wayPoint("done with vertvisc_coef (step_MOM_dyn_split_RK2b)")
+
+
+  call cpu_clock_begin(id_clock_pass)
+  if (G%nonblocking_updates) then
+    call complete_group_pass(CS%pass_eta, G%Domain)
+    call start_group_pass(CS%pass_visc_rem, G%Domain)
+  else
+    call do_group_pass(CS%pass_eta, G%Domain)
+    call do_group_pass(CS%pass_visc_rem, G%Domain)
+  endif
+  call cpu_clock_end(id_clock_pass)
+
+  call cpu_clock_begin(id_clock_btcalc)
+  ! Calculate the relative layer weights for determining barotropic quantities.
+  if (.not.BT_cont_BT_thick) &
+    call btcalc(h, G, GV, CS%barotropic_CSp, OBC=CS%OBC)
+  call bt_mass_source(h, eta, .true., G, GV, CS%barotropic_CSp)
+
+  SpV_avg(:,:) = 0.0
+  if ((.not.GV%Boussinesq) .and. associated(CS%OBC)) then
+    ! Determine the column average specific volume if it is needed due to the
+    ! use of Flather open boundary conditions in non-Boussinesq mode.
+    if (open_boundary_query(CS%OBC, apply_Flather_OBC=.true.)) &
+      call find_col_avg_SpV(h, SpV_avg, tv, G, GV, US)
+  endif
+  call cpu_clock_end(id_clock_btcalc)
+
+  if (G%nonblocking_updates) &
+    call complete_group_pass(CS%pass_visc_rem, G%Domain, clock=id_clock_pass)
+
+! u_accel_bt = layer accelerations due to barotropic solver
+  call cpu_clock_begin(id_clock_continuity)
+  call continuity(u_inst, v_inst, h, hp, uh_in, vh_in, dt, G, GV, US, CS%continuity_CSp, CS%OBC, pbv, &
+                  visc_rem_u=CS%visc_rem_u, visc_rem_v=CS%visc_rem_v, BT_cont=CS%BT_cont)
+  call cpu_clock_end(id_clock_continuity)
+  if (BT_cont_BT_thick) then
+    call btcalc(h, G, GV, CS%barotropic_CSp, CS%BT_cont%h_u, CS%BT_cont%h_v, &
+                OBC=CS%OBC)
+  endif
+  if (showCallTree) call callTree_wayPoint("done with continuity[BT_cont] (step_MOM_dyn_split_RK2b)")
+
+  uh_ptr => uh_in ; vh_ptr => vh_in ; u_ptr => u_inst ; v_ptr => v_inst
+
+  call cpu_clock_begin(id_clock_btstep)
+  if (calc_dtbt) call set_dtbt(G, GV, US, CS%barotropic_CSp, eta, CS%pbce)
+  if (showCallTree) call callTree_enter("btstep(), MOM_barotropic.F90")
+  ! This is the predictor step call to btstep.
+  ! The CS%ADp argument here stores the weights for certain integrated diagnostics.
+  call btstep(u_inst, v_inst, eta, dt, u_bc_accel, v_bc_accel, forces, CS%pbce, CS%eta_PF, u_av, v_av, &
+              CS%u_accel_bt, CS%v_accel_bt, eta_pred, CS%uhbt, CS%vhbt, G, GV, US, &
+              CS%barotropic_CSp, CS%visc_rem_u, CS%visc_rem_v, SpV_avg, CS%ADp, CS%OBC, CS%BT_cont, &
+              eta_PF_start, taux_bot, tauy_bot, uh_ptr, vh_ptr, u_ptr, v_ptr)
+  if (showCallTree) call callTree_leave("btstep()")
+  call cpu_clock_end(id_clock_btstep)
+
+! up = u + dt_pred*( u_bc_accel + u_accel_bt )
+  dt_pred = dt * CS%be
+  call cpu_clock_begin(id_clock_mom_update)
+
+  !$OMP parallel do default(shared)
+  do k=1,nz
+    do J=Jsq,Jeq ; do i=is,ie
+      vp(i,J,k) = G%mask2dCv(i,J) * (v_inst(i,J,k) + dt_pred * &
+                      (v_bc_accel(i,J,k) + CS%v_accel_bt(i,J,k)))
+    enddo ; enddo
+    do j=js,je ; do I=Isq,Ieq
+      up(I,j,k) = G%mask2dCu(I,j) * (u_inst(I,j,k) + dt_pred * &
+                      (u_bc_accel(I,j,k) + CS%u_accel_bt(I,j,k)))
+    enddo ; enddo
+  enddo
+  call cpu_clock_end(id_clock_mom_update)
+
+  if (CS%debug) then
+    call uvchksum("Predictor 1 [uv]", up, vp, G%HI, haloshift=0, symmetric=sym, scale=US%L_T_to_m_s)
+    call hchksum(h, "Predictor 1 h", G%HI, haloshift=1, scale=GV%H_to_MKS)
+    call uvchksum("Predictor 1 [uv]h", uh, vh, G%HI,haloshift=2, &
+                  symmetric=sym, scale=GV%H_to_MKS*US%L_to_m**2*US%s_to_T)
+!   call MOM_state_chksum("Predictor 1", up, vp, h, uh, vh, G, GV, US, haloshift=1)
+    call MOM_accel_chksum("Predictor accel", CS%CAu_pred, CS%CAv_pred, CS%PFu, CS%PFv, &
+             CS%diffu, CS%diffv, G, GV, US, CS%pbce, CS%u_accel_bt, CS%v_accel_bt, symmetric=sym)
+    call MOM_state_chksum("Predictor 1 init", u_inst, v_inst, h, uh, vh, G, GV, US, haloshift=1, &
+                          symmetric=sym)
+    call check_redundant("Predictor 1 up", up, vp, G, unscale=US%L_T_to_m_s)
+    call check_redundant("Predictor 1 uh", uh, vh, G, unscale=GV%H_to_MKS*US%L_to_m**2*US%s_to_T)
+  endif
+
+! up <- up + dt_pred d/dz visc d/dz up
+! u_av  <- u_av  + dt_pred d/dz visc d/dz u_av
+  call cpu_clock_begin(id_clock_vertvisc)
+  if (CS%debug) then
+    call uvchksum("0 before vertvisc: [uv]p", up, vp, G%HI,haloshift=0, symmetric=sym, scale=US%L_T_to_m_s)
+  endif
+
+  if (CS%fpmix) then
+    uold(:,:,:) = 0.0
+    vold(:,:,:) = 0.0
+    do k=1,nz ; do j=js,je ; do I=Isq,Ieq
+      uold(I,j,k) = up(I,j,k)
+    enddo ; enddo ; enddo
+    do k=1,nz ; do J=Jsq,Jeq ; do i=is,ie
+      vold(i,J,k) = vp(i,J,k)
+    enddo ; enddo ; enddo
+  endif
+
+  call thickness_to_dz(h, tv, dz, G, GV, US, halo_size=1)
+  call vertvisc_coef(up, vp, h, dz, forces, visc, tv, dt_pred, G, GV, US, CS%vertvisc_CSp, &
+                     CS%OBC, VarMix)
+  call vertvisc(up, vp, h, forces, visc, dt_pred, CS%OBC, CS%AD_pred, CS%CDp, G, &
+                GV, US, CS%vertvisc_CSp, CS%taux_bot, CS%tauy_bot, waves=waves)
+
+  if (CS%fpmix) then
+    hbl(:,:) = 0.0
+    if (ASSOCIATED(CS%KPP_CSp)) call KPP_get_BLD(CS%KPP_CSp, hbl, G, US, m_to_BLD_units=GV%m_to_H)
+    if (ASSOCIATED(CS%energetic_PBL_CSp)) &
+      call energetic_PBL_get_MLD(CS%energetic_PBL_CSp, hbl, G, US, m_to_MLD_units=GV%m_to_H)
+    call vertFPmix(up, vp, uold, vold, hbl, h, forces, &
+                   dt_pred, G, GV, US, CS%vertvisc_CSp, CS%OBC)
+    call vertvisc(up, vp, h, forces, visc, dt_pred, CS%OBC, CS%ADp, CS%CDp, G, &
+                GV, US, CS%vertvisc_CSp, CS%taux_bot, CS%tauy_bot, waves=waves)
+  endif
+
+  if (showCallTree) call callTree_wayPoint("done with vertvisc (step_MOM_dyn_split_RK2b)")
+  if (G%nonblocking_updates) then
+    call cpu_clock_end(id_clock_vertvisc)
+    call start_group_pass(CS%pass_uvp, G%Domain, clock=id_clock_pass)
+    call cpu_clock_begin(id_clock_vertvisc)
+  endif
+  call vertvisc_remnant(visc, CS%visc_rem_u, CS%visc_rem_v, dt_pred, G, GV, US, CS%vertvisc_CSp)
+  call cpu_clock_end(id_clock_vertvisc)
+
+  call do_group_pass(CS%pass_visc_rem, G%Domain, clock=id_clock_pass)
+  if (G%nonblocking_updates) then
+    call complete_group_pass(CS%pass_uvp, G%Domain, clock=id_clock_pass)
+  else
+    call do_group_pass(CS%pass_uvp, G%Domain, clock=id_clock_pass)
+  endif
+
+  ! uh = u_av * h
+  ! hp = h + dt * div . uh
+  call cpu_clock_begin(id_clock_continuity)
+  call continuity(up, vp, h, hp, uh, vh, dt, G, GV, US, CS%continuity_CSp, CS%OBC, pbv, &
+                  CS%uhbt, CS%vhbt, CS%visc_rem_u, CS%visc_rem_v, &
+                  u_av, v_av, BT_cont=CS%BT_cont)
+  call cpu_clock_end(id_clock_continuity)
+  if (showCallTree) call callTree_wayPoint("done with continuity (step_MOM_dyn_split_RK2b)")
+
+  call do_group_pass(CS%pass_hp_uv, G%Domain, clock=id_clock_pass)
+
+  if (associated(CS%OBC)) then
+
+    if (CS%debug) &
+      call uvchksum("Pre OBC avg [uv]", u_av, v_av, G%HI, haloshift=1, symmetric=sym, scale=US%L_T_to_m_s)
+
+    call radiation_open_bdry_conds(CS%OBC, u_av, u_old_rad_OBC, v_av, v_old_rad_OBC, G, GV, US, dt_pred)
+
+    if (CS%debug) &
+      call uvchksum("Post OBC avg [uv]", u_av, v_av, G%HI, haloshift=1, symmetric=sym, scale=US%L_T_to_m_s)
+
+    ! These should be done with a pass that excludes uh & vh.
+!   call do_group_pass(CS%pass_hp_uv, G%Domain, clock=id_clock_pass)
+  endif
+
+  if (G%nonblocking_updates) then
+    call start_group_pass(CS%pass_av_uvh, G%Domain, clock=id_clock_pass)
+  endif
+
+  ! h_av = (h + hp)/2
+  !$OMP parallel do default(shared)
+  do k=1,nz ; do j=js-2,je+2 ; do i=is-2,ie+2
+    h_av(i,j,k) = 0.5*(h(i,j,k) + hp(i,j,k))
+  enddo ; enddo ; enddo
+
+  ! The correction phase of the time step starts here.
+  call enable_averages(dt, Time_local, CS%diag)
+
+  ! Calculate a revised estimate of the free-surface height correction to be
+  ! used in the next call to btstep.  This call is at this point so that
+  ! hp can be changed if CS%begw /= 0.
+  ! eta_cor = ...                 (hidden inside CS%barotropic_CSp)
+  call cpu_clock_begin(id_clock_btcalc)
+  call bt_mass_source(hp, eta_pred, .false., G, GV, CS%barotropic_CSp)
+  call cpu_clock_end(id_clock_btcalc)
+
+  if (CS%begw /= 0.0) then
+    ! hp <- (1-begw)*h_in + begw*hp
+    ! Back up hp to the value it would have had after a time-step of
+    ! begw*dt.  hp is not used again until recalculated by continuity.
+    !$OMP parallel do default(shared)
+    do k=1,nz ; do j=js-1,je+1 ; do i=is-1,ie+1
+      hp(i,j,k) = (1.0-CS%begw)*h(i,j,k) + CS%begw*hp(i,j,k)
+    enddo ; enddo ; enddo
+
+    ! PFu = d/dx M(hp,T,S)
+    ! pbce = dM/deta
+    call cpu_clock_begin(id_clock_pres)
+    call PressureForce(hp, tv, CS%PFu, CS%PFv, G, GV, US, CS%PressureForce_CSp, &
+                       CS%ALE_CSp, p_surf, CS%pbce, CS%eta_PF)
+    ! Stokes shear force contribution to pressure gradient
+    Use_Stokes_PGF = present(Waves)
+    if (Use_Stokes_PGF) then
+      Use_Stokes_PGF = associated(Waves)
+      if (Use_Stokes_PGF) Use_Stokes_PGF = Waves%Stokes_PGF
+      if (Use_Stokes_PGF) then
+        call thickness_to_dz(h, tv, dz, G, GV, US, halo_size=1)
+        call Stokes_PGF(G, GV, US, dz, u_inst, v_inst, CS%PFu_Stokes, CS%PFv_Stokes, Waves)
+        if (.not.Waves%Passive_Stokes_PGF) then
+          do k=1,nz
+            do j=js,je ; do I=Isq,Ieq
+              CS%PFu(I,j,k) = CS%PFu(I,j,k) + CS%PFu_Stokes(I,j,k)
+            enddo ; enddo
+          enddo
+          do k=1,nz
+            do J=Jsq,Jeq ; do i=is,ie
+              CS%PFv(i,J,k) = CS%PFv(i,J,k) + CS%PFv_Stokes(i,J,k)
+            enddo ; enddo
+          enddo
+        endif
+      endif
+    endif
+    call cpu_clock_end(id_clock_pres)
+    if (showCallTree) call callTree_wayPoint("done with PressureForce[hp=(1-b).h+b.h] (step_MOM_dyn_split_RK2b)")
+  endif
+
+  if (G%nonblocking_updates) &
+    call complete_group_pass(CS%pass_av_uvh, G%Domain, clock=id_clock_pass)
+
+  if (BT_cont_BT_thick) then
+    call btcalc(h, G, GV, CS%barotropic_CSp, CS%BT_cont%h_u, CS%BT_cont%h_v, &
+                OBC=CS%OBC)
+    if (showCallTree) call callTree_wayPoint("done with btcalc[BT_cont_BT_thick] (step_MOM_dyn_split_RK2b)")
+  endif
+
+  if (CS%debug) then
+    call MOM_state_chksum("Predictor ", up, vp, hp, uh, vh, G, GV, US, symmetric=sym)
+    call uvchksum("Predictor avg [uv]", u_av, v_av, G%HI, haloshift=1, symmetric=sym, scale=US%L_T_to_m_s)
+    call hchksum(h_av, "Predictor avg h", G%HI, haloshift=0, scale=GV%H_to_MKS)
+  ! call MOM_state_chksum("Predictor avg ", u_av, v_av, h_av, uh, vh, G, GV, US)
+    call check_redundant("Predictor up ", up, vp, G, unscale=US%L_T_to_m_s)
+    call check_redundant("Predictor uh ", uh, vh, G, unscale=GV%H_to_MKS*US%L_to_m**2*US%s_to_T)
+  endif
+
+! diffu = horizontal viscosity terms (u_av)
+  call cpu_clock_begin(id_clock_horvisc)
+  call horizontal_viscosity(u_av, v_av, h_av, CS%diffu, CS%diffv, &
+                            MEKE, Varmix, G, GV, US, CS%hor_visc, &
+                            OBC=CS%OBC, BT=CS%barotropic_CSp, TD=thickness_diffuse_CSp, &
+                            ADp=CS%ADp)
+  call cpu_clock_end(id_clock_horvisc)
+  if (showCallTree) call callTree_wayPoint("done with horizontal_viscosity (step_MOM_dyn_split_RK2b)")
+
+! CAu = -(f+zeta_av)/h_av vh + d/dx KE_av
+  call cpu_clock_begin(id_clock_Cor)
+  call CorAdCalc(u_av, v_av, h_av, uh, vh, CS%CAu, CS%CAv, CS%OBC, CS%ADp, &
+                 G, GV, US, CS%CoriolisAdv, pbv, Waves=Waves)
+  call cpu_clock_end(id_clock_Cor)
+  if (showCallTree) call callTree_wayPoint("done with CorAdCalc (step_MOM_dyn_split_RK2b)")
+
+! Calculate the momentum forcing terms for the barotropic equations.
+
+! u_bc_accel = CAu + PFu + diffu(u[n-1])
+  call cpu_clock_begin(id_clock_btforce)
+  !$OMP parallel do default(shared)
+  do k=1,nz
+    do j=js,je ; do I=Isq,Ieq
+      u_bc_accel(I,j,k) = (CS%Cau(I,j,k) + CS%PFu(I,j,k)) + CS%diffu(I,j,k)
+    enddo ; enddo
+    do J=Jsq,Jeq ; do i=is,ie
+      v_bc_accel(i,J,k) = (CS%Cav(i,J,k) + CS%PFv(i,J,k)) + CS%diffv(i,J,k)
+    enddo ; enddo
+  enddo
+  if (associated(CS%OBC)) then
+    call open_boundary_zero_normal_flow(CS%OBC, G, GV, u_bc_accel, v_bc_accel)
+  endif
+  call cpu_clock_end(id_clock_btforce)
+
+  if (CS%debug) then
+    call MOM_accel_chksum("corr pre-btstep accel", CS%CAu, CS%CAv, CS%PFu, CS%PFv, &
+                          CS%diffu, CS%diffv, G, GV, US, CS%pbce, u_bc_accel, v_bc_accel, &
+                          symmetric=sym)
+    call check_redundant("corr pre-btstep CS%CA ", CS%CAu, CS%CAv, G, unscale=US%L_T2_to_m_s2)
+    call check_redundant("corr pre-btstep CS%PF ", CS%PFu, CS%PFv, G, unscale=US%L_T2_to_m_s2)
+    call check_redundant("corr pre-btstep CS%diff ", CS%diffu, CS%diffv, G, unscale=US%L_T2_to_m_s2)
+    call check_redundant("corr pre-btstep u_bc_accel ", u_bc_accel, v_bc_accel, G, unscale=US%L_T2_to_m_s2)
+  endif
+
+  ! u_accel_bt = layer accelerations due to barotropic solver
+  ! pbce = dM/deta
+  call cpu_clock_begin(id_clock_btstep)
+
+  uh_ptr => uh ; vh_ptr => vh ; u_ptr => u_av ; v_ptr => v_av
+
+  if (showCallTree) call callTree_enter("btstep(), MOM_barotropic.F90")
+  ! This is the corrector step call to btstep.
+  call btstep(u_inst, v_inst, eta, dt, u_bc_accel, v_bc_accel, forces, CS%pbce, CS%eta_PF, u_av, v_av, &
+              CS%u_accel_bt, CS%v_accel_bt, eta_pred, CS%uhbt, CS%vhbt, G, GV, US, &
+              CS%barotropic_CSp, CS%visc_rem_u, CS%visc_rem_v, SpV_avg, CS%ADp, CS%OBC, CS%BT_cont, &
+              eta_PF_start, taux_bot, tauy_bot, uh_ptr, vh_ptr, u_ptr, v_ptr, etaav=eta_av)
+  if (CS%id_deta_dt>0) then
+    do j=js,je ; do i=is,ie ; deta_dt(i,j) = (eta_pred(i,j) - eta(i,j))*Idt_bc ; enddo ; enddo
+  endif
+  do j=js,je ; do i=is,ie ; eta(i,j) = eta_pred(i,j) ; enddo ; enddo
+
+  call cpu_clock_end(id_clock_btstep)
+  if (showCallTree) call callTree_leave("btstep()")
+
+  if (CS%debug) then
+    call check_redundant("u_accel_bt ", CS%u_accel_bt, CS%v_accel_bt, G, unscale=US%L_T2_to_m_s2)
+  endif
+
+  ! u = u + dt*( u_bc_accel + u_accel_bt )
+  call cpu_clock_begin(id_clock_mom_update)
+  !$OMP parallel do default(shared)
+  do k=1,nz
+    do j=js,je ; do I=Isq,Ieq
+      u_inst(I,j,k) = G%mask2dCu(I,j) * (u_inst(I,j,k) + dt * &
+                      (u_bc_accel(I,j,k) + CS%u_accel_bt(I,j,k)))
+    enddo ; enddo
+    do J=Jsq,Jeq ; do i=is,ie
+      v_inst(i,J,k) = G%mask2dCv(i,J) * (v_inst(i,J,k) + dt * &
+                      (v_bc_accel(i,J,k) + CS%v_accel_bt(i,J,k)))
+    enddo ; enddo
+  enddo
+  call cpu_clock_end(id_clock_mom_update)
+
+  if (CS%debug) then
+    call uvchksum("Corrector 1 [uv]", u_inst, v_inst, G%HI, haloshift=0, symmetric=sym, scale=US%L_T_to_m_s)
+    call hchksum(h, "Corrector 1 h", G%HI, haloshift=1, scale=GV%H_to_MKS)
+    call uvchksum("Corrector 1 [uv]h", uh, vh, G%HI, haloshift=2, &
+                  symmetric=sym, scale=GV%H_to_MKS*US%L_to_m**2*US%s_to_T)
+  ! call MOM_state_chksum("Corrector 1", u_inst, v_inst, h, uh, vh, G, GV, US, haloshift=1)
+    call MOM_accel_chksum("Corrector accel", CS%CAu, CS%CAv, CS%PFu, CS%PFv, &
+                          CS%diffu, CS%diffv, G, GV, US, CS%pbce, CS%u_accel_bt, CS%v_accel_bt, &
+                          symmetric=sym)
+  endif
+
+  ! u <- u + dt d/dz visc d/dz u
+  ! u_av <- u_av + dt d/dz visc d/dz u_av
+  call cpu_clock_begin(id_clock_vertvisc)
+
+  if (CS%fpmix) then
+    uold(:,:,:) = 0.0
+    vold(:,:,:) = 0.0
+    do k=1,nz ; do j=js,je ; do I=Isq,Ieq
+      uold(I,j,k) = u_inst(I,j,k)
+    enddo ; enddo ; enddo
+    do k=1,nz ; do J=Jsq,Jeq ; do i=is,ie
+      vold(i,J,k) = v_inst(i,J,k)
+    enddo ; enddo ; enddo
+  endif
+
+  call thickness_to_dz(h, tv, dz, G, GV, US, halo_size=1)
+  call vertvisc_coef(u_inst, v_inst, h, dz, forces, visc, tv, dt, G, GV, US, CS%vertvisc_CSp, CS%OBC, VarMix)
+  call vertvisc(u_inst, v_inst, h, forces, visc, dt, CS%OBC, CS%ADp, CS%CDp, G, GV, US, &
+                CS%vertvisc_CSp, CS%taux_bot, CS%tauy_bot,waves=waves)
+
+  if (CS%fpmix) then
+    call vertFPmix(u_inst, v_inst, uold, vold, hbl, h, forces, dt, &
+                   G, GV, US, CS%vertvisc_CSp, CS%OBC)
+    call vertvisc(u_inst, v_inst, h, forces, visc, dt, CS%OBC, CS%ADp, CS%CDp, G, GV, US, &
+                  CS%vertvisc_CSp, CS%taux_bot, CS%tauy_bot, waves=waves)
+  endif
+
+  if (G%nonblocking_updates) then
+    call cpu_clock_end(id_clock_vertvisc)
+    call start_group_pass(CS%pass_uv, G%Domain, clock=id_clock_pass)
+    call cpu_clock_begin(id_clock_vertvisc)
+  endif
+  call vertvisc_remnant(visc, CS%visc_rem_u, CS%visc_rem_v, dt, G, GV, US, CS%vertvisc_CSp)
+  call cpu_clock_end(id_clock_vertvisc)
+  if (showCallTree) call callTree_wayPoint("done with vertvisc (step_MOM_dyn_split_RK2b)")
+
+! Later, h_av = (h_in + h_out)/2, but for now use h_av to store h_in.
+  !$OMP parallel do default(shared)
+  do k=1,nz ; do j=js-2,je+2 ; do i=is-2,ie+2
+    h_av(i,j,k) = h(i,j,k)
+  enddo ; enddo ; enddo
+
+  call do_group_pass(CS%pass_visc_rem, G%Domain, clock=id_clock_pass)
+  if (G%nonblocking_updates) then
+    call complete_group_pass(CS%pass_uv, G%Domain, clock=id_clock_pass)
+  else
+    call do_group_pass(CS%pass_uv, G%Domain, clock=id_clock_pass)
+  endif
+
+  ! uh = u_av * h
+  ! h  = h + dt * div . uh
+  ! u_av and v_av adjusted so their mass transports match uhbt and vhbt.
+  call cpu_clock_begin(id_clock_continuity)
+  call continuity(u_inst, v_inst, h, h, uh, vh, dt, G, GV, US, CS%continuity_CSp, CS%OBC, pbv, &
+                  CS%uhbt, CS%vhbt, CS%visc_rem_u, CS%visc_rem_v, u_av, v_av)
+  call cpu_clock_end(id_clock_continuity)
+  call do_group_pass(CS%pass_h, G%Domain, clock=id_clock_pass)
+  ! Whenever thickness changes let the diag manager know, target grids
+  ! for vertical remapping may need to be regenerated.
+  call diag_update_remap_grids(CS%diag)
+  if (showCallTree) call callTree_wayPoint("done with continuity (step_MOM_dyn_split_RK2b)")
+
+  if (G%nonblocking_updates) then
+    call start_group_pass(CS%pass_av_uvh, G%Domain, clock=id_clock_pass)
+  else
+    call do_group_pass(CS%pass_av_uvh, G%domain, clock=id_clock_pass)
+  endif
+
+  if (associated(CS%OBC)) then
+    call radiation_open_bdry_conds(CS%OBC, u_inst, u_old_rad_OBC, v_inst, v_old_rad_OBC, G, GV, US, dt)
+  endif
+
+! h_av = (h_in + h_out)/2 . Going in to this line, h_av = h_in.
+  !$OMP parallel do default(shared)
+  do k=1,nz ; do j=js-2,je+2 ; do i=is-2,ie+2
+    h_av(i,j,k) = 0.5*(h_av(i,j,k) + h(i,j,k))
+  enddo ; enddo ; enddo
+
+  if (G%nonblocking_updates) &
+    call complete_group_pass(CS%pass_av_uvh, G%Domain, clock=id_clock_pass)
+
+  !$OMP parallel do default(shared)
+  do k=1,nz
+    do j=js-2,je+2 ; do I=Isq-2,Ieq+2
+      uhtr(I,j,k) = uhtr(I,j,k) + uh(I,j,k)*dt
+    enddo ; enddo
+    do J=Jsq-2,Jeq+2 ; do i=is-2,ie+2
+      vhtr(i,J,k) = vhtr(i,J,k) + vh(i,J,k)*dt
+    enddo ; enddo
+  enddo
+
+  if (CS%store_CAu) then
+    ! Calculate a predictor-step estimate of the Coriolis and momentum advection terms
+    ! for use in the next time step, possibly after it has been vertically remapped.
+    call cpu_clock_begin(id_clock_Cor)
+    call disable_averaging(CS%diag)  ! These calculations should not be used for diagnostics.
+    ! CAu = -(f+zeta_av)/h_av vh + d/dx KE_av
+    call CorAdCalc(u_av, v_av, h_av, uh, vh, CS%CAu_pred, CS%CAv_pred, CS%OBC, CS%AD_pred, &
+                   G, GV, US, CS%CoriolisAdv, pbv, Waves=Waves)
+    CS%CAu_pred_stored = .true.
+    call enable_averages(dt, Time_local, CS%diag) ! Reenable the averaging
+    call cpu_clock_end(id_clock_Cor)
+    if (showCallTree) call callTree_wayPoint("done with CorAdCalc (step_MOM_dyn_split_RK2b)")
+  else
+    CS%CAu_pred_stored = .false.
+  endif
+
+  if (CS%fpmix) then
+    if (CS%id_uold > 0) call post_data(CS%id_uold, uold, CS%diag)
+    if (CS%id_vold > 0) call post_data(CS%id_vold, vold, CS%diag)
+  endif
+
+  ! The time-averaged free surface height has already been set by the last call to btstep.
+
+  ! Deallocate this memory to avoid a memory leak. ### We should revisit how this array is declared. -RWH
+  if (dyn_p_surf .and. associated(eta_PF_start)) deallocate(eta_PF_start)
+
+  !  Here various terms used in to update the momentum equations are
+  !  offered for time averaging.
+  if (CS%id_PFu > 0) call post_data(CS%id_PFu, CS%PFu, CS%diag)
+  if (CS%id_PFv > 0) call post_data(CS%id_PFv, CS%PFv, CS%diag)
+  if (CS%id_CAu > 0) call post_data(CS%id_CAu, CS%CAu, CS%diag)
+  if (CS%id_CAv > 0) call post_data(CS%id_CAv, CS%CAv, CS%diag)
+
+  ! Here the thickness fluxes are offered for time averaging.
+  if (CS%id_uh         > 0) call post_data(CS%id_uh,  uh,                   CS%diag)
+  if (CS%id_vh         > 0) call post_data(CS%id_vh,  vh,                   CS%diag)
+  if (CS%id_uav        > 0) call post_data(CS%id_uav, u_av,                 CS%diag)
+  if (CS%id_vav        > 0) call post_data(CS%id_vav, v_av,                 CS%diag)
+  if (CS%id_u_BT_accel > 0) call post_data(CS%id_u_BT_accel, CS%u_accel_bt, CS%diag)
+  if (CS%id_v_BT_accel > 0) call post_data(CS%id_v_BT_accel, CS%v_accel_bt, CS%diag)
+
+  ! Calculate effective areas and post data
+  if (CS%id_ueffA > 0) then
+    ueffA(:,:,:) = 0
+    do k=1,nz ; do j=js,je ; do I=Isq,Ieq
+      if (abs(up(I,j,k)) > 0.) ueffA(I,j,k) = uh(I,j,k) / up(I,j,k)
+    enddo ; enddo ; enddo
+    call post_data(CS%id_ueffA, ueffA, CS%diag)
+  endif
+
+  if (CS%id_veffA > 0) then
+    veffA(:,:,:) = 0
+    do k=1,nz ; do J=Jsq,Jeq ; do i=is,ie
+      if (abs(vp(i,J,k)) > 0.) veffA(i,J,k) = vh(i,J,k) / vp(i,J,k)
+    enddo ; enddo ; enddo
+    call post_data(CS%id_veffA, veffA, CS%diag)
+  endif
+
+  ! Diagnostics of the fractional thicknesses times momentum budget terms
+  ! 3D diagnostics hf_PFu etc. are commented because there is no clarity on proper remapping grid option.
+  ! The code is retained for debugging purposes in the future.
+  !if (CS%id_hf_PFu > 0) call post_product_u(CS%id_hf_PFu, CS%PFu, CS%ADp%diag_hfrac_u, G, nz, CS%diag)
+  !if (CS%id_hf_PFv > 0) call post_product_v(CS%id_hf_PFv, CS%PFv, CS%ADp%diag_hfrac_v, G, nz, CS%diag)
+  !if (CS%id_hf_CAu > 0) call post_product_u(CS%id_hf_CAu, CS%CAu, CS%ADp%diag_hfrac_u, G, nz, CS%diag)
+  !if (CS%id_hf_CAv > 0) call post_product_v(CS%id_hf_CAv, CS%CAv, CS%ADp%diag_hfrac_v, G, nz, CS%diag)
+  !if (CS%id_hf_u_BT_accel > 0) &
+  !  call post_product_u(CS%id_hf_u_BT_accel, CS%u_accel_bt, CS%ADp%diag_hfrac_u, G, nz, CS%diag)
+  !if (CS%id_hf_v_BT_accel > 0) &
+  !  call post_product_v(CS%id_hf_v_BT_accel, CS%v_accel_bt, CS%ADp%diag_hfrac_v, G, nz, CS%diag)
+
+  ! Diagnostics for the vertical sum of layer thickness x prssure force accelerations
+  if (CS%id_intz_PFu_2d > 0) call post_product_sum_u(CS%id_intz_PFu_2d, CS%PFu, CS%ADp%diag_hu, G, nz, CS%diag)
+  if (CS%id_intz_PFv_2d > 0) call post_product_sum_v(CS%id_intz_PFv_2d, CS%PFv, CS%ADp%diag_hv, G, nz, CS%diag)
+
+  ! Diagnostics for thickness-weighted vertically averaged prssure force accelerations
+  if (CS%id_hf_PFu_2d > 0) call post_product_sum_u(CS%id_hf_PFu_2d, CS%PFu, CS%ADp%diag_hfrac_u, G, nz, CS%diag)
+  if (CS%id_hf_PFv_2d > 0) call post_product_sum_v(CS%id_hf_PFv_2d, CS%PFv, CS%ADp%diag_hfrac_v, G, nz, CS%diag)
+
+  ! Diagnostics for thickness x prssure force accelerations
+  if (CS%id_h_PFu > 0) call post_product_u(CS%id_h_PFu, CS%PFu, CS%ADp%diag_hu, G, nz, CS%diag)
+  if (CS%id_h_PFv > 0) call post_product_v(CS%id_h_PFv, CS%PFv, CS%ADp%diag_hv, G, nz, CS%diag)
+
+  ! Diagnostics of Coriolis acceleratations
+  if (CS%id_intz_CAu_2d > 0) call post_product_sum_u(CS%id_intz_CAu_2d, CS%CAu, CS%ADp%diag_hu, G, nz, CS%diag)
+  if (CS%id_intz_CAv_2d > 0) call post_product_sum_v(CS%id_intz_CAv_2d, CS%CAv, CS%ADp%diag_hv, G, nz, CS%diag)
+  if (CS%id_hf_CAu_2d > 0) call post_product_sum_u(CS%id_hf_CAu_2d, CS%CAu, CS%ADp%diag_hfrac_u, G, nz, CS%diag)
+  if (CS%id_hf_CAv_2d > 0) call post_product_sum_v(CS%id_hf_CAv_2d, CS%CAv, CS%ADp%diag_hfrac_v, G, nz, CS%diag)
+  if (CS%id_h_CAu > 0) call post_product_u(CS%id_h_CAu, CS%CAu, CS%ADp%diag_hu, G, nz, CS%diag)
+  if (CS%id_h_CAv > 0) call post_product_v(CS%id_h_CAv, CS%CAv, CS%ADp%diag_hv, G, nz, CS%diag)
+
+  ! Diagnostics of barotropic solver acceleratations
+  if (CS%id_intz_u_BT_accel_2d > 0) &
+    call post_product_sum_u(CS%id_intz_u_BT_accel_2d, CS%u_accel_bt, CS%ADp%diag_hu, G, nz, CS%diag)
+  if (CS%id_intz_v_BT_accel_2d > 0) &
+    call post_product_sum_v(CS%id_intz_v_BT_accel_2d, CS%v_accel_bt, CS%ADp%diag_hv, G, nz, CS%diag)
+  if (CS%id_hf_u_BT_accel_2d > 0) &
+    call post_product_sum_u(CS%id_hf_u_BT_accel_2d, CS%u_accel_bt, CS%ADp%diag_hfrac_u, G, nz, CS%diag)
+  if (CS%id_hf_v_BT_accel_2d > 0) &
+    call post_product_sum_v(CS%id_hf_v_BT_accel_2d, CS%v_accel_bt, CS%ADp%diag_hfrac_v, G, nz, CS%diag)
+  if (CS%id_h_u_BT_accel > 0) &
+    call post_product_u(CS%id_h_u_BT_accel, CS%u_accel_bt, CS%ADp%diag_hu, G, nz, CS%diag)
+  if (CS%id_h_v_BT_accel > 0) &
+    call post_product_v(CS%id_h_v_BT_accel, CS%v_accel_bt, CS%ADp%diag_hv, G, nz, CS%diag)
+
+  ! Diagnostics for momentum budget terms multiplied by visc_rem_[uv],
+  if (CS%id_PFu_visc_rem > 0) call post_product_u(CS%id_PFu_visc_rem, CS%PFu, CS%ADp%visc_rem_u, G, nz, CS%diag)
+  if (CS%id_PFv_visc_rem > 0) call post_product_v(CS%id_PFv_visc_rem, CS%PFv, CS%ADp%visc_rem_v, G, nz, CS%diag)
+  if (CS%id_CAu_visc_rem > 0) call post_product_u(CS%id_CAu_visc_rem, CS%CAu, CS%ADp%visc_rem_u, G, nz, CS%diag)
+  if (CS%id_CAv_visc_rem > 0) call post_product_v(CS%id_CAv_visc_rem, CS%CAv, CS%ADp%visc_rem_v, G, nz, CS%diag)
+  if (CS%id_u_BT_accel_visc_rem > 0) &
+    call post_product_u(CS%id_u_BT_accel_visc_rem, CS%u_accel_bt, CS%ADp%visc_rem_u, G, nz, CS%diag)
+  if (CS%id_v_BT_accel_visc_rem > 0) &
+    call post_product_v(CS%id_v_BT_accel_visc_rem, CS%v_accel_bt, CS%ADp%visc_rem_v, G, nz, CS%diag)
+
+  ! Diagnostics related to changes in eta
+  if (CS%id_deta_dt > 0) call post_data(CS%id_deta_dt, deta_dt, CS%diag)
+
+  if (CS%debug) then
+    call MOM_state_chksum("Corrector ", u_inst, v_inst, h, uh, vh, G, GV, US, symmetric=sym)
+    call uvchksum("Corrector avg [uv]", u_av, v_av, G%HI, haloshift=1, symmetric=sym, scale=US%L_T_to_m_s)
+    call hchksum(h_av, "Corrector avg h", G%HI, haloshift=1, scale=GV%H_to_MKS)
+ !  call MOM_state_chksum("Corrector avg ", u_av, v_av, h_av, uh, vh, G, GV, US)
+  endif
+
+  if (showCallTree) call callTree_leave("step_MOM_dyn_split_RK2b()")
+
+end subroutine step_MOM_dyn_split_RK2b
+
+!> This subroutine sets up any auxiliary restart variables that are specific
+!! to the split-explicit time stepping scheme.  All variables registered here should
+!! have the ability to be recreated if they are not present in a restart file.
+subroutine register_restarts_dyn_split_RK2b(HI, GV, US, param_file, CS, restart_CS, uh, vh)
+  type(hor_index_type),          intent(in)    :: HI         !< Horizontal index structure
+  type(verticalGrid_type),       intent(in)    :: GV         !< ocean vertical grid structure
+  type(unit_scale_type),         intent(in)    :: US         !< A dimensional unit scaling type
+  type(param_file_type),         intent(in)    :: param_file !< parameter file
+  type(MOM_dyn_split_RK2b_CS),   pointer       :: CS         !< module control structure
+  type(MOM_restart_CS),          intent(inout) :: restart_CS !< MOM restart control structure
+  real, dimension(SZIB_(HI),SZJ_(HI),SZK_(GV)), &
+                         target, intent(inout) :: uh !< zonal volume or mass transport [H L2 T-1 ~> m3 s-1 or kg s-1]
+  real, dimension(SZI_(HI),SZJB_(HI),SZK_(GV)), &
+                         target, intent(inout) :: vh !< merid volume or mass transport [H L2 T-1 ~> m3 s-1 or kg s-1]
+
+  character(len=40) :: mdl = "MOM_dynamics_split_RK2b" ! This module's name.
+  type(vardesc)     :: vd(2)
+  character(len=48) :: thickness_units, flux_units
+
+  integer :: isd, ied, jsd, jed, nz, IsdB, IedB, JsdB, JedB
+
+  isd  = HI%isd  ; ied  = HI%ied  ; jsd  = HI%jsd  ; jed  = HI%jed ; nz = GV%ke
+  IsdB = HI%IsdB ; IedB = HI%IedB ; JsdB = HI%JsdB ; JedB = HI%JedB
+
+  ! This is where a control structure specific to this module would be allocated.
+  if (associated(CS)) then
+    call MOM_error(WARNING, "register_restarts_dyn_split_RK2b called with an associated "// &
+                             "control structure.")
+    return
+  endif
+  allocate(CS)
+
+  ALLOC_(CS%diffu(IsdB:IedB,jsd:jed,nz)) ; CS%diffu(:,:,:) = 0.0
+  ALLOC_(CS%diffv(isd:ied,JsdB:JedB,nz)) ; CS%diffv(:,:,:) = 0.0
+  ALLOC_(CS%CAu(IsdB:IedB,jsd:jed,nz))   ; CS%CAu(:,:,:)   = 0.0
+  ALLOC_(CS%CAv(isd:ied,JsdB:JedB,nz))   ; CS%CAv(:,:,:)   = 0.0
+  ALLOC_(CS%CAu_pred(IsdB:IedB,jsd:jed,nz)) ; CS%CAu_pred(:,:,:)   = 0.0
+  ALLOC_(CS%CAv_pred(isd:ied,JsdB:JedB,nz)) ; CS%CAv_pred(:,:,:)   = 0.0
+  ALLOC_(CS%PFu(IsdB:IedB,jsd:jed,nz))   ; CS%PFu(:,:,:)   = 0.0
+  ALLOC_(CS%PFv(isd:ied,JsdB:JedB,nz))   ; CS%PFv(:,:,:)   = 0.0
+
+  ALLOC_(CS%eta(isd:ied,jsd:jed))       ; CS%eta(:,:)    = 0.0
+  ALLOC_(CS%u_av(IsdB:IedB,jsd:jed,nz)) ; CS%u_av(:,:,:) = 0.0
+  ALLOC_(CS%v_av(isd:ied,JsdB:JedB,nz)) ; CS%v_av(:,:,:) = 0.0
+  ALLOC_(CS%h_av(isd:ied,jsd:jed,nz))   ; CS%h_av(:,:,:) = GV%Angstrom_H
+
+  thickness_units = get_thickness_units(GV)
+  flux_units = get_flux_units(GV)
+
+  call get_param(param_file, mdl, "STORE_CORIOLIS_ACCEL", CS%store_CAu, &
+                 "If true, calculate the Coriolis accelerations at the end of each "//&
+                 "timestep for use in the predictor step of the next split RK2 timestep.", &
+                 default=.true., do_not_log=.true.)
+
+  if (GV%Boussinesq) then
+    call register_restart_field(CS%eta, "sfc", .false., restart_CS, &
+             longname="Free surface Height", units=thickness_units, conversion=GV%H_to_mks)
+  else
+    call register_restart_field(CS%eta, "p_bot", .false., restart_CS, &
+             longname="Bottom Pressure", units=thickness_units, conversion=GV%H_to_mks)
+  endif
+
+  ! These are needed, either to calculate CAu and CAv or to calculate the velocity anomalies in
+  ! the barotropic solver's Coriolis terms.
+  vd(1) = var_desc("u2", "m s-1", "Auxiliary Zonal velocity", 'u', 'L')
+  vd(2) = var_desc("v2", "m s-1", "Auxiliary Meridional velocity", 'v', 'L')
+  call register_restart_pair(CS%u_av, CS%v_av, vd(1), vd(2), .false., restart_CS, &
+                             conversion=US%L_T_to_m_s)
+
+  if (CS%store_CAu) then
+    vd(1) = var_desc("CAu", "m s-2", "Zonal Coriolis and advactive acceleration", 'u', 'L')
+    vd(2) = var_desc("CAv", "m s-2", "Meridional Coriolis and advactive  acceleration", 'v', 'L')
+    call register_restart_pair(CS%CAu_pred, CS%CAv_pred, vd(1), vd(2), .false., restart_CS, &
+                               conversion=US%L_T2_to_m_s2)
+  else
+    call register_restart_field(CS%h_av, "h2", .false., restart_CS, &
+           longname="Auxiliary Layer Thickness", units=thickness_units, conversion=GV%H_to_mks)
+
+    vd(1) = var_desc("uh", flux_units, "Zonal thickness flux", 'u', 'L')
+    vd(2) = var_desc("vh", flux_units, "Meridional thickness flux", 'v', 'L')
+    call register_restart_pair(uh, vh, vd(1), vd(2), .false., restart_CS, &
+                               conversion=GV%H_to_MKS*US%L_to_m**2*US%s_to_T)
+  endif
+
+  vd(1) = var_desc("diffu", "m s-2", "Zonal horizontal viscous acceleration", 'u', 'L')
+  vd(2) = var_desc("diffv", "m s-2", "Meridional horizontal viscous acceleration", 'v', 'L')
+  call register_restart_pair(CS%diffu, CS%diffv, vd(1), vd(2), .false., restart_CS, &
+                             conversion=US%L_T2_to_m_s2)
+
+  call register_barotropic_restarts(HI, GV, US, param_file, CS%barotropic_CSp, restart_CS)
+
+end subroutine register_restarts_dyn_split_RK2b
+
+!> This subroutine does remapping for the auxiliary restart variables that are used
+!! with the split RK2 time stepping scheme.
+subroutine remap_dyn_split_RK2b_aux_vars(G, GV, CS, h_old_u, h_old_v, h_new_u, h_new_v, ALE_CSp)
+  type(ocean_grid_type),            intent(inout) :: G        !< ocean grid structure
+  type(verticalGrid_type),          intent(in)    :: GV       !< ocean vertical grid structure
+  type(MOM_dyn_split_RK2b_CS),      pointer       :: CS       !< module control structure
+  real, dimension(SZIB_(G),SZJ_(G),SZK_(GV)), &
+                                    intent(in)    :: h_old_u  !< Source grid thickness at zonal
+                                                              !! velocity points [H ~> m or kg m-2]
+  real, dimension(SZI_(G),SZJB_(G),SZK_(GV)), &
+                                    intent(in)    :: h_old_v  !< Source grid thickness at meridional
+                                                              !! velocity points [H ~> m or kg m-2]
+  real, dimension(SZIB_(G),SZJ_(G),SZK_(GV)), &
+                                    intent(in)    :: h_new_u  !< Destination grid thickness at zonal
+                                                              !! velocity points [H ~> m or kg m-2]
+  real, dimension(SZI_(G),SZJB_(G),SZK_(GV)), &
+                                    intent(in)    :: h_new_v  !< Destination grid thickness at meridional
+                                                              !! velocity points [H ~> m or kg m-2]
+  type(ALE_CS),                     pointer       :: ALE_CSp  !< ALE control structure to use when remapping
+
+  if (.not.CS%remap_aux) return
+
+  if (CS%store_CAu) then
+    call ALE_remap_velocities(ALE_CSp, G, GV, h_old_u, h_old_v, h_new_u, h_new_v, CS%u_av, CS%v_av)
+    call pass_vector(CS%u_av, CS%v_av, G%Domain, complete=.false.)
+    call ALE_remap_velocities(ALE_CSp, G, GV, h_old_u, h_old_v, h_new_u, h_new_v, CS%CAu_pred, CS%CAv_pred)
+    call pass_vector(CS%CAu_pred, CS%CAv_pred, G%Domain, complete=.true.)
+  endif
+
+  call ALE_remap_velocities(ALE_CSp, G, GV, h_old_u, h_old_v, h_new_u, h_new_v, CS%diffu, CS%diffv)
+
+end subroutine remap_dyn_split_RK2b_aux_vars
+
+!> This subroutine initializes all of the variables that are used by this
+!! dynamic core, including diagnostics and the cpu clocks.
+subroutine initialize_dyn_split_RK2b(u, v, h, uh, vh, eta, Time, G, GV, US, param_file, &
+                      diag, CS, restart_CS, dt, Accel_diag, Cont_diag, MIS, &
+                      VarMix, MEKE, thickness_diffuse_CSp,                  &
+                      OBC, update_OBC_CSp, ALE_CSp, set_visc, &
+                      visc, dirs, ntrunc, pbv, calc_dtbt, cont_stencil)
+  type(ocean_grid_type),            intent(inout) :: G          !< ocean grid structure
+  type(verticalGrid_type),          intent(in)    :: GV         !< ocean vertical grid structure
+  type(unit_scale_type),            intent(in)    :: US         !< A dimensional unit scaling type
+  real, dimension(SZIB_(G),SZJ_(G),SZK_(GV)), &
+                                    intent(inout) :: u          !< zonal velocity [L T-1 ~> m s-1]
+  real, dimension(SZI_(G),SZJB_(G),SZK_(GV)), &
+                                    intent(inout) :: v          !< merid velocity [L T-1 ~> m s-1]
+  real, dimension(SZI_(G),SZJ_(G),SZK_(GV)),  &
+                                    intent(inout) :: h          !< layer thickness [H ~> m or kg m-2]
+  real, dimension(SZIB_(G),SZJ_(G),SZK_(GV)), &
+                            target, intent(inout) :: uh    !< zonal volume/mass transport [H L2 T-1 ~> m3 s-1 or kg s-1]
+  real, dimension(SZI_(G),SZJB_(G),SZK_(GV)), &
+                            target, intent(inout) :: vh    !< merid volume/mass transport [H L2 T-1 ~> m3 s-1 or kg s-1]
+  real, dimension(SZI_(G),SZJ_(G)), intent(inout) :: eta        !< free surface height or column mass [H ~> m or kg m-2]
+  type(time_type),          target, intent(in)    :: Time       !< current model time
+  type(param_file_type),            intent(in)    :: param_file !< parameter file for parsing
+  type(diag_ctrl),          target, intent(inout) :: diag       !< to control diagnostics
+  type(MOM_dyn_split_RK2b_CS),      pointer       :: CS         !< module control structure
+  type(MOM_restart_CS),             intent(inout) :: restart_CS !< MOM restart control structure
+  real,                             intent(in)    :: dt         !< time step [T ~> s]
+  type(accel_diag_ptrs),    target, intent(inout) :: Accel_diag !< points to momentum equation terms for
+                                                                !! budget analysis
+  type(cont_diag_ptrs),     target, intent(inout) :: Cont_diag  !< points to terms in continuity equation
+  type(ocean_internal_state),       intent(inout) :: MIS        !< "MOM6 internal state" used to pass
+                                                                !! diagnostic pointers
+  type(VarMix_CS),                  intent(inout) :: VarMix     !< points to spatially variable viscosities
+  type(MEKE_type),                  intent(inout) :: MEKE       !< MEKE fields
+  type(thickness_diffuse_CS),       intent(inout) :: thickness_diffuse_CSp !< Pointer to the control structure
+                                                                !! used for the isopycnal height diffusive transport.
+  type(ocean_OBC_type),             pointer       :: OBC        !< points to OBC related fields
+  type(update_OBC_CS),              pointer       :: update_OBC_CSp !< points to OBC update related fields
+  type(ALE_CS),                     pointer       :: ALE_CSp    !< points to ALE control structure
+  type(set_visc_CS),        target, intent(in)    :: set_visc   !< set_visc control structure
+  type(vertvisc_type),              intent(inout) :: visc       !< vertical viscosities, bottom drag, and related
+  type(directories),                intent(in)    :: dirs       !< contains directory paths
+  integer, target,                  intent(inout) :: ntrunc     !< A target for the variable that records
+                                                                !! the number of times the velocity is
+                                                                !! truncated (this should be 0).
+  logical,                          intent(out)   :: calc_dtbt  !< If true, recalculate the barotropic time step
+  type(porous_barrier_type),        intent(in)    :: pbv        !< porous barrier fractional cell metrics
+  integer,                          intent(out)   :: cont_stencil !< The stencil for thickness
+                                                                !! from the continuity solver.
+
+  ! local variables
+  real, dimension(SZI_(G),SZJ_(G),SZK_(GV)) :: h_tmp ! A temporary copy of the layer thicknesses [H ~> m or kg m-2]
+  character(len=40) :: mdl = "MOM_dynamics_split_RK2b" ! This module's name.
+  ! This include declares and sets the variable "version".
+# include "version_variable.h"
+  character(len=48) :: thickness_units, flux_units, eta_rest_name
+  type(group_pass_type) :: pass_av_h_uvh
+  logical :: debug_truncations
+  logical :: read_uv, read_h2
+
+  integer :: i, j, k, is, ie, js, je, isd, ied, jsd, jed, nz
+  integer :: IsdB, IedB, JsdB, JedB
+  is   = G%isc  ; ie   = G%iec  ; js   = G%jsc  ; je   = G%jec ; nz = GV%ke
+  isd  = G%isd  ; ied  = G%ied  ; jsd  = G%jsd  ; jed  = G%jed
+  IsdB = G%IsdB ; IedB = G%IedB ; JsdB = G%JsdB ; JedB = G%JedB
+
+  if (.not.associated(CS)) call MOM_error(FATAL, &
+      "initialize_dyn_split_RK2b called with an unassociated control structure.")
+  if (CS%module_is_initialized) then
+    call MOM_error(WARNING, "initialize_dyn_split_RK2b called with a control "// &
+                            "structure that has already been initialized.")
+    return
+  endif
+  CS%module_is_initialized = .true.
+
+  CS%diag => diag
+
+  call log_version(param_file, mdl, version, "")
+  call get_param(param_file, mdl, "TIDES", CS%use_tides, &
+                 "If true, apply tidal momentum forcing.", default=.false.)
+  call get_param(param_file, mdl, "CALCULATE_SAL", CS%calculate_SAL, &
+                 "If true, calculate self-attraction and loading.", default=CS%use_tides)
+  call get_param(param_file, mdl, "BE", CS%be, &
+                 "If SPLIT is true, BE determines the relative weighting "//&
+                 "of a  2nd-order Runga-Kutta baroclinic time stepping "//&
+                 "scheme (0.5) and a backward Euler scheme (1) that is "//&
+                 "used for the Coriolis and inertial terms.  BE may be "//&
+                 "from 0.5 to 1, but instability may occur near 0.5. "//&
+                 "BE is also applicable if SPLIT is false and USE_RK2 "//&
+                 "is true.", units="nondim", default=0.6)
+  call get_param(param_file, mdl, "BEGW", CS%begw, &
+                 "If SPLIT is true, BEGW is a number from 0 to 1 that "//&
+                 "controls the extent to which the treatment of gravity "//&
+                 "waves is forward-backward (0) or simulated backward "//&
+                 "Euler (1).  0 is almost always used. "//&
+                 "If SPLIT is false and USE_RK2 is true, BEGW can be "//&
+                 "between 0 and 0.5 to damp gravity waves.", &
+                 units="nondim", default=0.0)
+
+  call get_param(param_file, mdl, "SPLIT_BOTTOM_STRESS", CS%split_bottom_stress, &
+                 "If true, provide the bottom stress calculated by the "//&
+                 "vertical viscosity to the barotropic solver.", default=.false.)
+  call get_param(param_file, mdl, "STORE_CORIOLIS_ACCEL", CS%store_CAu, &
+                 "If true, calculate the Coriolis accelerations at the end of each "//&
+                 "timestep for use in the predictor step of the next split RK2 timestep.", &
+                 default=.true.)
+  call get_param(param_file, mdl, "FPMIX", CS%fpmix, &
+                 "If true, apply profiles of momentum flux magnitude and direction.", &
+                 default=.false.)
+  call get_param(param_file, mdl, "REMAP_AUXILIARY_VARS", CS%remap_aux, &
+                 "If true, apply ALE remapping to all of the auxiliary 3-dimensional "//&
+                 "variables that are needed to reproduce across restarts, similarly to "//&
+                 "what is already being done with the primary state variables.  "//&
+                 "The default should be changed to true.", default=.false., do_not_log=.true.)
+  if (CS%remap_aux .and. .not.CS%store_CAu) call MOM_error(FATAL, &
+      "REMAP_AUXILIARY_VARS requires that STORE_CORIOLIS_ACCEL = True.")
+  call get_param(param_file, mdl, "DEBUG", CS%debug, &
+                 "If true, write out verbose debugging data.", &
+                 default=.false., debuggingParam=.true.)
+  call get_param(param_file, mdl, "DEBUG_OBC", CS%debug_OBC, default=.false.)
+  call get_param(param_file, mdl, "DEBUG_TRUNCATIONS", debug_truncations, &
+                 default=.false.)
+
+  allocate(CS%taux_bot(IsdB:IedB,jsd:jed), source=0.0)
+  allocate(CS%tauy_bot(isd:ied,JsdB:JedB), source=0.0)
+
+  ALLOC_(CS%uhbt(IsdB:IedB,jsd:jed))          ; CS%uhbt(:,:)         = 0.0
+  ALLOC_(CS%vhbt(isd:ied,JsdB:JedB))          ; CS%vhbt(:,:)         = 0.0
+  ALLOC_(CS%visc_rem_u(IsdB:IedB,jsd:jed,nz)) ; CS%visc_rem_u(:,:,:) = 0.0
+  ALLOC_(CS%visc_rem_v(isd:ied,JsdB:JedB,nz)) ; CS%visc_rem_v(:,:,:) = 0.0
+  ALLOC_(CS%eta_PF(isd:ied,jsd:jed))          ; CS%eta_PF(:,:)       = 0.0
+  ALLOC_(CS%pbce(isd:ied,jsd:jed,nz))         ; CS%pbce(:,:,:)       = 0.0
+
+  ALLOC_(CS%u_accel_bt(IsdB:IedB,jsd:jed,nz)) ; CS%u_accel_bt(:,:,:) = 0.0
+  ALLOC_(CS%v_accel_bt(isd:ied,JsdB:JedB,nz)) ; CS%v_accel_bt(:,:,:) = 0.0
+  ALLOC_(CS%PFu_Stokes(IsdB:IedB,jsd:jed,nz)) ; CS%PFu_Stokes(:,:,:) = 0.0
+  ALLOC_(CS%PFv_Stokes(isd:ied,JsdB:JedB,nz)) ; CS%PFv_Stokes(:,:,:) = 0.0
+
+  MIS%diffu      => CS%diffu
+  MIS%diffv      => CS%diffv
+  MIS%PFu        => CS%PFu
+  MIS%PFv        => CS%PFv
+  MIS%CAu        => CS%CAu
+  MIS%CAv        => CS%CAv
+  MIS%pbce       => CS%pbce
+  MIS%u_accel_bt => CS%u_accel_bt
+  MIS%v_accel_bt => CS%v_accel_bt
+  MIS%u_av       => CS%u_av
+  MIS%v_av       => CS%v_av
+
+  CS%ADp           => Accel_diag
+  CS%CDp           => Cont_diag
+  Accel_diag%diffu => CS%diffu
+  Accel_diag%diffv => CS%diffv
+  Accel_diag%PFu   => CS%PFu
+  Accel_diag%PFv   => CS%PFv
+  Accel_diag%CAu   => CS%CAu
+  Accel_diag%CAv   => CS%CAv
+  Accel_diag%u_accel_bt => CS%u_accel_bt
+  Accel_diag%v_accel_bt => CS%v_accel_bt
+
+  allocate(CS%AD_pred)
+  CS%AD_pred%diffu => CS%diffu
+  CS%AD_pred%diffv => CS%diffv
+  CS%AD_pred%PFu   => CS%PFu
+  CS%AD_pred%PFv   => CS%PFv
+  CS%AD_pred%CAu   => CS%CAu_pred
+  CS%AD_pred%CAv   => CS%CAv_pred
+  CS%AD_pred%u_accel_bt => CS%u_accel_bt
+  CS%AD_pred%v_accel_bt => CS%v_accel_bt
+
+!  Accel_diag%pbce => CS%pbce
+!  Accel_diag%u_accel_bt => CS%u_accel_bt ; Accel_diag%v_accel_bt => CS%v_accel_bt
+!  Accel_diag%u_av => CS%u_av ; Accel_diag%v_av => CS%v_av
+
+  id_clock_pass_init = cpu_clock_id('(Ocean init message passing)', &
+                                     grain=CLOCK_ROUTINE)
+
+  call continuity_init(Time, G, GV, US, param_file, diag, CS%continuity_CSp)
+  cont_stencil = continuity_stencil(CS%continuity_CSp)
+  call CoriolisAdv_init(Time, G, GV, US, param_file, diag, CS%ADp, CS%CoriolisAdv)
+  if (CS%calculate_SAL) call SAL_init(G, US, param_file, CS%SAL_CSp)
+  if (CS%use_tides) call tidal_forcing_init(Time, G, US, param_file, CS%tides_CSp)
+  call PressureForce_init(Time, G, GV, US, param_file, diag, CS%PressureForce_CSp, &
+                          CS%SAL_CSp, CS%tides_CSp)
+  call hor_visc_init(Time, G, GV, US, param_file, diag, CS%hor_visc, ADp=CS%ADp)
+  call vertvisc_init(MIS, Time, G, GV, US, param_file, diag, CS%ADp, dirs, &
+                     ntrunc, CS%vertvisc_CSp)
+  CS%set_visc_CSp => set_visc
+  call updateCFLtruncationValue(Time, CS%vertvisc_CSp, US, &
+                                activate=is_new_run(restart_CS) )
+
+  if (associated(ALE_CSp)) CS%ALE_CSp => ALE_CSp
+  if (associated(OBC)) then
+    CS%OBC => OBC
+    if (OBC%ramp) call update_OBC_ramp(Time, CS%OBC, US, &
+                                activate=is_new_run(restart_CS) )
+  endif
+  if (associated(update_OBC_CSp)) CS%update_OBC_CSp => update_OBC_CSp
+
+  eta_rest_name = "sfc" ; if (.not.GV%Boussinesq) eta_rest_name = "p_bot"
+  if (.not. query_initialized(CS%eta, trim(eta_rest_name), restart_CS)) then
+    ! Estimate eta based on the layer thicknesses - h.  With the Boussinesq
+    ! approximation, eta is the free surface height anomaly, while without it
+    ! eta is the mass of ocean per unit area.  eta always has the same
+    ! dimensions as h, either m or kg m-3.
+    !   CS%eta(:,:) = 0.0 already from initialization.
+    if (GV%Boussinesq) then
+      do j=js,je ; do i=is,ie ; CS%eta(i,j) = -GV%Z_to_H * G%bathyT(i,j) ; enddo ; enddo
+    endif
+    do k=1,nz ; do j=js,je ; do i=is,ie
+      CS%eta(i,j) = CS%eta(i,j) + h(i,j,k)
+    enddo ; enddo ; enddo
+    call set_initialized(CS%eta, trim(eta_rest_name), restart_CS)
+  endif
+  ! Copy eta into an output array.
+  do j=js,je ; do i=is,ie ; eta(i,j) = CS%eta(i,j) ; enddo ; enddo
+
+  call barotropic_init(u, v, h, CS%eta, Time, G, GV, US, param_file, diag, &
+                       CS%barotropic_CSp, restart_CS, calc_dtbt, CS%BT_cont, &
+                       CS%SAL_CSp)
+
+  if (.not. query_initialized(CS%diffu, "diffu", restart_CS) .or. &
+      .not. query_initialized(CS%diffv, "diffv", restart_CS)) then
+    call horizontal_viscosity(u, v, h, CS%diffu, CS%diffv, MEKE, VarMix, G, GV, US, CS%hor_visc, &
+                              OBC=CS%OBC, BT=CS%barotropic_CSp, TD=thickness_diffuse_CSp)
+    call set_initialized(CS%diffu, "diffu", restart_CS)
+    call set_initialized(CS%diffv, "diffv", restart_CS)
+  endif
+
+  if (.not. query_initialized(CS%u_av, "u2", restart_CS) .or. &
+      .not. query_initialized(CS%v_av, "v2", restart_CS)) then
+    do k=1,nz ; do j=jsd,jed ; do I=IsdB,IedB ; CS%u_av(I,j,k) = u(I,j,k) ; enddo ; enddo ; enddo
+    do k=1,nz ; do J=JsdB,JedB ; do i=isd,ied ; CS%v_av(i,J,k) = v(i,J,k) ; enddo ; enddo ; enddo
+    call set_initialized(CS%u_av, "u2", restart_CS)
+    call set_initialized(CS%v_av, "v2", restart_CS)
+  endif
+
+  if (CS%store_CAu) then
+    if (query_initialized(CS%CAu_pred, "CAu", restart_CS) .and. &
+        query_initialized(CS%CAv_pred, "CAv", restart_CS)) then
+      CS%CAu_pred_stored = .true.
+    else
+      call only_read_from_restarts(uh, vh, 'uh', 'vh', G, restart_CS, stagger=CGRID_NE, &
+                   filename=dirs%input_filename, directory=dirs%restart_input_dir, &
+                   success=read_uv, scale=US%m_to_L**2*US%T_to_s/GV%H_to_mks)
+      call only_read_from_restarts('h2', CS%h_av, G, restart_CS, &
+                   filename=dirs%input_filename, directory=dirs%restart_input_dir, &
+                   success=read_h2, scale=1.0/GV%H_to_mks)
+      if (read_uv .and. read_h2) then
+        call pass_var(CS%h_av, G%Domain, clock=id_clock_pass_init)
+      else
+        do k=1,nz ; do j=jsd,jed ; do i=isd,ied ; h_tmp(i,j,k) = h(i,j,k) ; enddo ; enddo ; enddo
+        call continuity(CS%u_av, CS%v_av, h, h_tmp, uh, vh, dt, G, GV, US, CS%continuity_CSp, CS%OBC, pbv)
+        call pass_var(h_tmp, G%Domain, clock=id_clock_pass_init)
+        do k=1,nz ; do j=jsd,jed ; do i=isd,ied
+          CS%h_av(i,j,k) = 0.5*(h(i,j,k) + h_tmp(i,j,k))
+        enddo ; enddo ; enddo
+      endif
+      call pass_vector(CS%u_av, CS%v_av, G%Domain, halo=2, clock=id_clock_pass_init, complete=.false.)
+      call pass_vector(uh, vh, G%Domain, halo=2, clock=id_clock_pass_init, complete=.true.)
+      call CorAdCalc(CS%u_av, CS%v_av, CS%h_av, uh, vh, CS%CAu_pred, CS%CAv_pred, CS%OBC, CS%ADp, &
+                     G, GV, US, CS%CoriolisAdv, pbv) !, Waves=Waves)
+      CS%CAu_pred_stored = .true.
+    endif
+  else
+    CS%CAu_pred_stored = .false.
+    ! This call is just here to initialize uh and vh.
+    if (.not. query_initialized(uh, "uh", restart_CS) .or. &
+        .not. query_initialized(vh, "vh", restart_CS)) then
+      do k=1,nz ; do j=jsd,jed ; do i=isd,ied ; h_tmp(i,j,k) = h(i,j,k) ; enddo ; enddo ; enddo
+      call continuity(u, v, h, h_tmp, uh, vh, dt, G, GV, US, CS%continuity_CSp, CS%OBC, pbv)
+      call pass_var(h_tmp, G%Domain, clock=id_clock_pass_init)
+      do k=1,nz ; do j=jsd,jed ; do i=isd,ied
+        CS%h_av(i,j,k) = 0.5*(h(i,j,k) + h_tmp(i,j,k))
+      enddo ; enddo ; enddo
+      call set_initialized(uh, "uh", restart_CS)
+      call set_initialized(vh, "vh", restart_CS)
+      call set_initialized(CS%h_av, "h2", restart_CS)
+      ! Try reading the CAu and CAv fields from the restart file, in case this restart file is
+      ! using a newer format.
+      call only_read_from_restarts(CS%CAu_pred, CS%CAv_pred, "CAu", "CAv", G, restart_CS, &
+                   stagger=CGRID_NE, filename=dirs%input_filename, directory=dirs%restart_input_dir, &
+                   success=read_uv, scale=US%m_s_to_L_T*US%T_to_s)
+      CS%CAu_pred_stored = read_uv
+    else
+      if (.not. query_initialized(CS%h_av, "h2", restart_CS)) then
+        CS%h_av(:,:,:) = h(:,:,:)
+        call set_initialized(CS%h_av, "h2", restart_CS)
+      endif
+    endif
+  endif
+  call cpu_clock_begin(id_clock_pass_init)
+  call create_group_pass(pass_av_h_uvh, CS%u_av, CS%v_av, G%Domain, halo=2)
+  if (CS%CAu_pred_stored) then
+    call create_group_pass(pass_av_h_uvh, CS%CAu_pred, CS%CAv_pred, G%Domain, halo=2)
+  else
+    call create_group_pass(pass_av_h_uvh, CS%h_av, G%Domain, halo=2)
+    call create_group_pass(pass_av_h_uvh, uh, vh, G%Domain, halo=2)
+  endif
+  call do_group_pass(pass_av_h_uvh, G%Domain)
+  call cpu_clock_end(id_clock_pass_init)
+
+  flux_units = get_flux_units(GV)
+  thickness_units = get_thickness_units(GV)
+  CS%id_uh = register_diag_field('ocean_model', 'uh', diag%axesCuL, Time, &
+      'Zonal Thickness Flux', flux_units, conversion=GV%H_to_MKS*US%L_to_m**2*US%s_to_T, &
+      y_cell_method='sum', v_extensive=.true.)
+  CS%id_vh = register_diag_field('ocean_model', 'vh', diag%axesCvL, Time, &
+      'Meridional Thickness Flux', flux_units, conversion=GV%H_to_MKS*US%L_to_m**2*US%s_to_T, &
+      x_cell_method='sum', v_extensive=.true.)
+
+  CS%id_CAu = register_diag_field('ocean_model', 'CAu', diag%axesCuL, Time, &
+      'Zonal Coriolis and Advective Acceleration', 'm s-2', conversion=US%L_T2_to_m_s2)
+  CS%id_CAv = register_diag_field('ocean_model', 'CAv', diag%axesCvL, Time, &
+      'Meridional Coriolis and Advective Acceleration', 'm s-2', conversion=US%L_T2_to_m_s2)
+  CS%id_PFu = register_diag_field('ocean_model', 'PFu', diag%axesCuL, Time, &
+      'Zonal Pressure Force Acceleration', 'm s-2', conversion=US%L_T2_to_m_s2)
+  CS%id_PFv = register_diag_field('ocean_model', 'PFv', diag%axesCvL, Time, &
+      'Meridional Pressure Force Acceleration', 'm s-2', conversion=US%L_T2_to_m_s2)
+  CS%id_ueffA = register_diag_field('ocean_model', 'ueffA', diag%axesCuL, Time, &
+       'Effective U-Face Area', 'm^2', conversion=GV%H_to_m*US%L_to_m, &
+       y_cell_method='sum', v_extensive=.true.)
+  CS%id_veffA = register_diag_field('ocean_model', 'veffA', diag%axesCvL, Time, &
+       'Effective V-Face Area', 'm^2', conversion=GV%H_to_m*US%L_to_m, &
+       x_cell_method='sum', v_extensive=.true.)
+  if (GV%Boussinesq) then
+    CS%id_deta_dt = register_diag_field('ocean_model', 'deta_dt', diag%axesT1, Time, &
+      'Barotropic SSH tendency due to dynamics', trim(thickness_units)//' s-1', conversion=GV%H_to_MKS*US%s_to_T)
+  else
+    CS%id_deta_dt = register_diag_field('ocean_model', 'deta_dt', diag%axesT1, Time, &
+      'Barotropic column-mass tendency due to dynamics', trim(thickness_units)//' s-1', &
+      conversion=GV%H_to_mks*US%s_to_T)
+  endif
+
+  !CS%id_hf_PFu = register_diag_field('ocean_model', 'hf_PFu', diag%axesCuL, Time, &
+  !    'Fractional Thickness-weighted Zonal Pressure Force Acceleration', &
+  !    'm s-2', v_extensive=.true., conversion=US%L_T2_to_m_s2)
+  !if (CS%id_hf_PFu > 0) call safe_alloc_ptr(CS%ADp%diag_hfrac_u,IsdB,IedB,jsd,jed,nz)
+
+  !CS%id_hf_PFv = register_diag_field('ocean_model', 'hf_PFv', diag%axesCvL, Time, &
+  !    'Fractional Thickness-weighted Meridional Pressure Force Acceleration', &
+  !    'm s-2', v_extensive=.true., conversion=US%L_T2_to_m_s2)
+  !if (CS%id_hf_PFv > 0) call safe_alloc_ptr(CS%ADp%diag_hfrac_v,isd,ied,JsdB,JedB,nz)
+
+  !CS%id_hf_CAu = register_diag_field('ocean_model', 'hf_CAu', diag%axesCuL, Time, &
+  !    'Fractional Thickness-weighted Zonal Coriolis and Advective Acceleration', &
+  !    'm s-2', v_extensive=.true., conversion=US%L_T2_to_m_s2)
+  !if (CS%id_hf_CAu > 0) call safe_alloc_ptr(CS%ADp%diag_hfrac_u,IsdB,IedB,jsd,jed,nz)
+
+  !CS%id_hf_CAv = register_diag_field('ocean_model', 'hf_CAv', diag%axesCvL, Time, &
+  !    'Fractional Thickness-weighted Meridional Coriolis and Advective Acceleration', &
+  !    'm s-2', v_extensive=.true., conversion=US%L_T2_to_m_s2)
+  !if (CS%id_hf_CAv > 0) call safe_alloc_ptr(CS%ADp%diag_hfrac_v,isd,ied,JsdB,JedB,nz)
+
+  CS%id_hf_PFu_2d = register_diag_field('ocean_model', 'hf_PFu_2d', diag%axesCu1, Time, &
+      'Depth-sum Fractional Thickness-weighted Zonal Pressure Force Acceleration', &
+      'm s-2', conversion=US%L_T2_to_m_s2)
+  if (CS%id_hf_PFu_2d > 0) call safe_alloc_ptr(CS%ADp%diag_hfrac_u,IsdB,IedB,jsd,jed,nz)
+
+  CS%id_hf_PFv_2d = register_diag_field('ocean_model', 'hf_PFv_2d', diag%axesCv1, Time, &
+      'Depth-sum Fractional Thickness-weighted Meridional Pressure Force Acceleration', &
+      'm s-2', conversion=US%L_T2_to_m_s2)
+  if (CS%id_hf_PFv_2d > 0) call safe_alloc_ptr(CS%ADp%diag_hfrac_v,isd,ied,JsdB,JedB,nz)
+
+  CS%id_h_PFu = register_diag_field('ocean_model', 'h_PFu', diag%axesCuL, Time, &
+      'Thickness Multiplied Zonal Pressure Force Acceleration', &
+      'm2 s-2', conversion=GV%H_to_m*US%L_T2_to_m_s2)
+  if (CS%id_h_PFu > 0) call safe_alloc_ptr(CS%ADp%diag_hu,IsdB,IedB,jsd,jed,nz)
+
+  CS%id_h_PFv = register_diag_field('ocean_model', 'h_PFv', diag%axesCvL, Time, &
+      'Thickness Multiplied Meridional Pressure Force Acceleration', &
+      'm2 s-2', conversion=GV%H_to_m*US%L_T2_to_m_s2)
+  if (CS%id_h_PFv > 0) call safe_alloc_ptr(CS%ADp%diag_hv,isd,ied,JsdB,JedB,nz)
+
+  CS%id_intz_PFu_2d = register_diag_field('ocean_model', 'intz_PFu_2d', diag%axesCu1, Time, &
+      'Depth-integral of Zonal Pressure Force Acceleration', &
+      'm2 s-2', conversion=GV%H_to_m*US%L_T2_to_m_s2)
+  if (CS%id_intz_PFu_2d > 0) call safe_alloc_ptr(CS%ADp%diag_hu,IsdB,IedB,jsd,jed,nz)
+
+  CS%id_intz_PFv_2d = register_diag_field('ocean_model', 'intz_PFv_2d', diag%axesCv1, Time, &
+      'Depth-integral of Meridional Pressure Force Acceleration', &
+      'm2 s-2', conversion=GV%H_to_m*US%L_T2_to_m_s2)
+  if (CS%id_intz_PFv_2d > 0) call safe_alloc_ptr(CS%ADp%diag_hv,isd,ied,JsdB,JedB,nz)
+
+  CS%id_hf_CAu_2d = register_diag_field('ocean_model', 'hf_CAu_2d', diag%axesCu1, Time, &
+      'Depth-sum Fractional Thickness-weighted Zonal Coriolis and Advective Acceleration', &
+      'm s-2', conversion=US%L_T2_to_m_s2)
+  if (CS%id_hf_CAu_2d > 0) call safe_alloc_ptr(CS%ADp%diag_hfrac_u,IsdB,IedB,jsd,jed,nz)
+
+  CS%id_hf_CAv_2d = register_diag_field('ocean_model', 'hf_CAv_2d', diag%axesCv1, Time, &
+      'Depth-sum Fractional Thickness-weighted Meridional Coriolis and Advective Acceleration', &
+      'm s-2', conversion=US%L_T2_to_m_s2)
+  if (CS%id_hf_CAv_2d > 0) call safe_alloc_ptr(CS%ADp%diag_hfrac_v,isd,ied,JsdB,JedB,nz)
+
+  CS%id_h_CAu = register_diag_field('ocean_model', 'h_CAu', diag%axesCuL, Time, &
+      'Thickness Multiplied Zonal Coriolis and Advective Acceleration', &
+      'm2 s-2', conversion=GV%H_to_m*US%L_T2_to_m_s2)
+  if (CS%id_h_CAu > 0) call safe_alloc_ptr(CS%ADp%diag_hu,IsdB,IedB,jsd,jed,nz)
+
+  CS%id_h_CAv = register_diag_field('ocean_model', 'h_CAv', diag%axesCvL, Time, &
+      'Thickness Multiplied Meridional Coriolis and Advective Acceleration', &
+      'm2 s-2', conversion=GV%H_to_m*US%L_T2_to_m_s2)
+  if (CS%id_h_CAv > 0) call safe_alloc_ptr(CS%ADp%diag_hv,isd,ied,JsdB,JedB,nz)
+
+  CS%id_intz_CAu_2d = register_diag_field('ocean_model', 'intz_CAu_2d', diag%axesCu1, Time, &
+      'Depth-integral of Zonal Coriolis and Advective Acceleration', &
+      'm2 s-2', conversion=GV%H_to_m*US%L_T2_to_m_s2)
+  if (CS%id_intz_CAu_2d > 0) call safe_alloc_ptr(CS%ADp%diag_hu,IsdB,IedB,jsd,jed,nz)
+
+  CS%id_intz_CAv_2d = register_diag_field('ocean_model', 'intz_CAv_2d', diag%axesCv1, Time, &
+      'Depth-integral of Meridional Coriolis and Advective Acceleration', &
+      'm2 s-2', conversion=GV%H_to_m*US%L_T2_to_m_s2)
+  if (CS%id_intz_CAv_2d > 0) call safe_alloc_ptr(CS%ADp%diag_hv,isd,ied,JsdB,JedB,nz)
+
+  CS%id_uav = register_diag_field('ocean_model', 'uav', diag%axesCuL, Time, &
+      'Barotropic-step Averaged Zonal Velocity', 'm s-1', conversion=US%L_T_to_m_s)
+  CS%id_vav = register_diag_field('ocean_model', 'vav', diag%axesCvL, Time, &
+      'Barotropic-step Averaged Meridional Velocity', 'm s-1', conversion=US%L_T_to_m_s)
+
+  CS%id_u_BT_accel = register_diag_field('ocean_model', 'u_BT_accel', diag%axesCuL, Time, &
+    'Barotropic Anomaly Zonal Acceleration', 'm s-2', conversion=US%L_T2_to_m_s2)
+  CS%id_v_BT_accel = register_diag_field('ocean_model', 'v_BT_accel', diag%axesCvL, Time, &
+    'Barotropic Anomaly Meridional Acceleration', 'm s-2', conversion=US%L_T2_to_m_s2)
+
+  !CS%id_hf_u_BT_accel = register_diag_field('ocean_model', 'hf_u_BT_accel', diag%axesCuL, Time, &
+  !    'Fractional Thickness-weighted Barotropic Anomaly Zonal Acceleration', &
+  !    'm s-2', v_extensive=.true., conversion=US%L_T2_to_m_s2)
+  !if (CS%id_hf_u_BT_accel > 0) call safe_alloc_ptr(CS%ADp%diag_hfrac_u,IsdB,IedB,jsd,jed,nz)
+
+  !CS%id_hf_v_BT_accel = register_diag_field('ocean_model', 'hf_v_BT_accel', diag%axesCvL, Time, &
+  !    'Fractional Thickness-weighted Barotropic Anomaly Meridional Acceleration', &
+  !    'm s-2', v_extensive=.true., conversion=US%L_T2_to_m_s2)
+  !if (CS%id_hf_v_BT_accel > 0) call safe_alloc_ptr(CS%ADp%diag_hfrac_v,isd,ied,JsdB,JedB,nz)
+
+  CS%id_hf_u_BT_accel_2d = register_diag_field('ocean_model', 'hf_u_BT_accel_2d', diag%axesCu1, Time, &
+      'Depth-sum Fractional Thickness-weighted Barotropic Anomaly Zonal Acceleration', &
+      'm s-2', conversion=US%L_T2_to_m_s2)
+  if (CS%id_hf_u_BT_accel_2d > 0) call safe_alloc_ptr(CS%ADp%diag_hfrac_u,IsdB,IedB,jsd,jed,nz)
+
+  CS%id_hf_v_BT_accel_2d = register_diag_field('ocean_model', 'hf_v_BT_accel_2d', diag%axesCv1, Time, &
+      'Depth-sum Fractional Thickness-weighted Barotropic Anomaly Meridional Acceleration', &
+      'm s-2', conversion=US%L_T2_to_m_s2)
+  if (CS%id_hf_v_BT_accel_2d > 0) call safe_alloc_ptr(CS%ADp%diag_hfrac_v,isd,ied,JsdB,JedB,nz)
+
+  CS%id_h_u_BT_accel = register_diag_field('ocean_model', 'h_u_BT_accel', diag%axesCuL, Time, &
+      'Thickness Multiplied Barotropic Anomaly Zonal Acceleration', &
+      'm2 s-2', conversion=GV%H_to_m*US%L_T2_to_m_s2)
+  if (CS%id_h_u_BT_accel > 0) call safe_alloc_ptr(CS%ADp%diag_hu,IsdB,IedB,jsd,jed,nz)
+
+  CS%id_h_v_BT_accel = register_diag_field('ocean_model', 'h_v_BT_accel', diag%axesCvL, Time, &
+      'Thickness Multiplied Barotropic Anomaly Meridional Acceleration', &
+      'm2 s-2', conversion=GV%H_to_m*US%L_T2_to_m_s2)
+  if (CS%id_h_v_BT_accel > 0) call safe_alloc_ptr(CS%ADp%diag_hv,isd,ied,JsdB,JedB,nz)
+
+  CS%id_intz_u_BT_accel_2d = register_diag_field('ocean_model', 'intz_u_BT_accel_2d', diag%axesCu1, Time, &
+      'Depth-integral of Barotropic Anomaly Zonal Acceleration', &
+      'm2 s-2', conversion=GV%H_to_m*US%L_T2_to_m_s2)
+  if (CS%id_intz_u_BT_accel_2d > 0) call safe_alloc_ptr(CS%ADp%diag_hu,IsdB,IedB,jsd,jed,nz)
+
+  CS%id_intz_v_BT_accel_2d = register_diag_field('ocean_model', 'intz_v_BT_accel_2d', diag%axesCv1, Time, &
+      'Depth-integral of Barotropic Anomaly Meridional Acceleration', &
+      'm2 s-2', conversion=GV%H_to_m*US%L_T2_to_m_s2)
+  if (CS%id_intz_v_BT_accel_2d > 0) call safe_alloc_ptr(CS%ADp%diag_hv,isd,ied,JsdB,JedB,nz)
+
+  CS%id_PFu_visc_rem = register_diag_field('ocean_model', 'PFu_visc_rem', diag%axesCuL, Time, &
+      'Zonal Pressure Force Acceleration multiplied by the viscous remnant', &
+      'm s-2', conversion=US%L_T2_to_m_s2)
+  if (CS%id_PFu_visc_rem > 0) call safe_alloc_ptr(CS%ADp%visc_rem_u,IsdB,IedB,jsd,jed,nz)
+  CS%id_PFv_visc_rem = register_diag_field('ocean_model', 'PFv_visc_rem', diag%axesCvL, Time, &
+      'Meridional Pressure Force Acceleration multiplied by the viscous remnant', &
+      'm s-2', conversion=US%L_T2_to_m_s2)
+  if (CS%id_PFv_visc_rem > 0) call safe_alloc_ptr(CS%ADp%visc_rem_v,isd,ied,JsdB,JedB,nz)
+
+  CS%id_CAu_visc_rem = register_diag_field('ocean_model', 'CAu_visc_rem', diag%axesCuL, Time, &
+      'Zonal Coriolis and Advective Acceleration multiplied by the viscous remnant', &
+      'm s-2', conversion=US%L_T2_to_m_s2)
+  if (CS%id_CAu_visc_rem > 0) call safe_alloc_ptr(CS%ADp%visc_rem_u,IsdB,IedB,jsd,jed,nz)
+  CS%id_CAv_visc_rem = register_diag_field('ocean_model', 'CAv_visc_rem', diag%axesCvL, Time, &
+      'Meridional Coriolis and Advective Acceleration multiplied by the viscous remnant', &
+      'm s-2', conversion=US%L_T2_to_m_s2)
+  if (CS%id_CAv_visc_rem > 0) call safe_alloc_ptr(CS%ADp%visc_rem_v,isd,ied,JsdB,JedB,nz)
+
+  CS%id_u_BT_accel_visc_rem = register_diag_field('ocean_model', 'u_BT_accel_visc_rem', diag%axesCuL, Time, &
+      'Barotropic Anomaly Zonal Acceleration multiplied by the viscous remnant', &
+      'm s-2', conversion=US%L_T2_to_m_s2)
+  if (CS%id_u_BT_accel_visc_rem > 0) call safe_alloc_ptr(CS%ADp%visc_rem_u,IsdB,IedB,jsd,jed,nz)
+  CS%id_v_BT_accel_visc_rem = register_diag_field('ocean_model', 'v_BT_accel_visc_rem', diag%axesCvL, Time, &
+      'Barotropic Anomaly Meridional Acceleration multiplied by the viscous remnant', &
+      'm s-2', conversion=US%L_T2_to_m_s2)
+  if (CS%id_v_BT_accel_visc_rem > 0) call safe_alloc_ptr(CS%ADp%visc_rem_v,isd,ied,JsdB,JedB,nz)
+
+  id_clock_Cor        = cpu_clock_id('(Ocean Coriolis & mom advection)', grain=CLOCK_MODULE)
+  id_clock_continuity = cpu_clock_id('(Ocean continuity equation)',      grain=CLOCK_MODULE)
+  id_clock_pres       = cpu_clock_id('(Ocean pressure force)',           grain=CLOCK_MODULE)
+  id_clock_vertvisc   = cpu_clock_id('(Ocean vertical viscosity)',       grain=CLOCK_MODULE)
+  id_clock_horvisc    = cpu_clock_id('(Ocean horizontal viscosity)',     grain=CLOCK_MODULE)
+  id_clock_mom_update = cpu_clock_id('(Ocean momentum increments)',      grain=CLOCK_MODULE)
+  id_clock_pass       = cpu_clock_id('(Ocean message passing)',          grain=CLOCK_MODULE)
+  id_clock_btcalc     = cpu_clock_id('(Ocean barotropic mode calc)',     grain=CLOCK_MODULE)
+  id_clock_btstep     = cpu_clock_id('(Ocean barotropic mode stepping)', grain=CLOCK_MODULE)
+  id_clock_btforce    = cpu_clock_id('(Ocean barotropic forcing calc)',  grain=CLOCK_MODULE)
+
+end subroutine initialize_dyn_split_RK2b
+
+
+!> Close the dyn_split_RK2b module
+subroutine end_dyn_split_RK2b(CS)
+  type(MOM_dyn_split_RK2b_CS), pointer :: CS  !< module control structure
+
+  call barotropic_end(CS%barotropic_CSp)
+
+  call vertvisc_end(CS%vertvisc_CSp)
+  deallocate(CS%vertvisc_CSp)
+
+  call hor_visc_end(CS%hor_visc)
+  if (CS%calculate_SAL) call SAL_end(CS%SAL_CSp)
+  if (CS%use_tides) call tidal_forcing_end(CS%tides_CSp)
+  call CoriolisAdv_end(CS%CoriolisAdv)
+
+  DEALLOC_(CS%diffu) ; DEALLOC_(CS%diffv)
+  DEALLOC_(CS%CAu)   ; DEALLOC_(CS%CAv)
+  DEALLOC_(CS%CAu_pred) ; DEALLOC_(CS%CAv_pred)
+  DEALLOC_(CS%PFu)   ; DEALLOC_(CS%PFv)
+
+  if (associated(CS%taux_bot)) deallocate(CS%taux_bot)
+  if (associated(CS%tauy_bot)) deallocate(CS%tauy_bot)
+  DEALLOC_(CS%uhbt) ; DEALLOC_(CS%vhbt)
+  DEALLOC_(CS%u_accel_bt) ; DEALLOC_(CS%v_accel_bt)
+  DEALLOC_(CS%visc_rem_u) ; DEALLOC_(CS%visc_rem_v)
+
+  DEALLOC_(CS%eta) ; DEALLOC_(CS%eta_PF) ; DEALLOC_(CS%pbce)
+  DEALLOC_(CS%h_av) ; DEALLOC_(CS%u_av) ; DEALLOC_(CS%v_av)
+
+  call dealloc_BT_cont_type(CS%BT_cont)
+  deallocate(CS%AD_pred)
+
+  deallocate(CS)
+end subroutine end_dyn_split_RK2b
+
+
+!> \namespace mom_dynamics_split_rk2b
+!!
+!!  This file time steps the adiabatic dynamic core by splitting
+!!  between baroclinic and barotropic modes. It uses a pseudo-second order
+!!  Runge-Kutta time stepping scheme for the baroclinic momentum
+!!  equation and a forward-backward coupling between the baroclinic
+!!  momentum and continuity equations.  This split time-stepping
+!!  scheme is described in detail in Hallberg (JCP, 1997). Additional
+!!  issues related to exact tracer conservation and how to
+!!  ensure consistency between the barotropic and layered estimates
+!!  of the free surface height are described in Hallberg and
+!!  Adcroft (Ocean Modelling, 2009).  This was the time stepping code
+!!  that is used for most GOLD applications, including GFDL's ESM2G
+!!  Earth system model, and all of the examples provided with the
+!!  MOM code (although several of these solutions are routinely
+!!  verified by comparison with the slower unsplit schemes).
+!!
+!!  The subroutine step_MOM_dyn_split_RK2b actually does the time
+!!  stepping, while register_restarts_dyn_split_RK2b sets the fields
+!!  that are found in a full restart file with this scheme, and
+!!  initialize_dyn_split_RK2b initializes the cpu clocks that are
+!!  used in this module.  For largely historical reasons, this module
+!!  does not have its own control structure, but shares the same
+!!  control structure with MOM.F90 and the other MOM_dynamics_...
+!!  modules.
+
+end module MOM_dynamics_split_RK2b

--- a/src/core/MOM_dynamics_split_RK2b.F90
+++ b/src/core/MOM_dynamics_split_RK2b.F90
@@ -73,9 +73,6 @@ use MOM_vert_friction,         only : updateCFLtruncationValue, vertFPmix
 use MOM_verticalGrid,          only : verticalGrid_type, get_thickness_units
 use MOM_verticalGrid,          only : get_flux_units, get_tr_flux_units
 use MOM_wave_interface,        only: wave_parameters_CS, Stokes_PGF
-use MOM_CVMix_KPP,             only : KPP_get_BLD, KPP_CS
-use MOM_energetic_PBL,         only : energetic_PBL_get_MLD, energetic_PBL_CS
-use MOM_diabatic_driver,       only : diabatic_CS, extract_diabatic_member
 
 implicit none ; private
 
@@ -147,8 +144,6 @@ type, public :: MOM_dyn_split_RK2b_CS ; private
   real ALLOCABLE_, dimension(NIMEM_,NJMEMB_PTR_)        :: dv_av_inst !< The barotropic meridional velocity increment
                                                                   !! between filtered and instantaneous velocities
                                                                   !! [L T-1 ~> m s-1]
-  type(KPP_CS),           pointer :: KPP_CSp => NULL() !< KPP control structure needed to ge
-  type(energetic_PBL_CS), pointer :: energetic_PBL_CSp => NULL()  !< ePBL control structure
 
   real, pointer, dimension(:,:) :: taux_bot => NULL() !< frictional x-bottom stress from the ocean
                                                       !! to the seafloor [R L Z T-2 ~> Pa]
@@ -734,9 +729,7 @@ subroutine step_MOM_dyn_split_RK2b(u_av, v_av, h, tv, visc, Time_local, dt, forc
 
   !  if (CS%fpmix) then
   !    hbl(:,:) = 0.0
-  !    if (ASSOCIATED(CS%KPP_CSp)) call KPP_get_BLD(CS%KPP_CSp, hbl, G, US, m_to_BLD_units=GV%m_to_H)
-  !    if (ASSOCIATED(CS%energetic_PBL_CSp)) &
-  !      call energetic_PBL_get_MLD(CS%energetic_PBL_CSp, hbl, G, US, m_to_MLD_units=GV%m_to_H)
+  !    if (associated(visc%h_ML)) hbl(:,:) = visc%h_ML(:,:)
   !    call vertFPmix(up, vp, uold, vold, hbl, h, forces, &
   !                   dt_pred, G, GV, US, CS%vertvisc_CSp, CS%OBC)
   !    call vertvisc(up, vp, h, forces, visc, dt_pred, CS%OBC, CS%ADp, CS%CDp, G, &

--- a/src/core/MOM_dynamics_unsplit.F90
+++ b/src/core/MOM_dynamics_unsplit.F90
@@ -263,7 +263,7 @@ subroutine step_MOM_dyn_unsplit(u, v, h, tv, visc, Time_local, dt, forces, &
 ! diffu = horizontal viscosity terms (u,h)
   call enable_averages(dt, Time_local, CS%diag)
   call cpu_clock_begin(id_clock_horvisc)
-  call horizontal_viscosity(u, v, h, CS%diffu, CS%diffv, MEKE, Varmix, G, GV, US, CS%hor_visc)
+  call horizontal_viscosity(u, v, h, CS%diffu, CS%diffv, MEKE, Varmix, G, GV, US, CS%hor_visc, tv, dt)
   call cpu_clock_end(id_clock_horvisc)
   call disable_averaging(CS%diag)
 

--- a/src/core/MOM_dynamics_unsplit.F90
+++ b/src/core/MOM_dynamics_unsplit.F90
@@ -65,7 +65,7 @@ use MOM_domains, only : pass_var, pass_var_start, pass_var_complete
 use MOM_domains, only : pass_vector, pass_vector_start, pass_vector_complete
 use MOM_domains, only : To_South, To_West, To_All, CGRID_NE, SCALAR_PAIR
 use MOM_error_handler, only : MOM_error, MOM_mesg, FATAL, WARNING, is_root_pe
-use MOM_file_parser, only : get_param, log_version, param_file_type
+use MOM_file_parser, only : get_param, log_param, log_version, param_file_type
 use MOM_get_input, only : directories
 use MOM_time_manager, only : time_type, real_to_time, operator(+)
 use MOM_time_manager, only : operator(-), operator(>), operator(*), operator(/)
@@ -116,13 +116,13 @@ type, public :: MOM_dyn_unsplit_CS ; private
   real, pointer, dimension(:,:) :: tauy_bot => NULL() !< frictional y-bottom stress from the ocean
                                                       !! to the seafloor [R L Z T-2 ~> Pa]
 
-  logical :: use_correct_dt_visc !< If true, use the correct timestep in the viscous terms applied
-                                 !! in the first predictor step with the unsplit time stepping scheme,
-                                 !! and in the calculation of the turbulent mixed layer properties
-                                 !! for viscosity.  The default should be true, but it is false.
-  logical :: debug           !< If true, write verbose checksums for debugging purposes.
-  logical :: calculate_SAL        !< If true, calculate self-attraction and loading.
-  logical :: use_tides            !< If true, tidal forcing is enabled.
+  logical :: dt_visc_bug    !< If false, use the correct timestep in viscous terms applied in the
+                            !! first predictor step and in the calculation of the turbulent mixed
+                            !! layer properties for viscosity.  If this is true, an older incorrect
+                            !! setting is used.
+  logical :: debug          !< If true, write verbose checksums for debugging purposes.
+  logical :: calculate_SAL  !< If true, calculate self-attraction and loading.
+  logical :: use_tides      !< If true, tidal forcing is enabled.
 
   logical :: module_is_initialized = .false. !< Record whether this module has been initialized.
 
@@ -346,11 +346,11 @@ subroutine step_MOM_dyn_unsplit(u, v, h, tv, visc, Time_local, dt, forces, &
  ! up <- up + dt/2 d/dz visc d/dz up
   call cpu_clock_begin(id_clock_vertvisc)
   call enable_averages(dt, Time_local, CS%diag)
-  dt_visc = 0.5*dt ; if (CS%use_correct_dt_visc) dt_visc = dt
+  dt_visc = dt ; if (CS%dt_visc_bug) dt_visc = 0.5*dt
   call set_viscous_ML(u, v, h_av, tv, forces, visc, dt_visc, G, GV, US, CS%set_visc_CSp)
   call disable_averaging(CS%diag)
 
-  dt_visc = 0.5*dt ; if (CS%use_correct_dt_visc) dt_visc = dt_pred
+  dt_visc = dt_pred ; if (CS%dt_visc_bug) dt_visc = 0.5*dt
   call thickness_to_dz(h_av, tv, dz, G, GV, US, halo_size=1)
   call vertvisc_coef(up, vp, h_av, dz, forces, visc, tv, dt_visc, G, GV, US, CS%vertvisc_CSp, CS%OBC, VarMix)
   call vertvisc(up, vp, h_av, forces, visc, dt_visc, CS%OBC, CS%ADp, CS%CDp, &
@@ -630,6 +630,9 @@ subroutine initialize_dyn_unsplit(u, v, h, Time, G, GV, US, param_file, diag, CS
   character(len=48) :: flux_units
   ! This include declares and sets the variable "version".
 # include "version_variable.h"
+  logical :: use_correct_dt_visc
+  logical :: test_value  ! This is used to determine whether a logical parameter is being set explicitly.
+  logical :: explicit_bug, explicit_fix ! These indicate which parameters are set explicitly.
   integer :: isd, ied, jsd, jed, nz, IsdB, IedB, JsdB, JedB
   isd = G%isd ; ied = G%ied ; jsd = G%jsd ; jed = G%jed ; nz = GV%ke
   IsdB = G%IsdB ; IedB = G%IedB ; JsdB = G%JsdB ; JedB = G%JedB
@@ -646,11 +649,41 @@ subroutine initialize_dyn_unsplit(u, v, h, Time, G, GV, US, param_file, diag, CS
   CS%diag => diag
 
   call log_version(param_file, mdl, version, "")
-  call get_param(param_file, mdl, "FIX_UNSPLIT_DT_VISC_BUG", CS%use_correct_dt_visc, &
+
+  call get_param(param_file, mdl, "UNSPLIT_DT_VISC_BUG", CS%dt_visc_bug, &
+                 "If false, use the correct timestep in the viscous terms applied in the first "//&
+                 "predictor step with the unsplit time stepping scheme, and in the calculation "//&
+                 "of the turbulent mixed layer properties for viscosity with unsplit or "//&
+                 "unsplit_RK2.  If true, an older incorrect value is used.", &
+                 default=.false., do_not_log=.true.)
+  ! This is used to test whether UNSPLIT_DT_VISC_BUG is being actively set.
+  call get_param(param_file, mdl, "UNSPLIT_DT_VISC_BUG", test_value, default=.true., do_not_log=.true.)
+  explicit_bug = CS%dt_visc_bug .eqv. test_value
+  call get_param(param_file, mdl, "FIX_UNSPLIT_DT_VISC_BUG", use_correct_dt_visc, &
                  "If true, use the correct timestep in the viscous terms applied in the first "//&
                  "predictor step with the unsplit time stepping scheme, and in the calculation "//&
                  "of the turbulent mixed layer properties for viscosity with unsplit or "//&
-                 "unsplit_RK2.", default=.true.)
+                 "unsplit_RK2.", default=.true., do_not_log=.true.)
+  call get_param(param_file, mdl, "FIX_UNSPLIT_DT_VISC_BUG", test_value, default=.false., do_not_log=.true.)
+  explicit_fix = use_correct_dt_visc .eqv. test_value
+
+  if (explicit_bug .and. explicit_fix .and. (use_correct_dt_visc .eqv. CS%dt_visc_bug)) then
+    ! UNSPLIT_DT_VISC_BUG is being explicitly set, and should not be changed.
+    call MOM_error(FATAL, "UNSPLIT_DT_VISC_BUG and FIX_UNSPLIT_DT_VISC_BUG are both being set "//&
+                   "with inconsistent values.  FIX_UNSPLIT_DT_VISC_BUG is an obsolete "//&
+                   "parameter and should be removed.")
+  elseif (explicit_fix) then
+    call MOM_error(WARNING, "FIX_UNSPLIT_DT_VISC_BUG is an obsolete parameter.  "//&
+                   "Use UNSPLIT_DT_VISC_BUG instead (noting that it has the opposite sense).")
+    CS%dt_visc_bug = .not.use_correct_dt_visc
+  endif
+  call log_param(param_file, mdl, "UNSPLIT_DT_VISC_BUG", CS%dt_visc_bug, &
+                 "If false, use the correct timestep in the viscous terms applied in the first "//&
+                 "predictor step with the unsplit time stepping scheme, and in the calculation "//&
+                 "of the turbulent mixed layer properties for viscosity with unsplit or "//&
+                 "unsplit_RK2.  If true, an older incorrect value is used.", &
+                 default=.false.)
+
   call get_param(param_file, mdl, "DEBUG", CS%debug, &
                  "If true, write out verbose debugging data.", &
                  default=.false., debuggingParam=.true.)

--- a/src/core/MOM_dynamics_unsplit_RK2.F90
+++ b/src/core/MOM_dynamics_unsplit_RK2.F90
@@ -276,7 +276,7 @@ subroutine step_MOM_dyn_unsplit_RK2(u_in, v_in, h_in, tv, visc, Time_local, dt, 
   call enable_averages(dt,Time_local, CS%diag)
   call cpu_clock_begin(id_clock_horvisc)
   call horizontal_viscosity(u_in, v_in, h_in, CS%diffu, CS%diffv, MEKE, VarMix, &
-                            G, GV, US, CS%hor_visc)
+                            G, GV, US, CS%hor_visc, tv, dt)
   call cpu_clock_end(id_clock_horvisc)
   call disable_averaging(CS%diag)
   call pass_vector(CS%diffu, CS%diffv, G%Domain, clock=id_clock_pass)

--- a/src/core/MOM_dynamics_unsplit_RK2.F90
+++ b/src/core/MOM_dynamics_unsplit_RK2.F90
@@ -64,7 +64,7 @@ use MOM_domains, only : pass_vector, pass_vector_start, pass_vector_complete
 use MOM_domains, only : To_South, To_West, To_All, CGRID_NE, SCALAR_PAIR
 use MOM_error_handler, only : MOM_error, MOM_mesg, FATAL, WARNING, is_root_pe
 use MOM_error_handler, only : MOM_set_verbosity
-use MOM_file_parser, only : get_param, log_version, param_file_type
+use MOM_file_parser, only : get_param, log_param, log_version, param_file_type
 use MOM_get_input, only : directories
 use MOM_time_manager, only : time_type, time_type_to_real, operator(+)
 use MOM_time_manager, only : operator(-), operator(>), operator(*), operator(/)
@@ -114,18 +114,18 @@ type, public :: MOM_dyn_unsplit_RK2_CS ; private
   real, pointer, dimension(:,:) :: tauy_bot => NULL() !< frictional y-bottom stress from the ocean
                                                       !! to the seafloor [R L Z T-2 ~> Pa]
 
-  real    :: be      !< A nondimensional number from 0.5 to 1 that controls
-                     !! the backward weighting of the time stepping scheme [nondim].
-  real    :: begw    !< A nondimensional number from 0 to 1 that controls
-                     !! the extent to which the treatment of gravity waves
-                     !! is forward-backward (0) or simulated backward
-                     !! Euler (1) [nondim].  0 is often used.
-  logical :: use_correct_dt_visc !< If true, use the correct timestep in the calculation of the
-                                 !! turbulent mixed layer properties for viscosity.
-                                 !! The default should be true, but it is false.
-  logical :: debug   !< If true, write verbose checksums for debugging purposes.
-  logical :: calculate_SAL        !< If true, calculate self-attraction and loading.
-  logical :: use_tides            !< If true, tidal forcing is enabled.
+  real    :: be             !< A nondimensional number from 0.5 to 1 that controls
+                            !! the backward weighting of the time stepping scheme [nondim].
+  real    :: begw           !< A nondimensional number from 0 to 1 that controls
+                            !! the extent to which the treatment of gravity waves
+                            !! is forward-backward (0) or simulated backward
+                            !! Euler (1) [nondim].  0 is often used.
+  logical :: dt_visc_bug    !< If false, use the correct timestep in the calculation of the
+                            !! turbulent mixed layer properties for viscosity.  Otherwise if
+                            !! this is true, an older incorrect setting is used.
+  logical :: debug          !< If true, write verbose checksums for debugging purposes.
+  logical :: calculate_SAL  !< If true, calculate self-attraction and loading.
+  logical :: use_tides      !< If true, tidal forcing is enabled.
 
   logical :: module_is_initialized = .false. !< Record whether this module has been initialized.
 
@@ -344,7 +344,7 @@ subroutine step_MOM_dyn_unsplit_RK2(u_in, v_in, h_in, tv, visc, Time_local, dt, 
  ! up[n-1/2] <- up*[n-1/2] + dt/2 d/dz visc d/dz up[n-1/2]
   call cpu_clock_begin(id_clock_vertvisc)
   call enable_averages(dt, Time_local, CS%diag)
-  dt_visc = dt_pred ; if (CS%use_correct_dt_visc) dt_visc = dt
+  dt_visc = dt ; if (CS%dt_visc_bug) dt_visc = dt_pred
   call set_viscous_ML(u_in, v_in, h_av, tv, forces, visc, dt_visc, G, GV, US, CS%set_visc_CSp)
   call disable_averaging(CS%diag)
 
@@ -578,6 +578,9 @@ subroutine initialize_dyn_unsplit_RK2(u, v, h, Time, G, GV, US, param_file, diag
   character(len=48) :: flux_units
   ! This include declares and sets the variable "version".
 # include "version_variable.h"
+  logical :: use_correct_dt_visc
+  logical :: test_value  ! This is used to determine whether a logical parameter is being set explicitly.
+  logical :: explicit_bug, explicit_fix ! These indicate which parameters are set explicitly.
   integer :: isd, ied, jsd, jed, nz, IsdB, IedB, JsdB, JedB
   isd = G%isd ; ied = G%ied ; jsd = G%jsd ; jed = G%jed ; nz = GV%ke
   IsdB = G%IsdB ; IedB = G%IedB ; JsdB = G%JsdB ; JedB = G%JedB
@@ -610,11 +613,41 @@ subroutine initialize_dyn_unsplit_RK2(u, v, h, Time, G, GV, US, param_file, diag
                  "If SPLIT is false and USE_RK2 is true, BEGW can be "//&
                  "between 0 and 0.5 to damp gravity waves.", &
                  units="nondim", default=0.0)
-  call get_param(param_file, mdl, "FIX_UNSPLIT_DT_VISC_BUG", CS%use_correct_dt_visc, &
+
+  call get_param(param_file, mdl, "UNSPLIT_DT_VISC_BUG", CS%dt_visc_bug, &
+                 "If false, use the correct timestep in the viscous terms applied in the first "//&
+                 "predictor step with the unsplit time stepping scheme, and in the calculation "//&
+                 "of the turbulent mixed layer properties for viscosity with unsplit or "//&
+                 "unsplit_RK2.  If true, an older incorrect value is used.", &
+                 default=.false., do_not_log=.true.)
+  ! This is used to test whether UNSPLIT_DT_VISC_BUG is being explicitly set.
+  call get_param(param_file, mdl, "UNSPLIT_DT_VISC_BUG", test_value, default=.true., do_not_log=.true.)
+  explicit_bug = CS%dt_visc_bug .eqv. test_value
+  call get_param(param_file, mdl, "FIX_UNSPLIT_DT_VISC_BUG", use_correct_dt_visc, &
                  "If true, use the correct timestep in the viscous terms applied in the first "//&
                  "predictor step with the unsplit time stepping scheme, and in the calculation "//&
                  "of the turbulent mixed layer properties for viscosity with unsplit or "//&
-                 "unsplit_RK2.", default=.true.)
+                 "unsplit_RK2.", default=.true., do_not_log=.true.)
+  call get_param(param_file, mdl, "FIX_UNSPLIT_DT_VISC_BUG", test_value, default=.false., do_not_log=.true.)
+  explicit_fix = use_correct_dt_visc .eqv. test_value
+
+  if (explicit_bug .and. explicit_fix .and. (use_correct_dt_visc .eqv. CS%dt_visc_bug)) then
+    ! UNSPLIT_DT_VISC_BUG is being explicitly set, and should not be changed.
+    call MOM_error(FATAL, "UNSPLIT_DT_VISC_BUG and FIX_UNSPLIT_DT_VISC_BUG are both being set "//&
+                   "with inconsistent values.  FIX_UNSPLIT_DT_VISC_BUG is an obsolete "//&
+                   "parameter and should be removed.")
+  elseif (explicit_fix) then
+    call MOM_error(WARNING, "FIX_UNSPLIT_DT_VISC_BUG is an obsolete parameter.  "//&
+                   "Use UNSPLIT_DT_VISC_BUG instead (noting that it has the opposite sense).")
+    CS%dt_visc_bug = .not.use_correct_dt_visc
+  endif
+  call log_param(param_file, mdl, "UNSPLIT_DT_VISC_BUG", CS%dt_visc_bug, &
+                 "If false, use the correct timestep in the viscous terms applied in the first "//&
+                 "predictor step with the unsplit time stepping scheme, and in the calculation "//&
+                 "of the turbulent mixed layer properties for viscosity with unsplit or "//&
+                 "unsplit_RK2.  If true, an older incorrect value is used.", &
+                 default=.false.)
+
   call get_param(param_file, mdl, "DEBUG", CS%debug, &
                  "If true, write out verbose debugging data.", &
                  default=.false., debuggingParam=.true.)

--- a/src/core/MOM_forcing_type.F90
+++ b/src/core/MOM_forcing_type.F90
@@ -126,9 +126,8 @@ type, public :: forcing
   real, pointer, dimension(:,:) :: &
     netMassIn     => NULL(), & !< Sum of water mass fluxes into the ocean integrated over a
                                !! forcing timestep [H ~> m or kg m-2]
-    netMassOut    => NULL(), & !< Net water mass flux out of the ocean integrated over a forcing timestep,
+    netMassOut    => NULL()    !< Net water mass flux out of the ocean integrated over a forcing timestep,
                                !! with negative values for water leaving the ocean [H ~> m or kg m-2]
-    KPP_salt_flux => NULL()    !< KPP effective salt flux [ppt m s-1]
 
   ! heat associated with water crossing ocean surface
   real, pointer, dimension(:,:) :: &

--- a/src/core/MOM_forcing_type.F90
+++ b/src/core/MOM_forcing_type.F90
@@ -3492,7 +3492,7 @@ end subroutine get_mech_forcing_groups
 
 !> Allocates and zeroes-out array.
 subroutine myAlloc(array, is, ie, js, je, flag)
-  real, dimension(:,:), pointer :: array !< Array to be allocated
+  real, dimension(:,:), pointer :: array !< Array to be allocated [arbitrary]
   integer,           intent(in) :: is !< Start i-index
   integer,           intent(in) :: ie !< End i-index
   integer,           intent(in) :: js !< Start j-index
@@ -3970,11 +3970,12 @@ end subroutine homogenize_forcing
 
 subroutine homogenize_field_t(var, G, tmp_scale)
   type(ocean_grid_type),            intent(in)    :: G   !< The ocean's grid structure
-  real, dimension(SZI_(G),SZJ_(G)), intent(inout) :: var !< The variable to homogenize
-  real,                   optional, intent(in)    :: tmp_scale !< A temporary rescaling factor for the
-                                                         !! variable that is reversed in the return value
+  real, dimension(SZI_(G),SZJ_(G)), intent(inout) :: var !< The variable to homogenize [A ~> a]
+  real,                    optional, intent(in)    :: tmp_scale !< A temporary rescaling factor for the
+                                                         !! variable that is reversed in the
+                                                         !! return value [a A-1 ~> 1]
 
-  real    :: avg   ! Global average of var, in the same units as var
+  real    :: avg   ! Global average of var, in the same units as var [A ~> a]
   integer :: i, j, is, ie, js, je
   is = G%isc ; ie = G%iec ; js = G%jsc ; je = G%jec
 
@@ -3987,11 +3988,12 @@ end subroutine homogenize_field_t
 
 subroutine homogenize_field_v(var, G, tmp_scale)
   type(ocean_grid_type),             intent(in)    :: G    !< The ocean's grid structure
-  real, dimension(SZI_(G),SZJB_(G)), intent(inout) :: var  !< The variable to homogenize
+  real, dimension(SZI_(G),SZJB_(G)), intent(inout) :: var  !< The variable to homogenize [A ~> a]
   real,                    optional, intent(in)    :: tmp_scale !< A temporary rescaling factor for the
-                                                         !! variable that is reversed in the return value
+                                                           !! variable that is reversed in the
+                                                           !! return value [a A-1 ~> 1]
 
-  real    :: avg   ! Global average of var, in the same units as var
+  real    :: avg   ! Global average of var, in the same units as var [A ~> a]
   integer :: i, j, is, ie, jsB, jeB
   is = G%isc ; ie = G%iec ; jsB = G%jscB ; jeB = G%jecB
 
@@ -4004,11 +4006,12 @@ end subroutine homogenize_field_v
 
 subroutine homogenize_field_u(var, G, tmp_scale)
   type(ocean_grid_type),             intent(in)    :: G    !< The ocean's grid structure
-  real, dimension(SZI_(G),SZJB_(G)), intent(inout) :: var  !< The variable to homogenize
+  real, dimension(SZI_(G),SZJB_(G)), intent(inout) :: var  !< The variable to homogenize [A ~> a]
   real,                    optional, intent(in)    :: tmp_scale !< A temporary rescaling factor for the
-                                                         !! variable that is reversed in the return value
+                                                           !! variable that is reversed in the
+                                                           !! return value [a A-1 ~> 1]
 
-  real    :: avg   ! Global average of var, in the same units as var
+  real    :: avg   ! Global average of var, in the same units as var [A ~> a]
   integer :: i, j, isB, ieB, js, je
   isB = G%iscB ; ieB = G%iecB ; js = G%jsc ; je = G%jec
 

--- a/src/core/MOM_interface_heights.F90
+++ b/src/core/MOM_interface_heights.F90
@@ -19,6 +19,7 @@ implicit none ; private
 
 public find_eta, dz_to_thickness, thickness_to_dz, dz_to_thickness_simple
 public calc_derived_thermo
+public convert_MLD_to_ML_thickness
 public find_rho_bottom, find_col_avg_SpV
 
 !> Calculates the heights of the free surface or all interfaces from layer thicknesses.
@@ -823,5 +824,70 @@ subroutine thickness_to_dz_jslice(h, tv, dz, j, G, GV, halo_size)
   endif
 
 end subroutine thickness_to_dz_jslice
+
+
+!> Convert mixed layer depths in height units into the thickness of water in the mixed
+!! in thickness units.
+subroutine convert_MLD_to_ML_thickness(MLD_in, h, h_MLD, tv, G, GV, halo)
+  type(ocean_grid_type),   intent(in)    :: G  !< The ocean's grid structure
+  type(verticalGrid_type), intent(in)    :: GV !< The ocean's vertical grid structure
+  real, dimension(SZI_(G),SZJ_(G)), &
+                           intent(in)    :: MLD_in !< Input mixed layer depth [Z ~> m].
+  real, dimension(SZI_(G),SZJ_(G),SZK_(GV)), &
+                           intent(in)    :: h  !< Layer thicknesses [H ~> m or kg m-2]
+  real, dimension(SZI_(G),SZJ_(G)), &
+                           intent(out)   :: h_MLD !< Thickness of water in the mixed layer [H ~> m or kg m-2]
+  type(thermo_var_ptrs),   intent(in)    :: tv !< Structure containing pointers to any available
+                                               !! thermodynamic fields.
+  integer,       optional, intent(in)    :: halo !< Halo width over which to calculate frazil
+
+  ! Local variables
+  real :: MLD_rem(SZI_(G)) ! The vertical extent of the MLD_in that has not yet been accounted for [Z ~> m]
+  character(len=128) :: mesg    ! A string for error messages
+  logical :: keep_going
+  integer :: i, j, k, is, ie, js, je, nz, halos
+
+  is = G%isc ; ie = G%iec ; js = G%jsc ; je = G%jec ; nz = GV%ke
+
+  halos = 0 ; if (present(halo)) halos = halo
+  if (present(halo)) then
+    is = G%isc-halo ; ie = G%iec+halo ; js = G%jsc-halo ; je = G%jec+halo
+  endif
+
+  if (GV%Boussinesq .or. (.not.allocated(tv%SpV_avg))) then
+    do j=js,je ; do i=is,ie
+      h_MLD(i,j) = GV%Z_to_H * MLD_in(i,j)
+    enddo ; enddo
+  else  ! The fully non-Boussinesq conversion between height in MLD_in and thickness.
+    if ((allocated(tv%SpV_avg)) .and. (tv%valid_SpV_halo < halos)) then
+      if (tv%valid_SpV_halo < 0) then
+        mesg = "invalid values of SpV_avg."
+      else
+        write(mesg, '("insufficiently large SpV_avg halos of width ", i2, " but ", i2," is needed.")') &
+                     tv%valid_SpV_halo, halos
+      endif
+      call MOM_error(FATAL, "convert_MLD_to_ML_thickness called in fully non-Boussinesq mode with "//trim(mesg))
+    endif
+
+    do j=js,je
+      do i=is,ie ; MLD_rem(i) = MLD_in(i,j) ; h_MLD(i,j) = 0.0 ; enddo
+      do k=1,nz
+        keep_going = .false.
+        do i=is,ie ; if (MLD_rem(i) > 0.0) then
+          if (MLD_rem(i) > GV%H_to_RZ * h(i,j,k) * tv%SpV_avg(i,j,k)) then
+            h_MLD(i,j) = h_MLD(i,j) + h(i,j,k)
+            MLD_rem(i) = MLD_rem(i) - GV%H_to_RZ * h(i,j,k) * tv%SpV_avg(i,j,k)
+            keep_going = .true.
+          else
+            h_MLD(i,j) = h_MLD(i,j) + GV%RZ_to_H * MLD_rem(i) / tv%SpV_avg(i,j,k)
+            MLD_rem(i) = 0.0
+          endif
+        endif ; enddo
+        if (.not.keep_going) exit
+      enddo
+    enddo
+  endif
+
+end subroutine convert_MLD_to_ML_thickness
 
 end module MOM_interface_heights

--- a/src/core/MOM_isopycnal_slopes.F90
+++ b/src/core/MOM_isopycnal_slopes.F90
@@ -70,7 +70,10 @@ subroutine calc_isoneutral_slopes(G, GV, US, h, e, tv, dt_kappa_smooth, use_stan
                   ! in massless layers filled vertically by diffusion.
   real, dimension(SZI_(G), SZJ_(G),SZK_(GV)+1) :: &
     pres          ! The pressure at an interface [R L2 T-2 ~> Pa].
-  real, dimension(SZI_(G)) :: scrap ! An array to pass to calculate_density_second_derivs() that will be ingored.
+  real, dimension(SZI_(G)) :: scrap ! An array to pass to calculate_density_second_derivs() that is
+                  ! set there but will be ignored, it is used simultaneously with four different
+                  ! inconsistent units of [R S-1 C-1 ~> kg m-3 degC-1 ppt-1], [R S-2 ~> kg m-3 ppt-2],
+                  ! [T2 S-1 L-2 ~> kg m-3 ppt-1 Pa-1] and [T2 C-1 L-2 ~> kg m-3 degC-1 Pa-1].
   real, dimension(SZIB_(G)) :: &
     drho_dT_u, &  ! The derivative of density with temperature at u points [R C-1 ~> kg m-3 degC-1].
     drho_dS_u     ! The derivative of density with salinity at u points [R S-1 ~> kg m-3 ppt-1].

--- a/src/core/MOM_open_boundary.F90
+++ b/src/core/MOM_open_boundary.F90
@@ -5028,7 +5028,7 @@ subroutine mask_outside_OBCs(G, US, param_file, OBC)
   integer, parameter :: cin = 3, cout = 4, cland = -1, cedge = -2
   character(len=256) :: mesg    ! Message for error messages.
   real, allocatable, dimension(:,:) :: color, color2  ! For sorting inside from outside,
-                                                      ! two different ways
+                                                      ! two different ways [nondim]
 
   if (.not. associated(OBC)) return
 
@@ -5136,7 +5136,7 @@ end subroutine mask_outside_OBCs
 !> flood the cin, cout values
 subroutine flood_fill(G, color, cin, cout, cland)
   type(dyn_horgrid_type), intent(inout) :: G      !< Ocean grid structure
-  real, dimension(:,:),   intent(inout) :: color  !< For sorting inside from outside
+  real, dimension(:,:),   intent(inout) :: color  !< For sorting inside from outside [nondim]
   integer, intent(in) :: cin    !< color for inside the domain
   integer, intent(in) :: cout   !< color for outside the domain
   integer, intent(in) :: cland  !< color for inside the land mask
@@ -5196,7 +5196,7 @@ end subroutine flood_fill
 !> flood the cin, cout values
 subroutine flood_fill2(G, color, cin, cout, cland)
   type(dyn_horgrid_type), intent(inout) :: G       !< Ocean grid structure
-  real, dimension(:,:),   intent(inout) :: color   !< For sorting inside from outside
+  real, dimension(:,:),   intent(inout) :: color   !< For sorting inside from outside [nondim]
   integer, intent(in) :: cin    !< color for inside the domain
   integer, intent(in) :: cout   !< color for outside the domain
   integer, intent(in) :: cland  !< color for inside the land mask
@@ -5394,7 +5394,10 @@ subroutine update_segment_tracer_reservoirs(G, GV, uhr, vhr, h, OBC, dt, Reg)
                           ! For salinity the units would be [ppt S-1 ~> 1]
   integer :: i, j, k, m, n, ntr, nz, ntr_id, fd_id
   integer :: ishift, idir, jshift, jdir
-  real :: resrv_lfac_out, resrv_lfac_in
+  real :: resrv_lfac_out  ! The reservoir inverse length scale scaling factor for the outward
+                          ! direction per field [nondim]
+  real :: resrv_lfac_in   ! The reservoir inverse length scale scaling factor for the inward
+                          ! direction per field [nondim]
   real :: b_in, b_out     ! The 0 and 1 switch for tracer reservoirs
                           ! 1 if the length scale of reservoir is zero [nondim]
   real :: a_in, a_out     ! The 0 and 1(-1) switch for reservoir source weights

--- a/src/core/MOM_open_boundary.F90
+++ b/src/core/MOM_open_boundary.F90
@@ -3919,7 +3919,7 @@ subroutine update_OBC_segment_data(G, GV, US, OBC, tv, h, Time)
           segment%Htot(I,j) = segment%Htot(I,j) + segment%h(I,j,k)
           segment%dZtot(I,j) = segment%dZtot(I,j) + dz(i+ishift,j,k)
         enddo
-        segment%Cg(I,j) = sqrt(GV%g_prime(1) * segment%dZtot(I,j))
+        segment%Cg(I,j) = sqrt(GV%g_prime(1) * max(0.0, segment%dZtot(I,j)))
       enddo
     else! (segment%direction == OBC_DIRECTION_N .or. segment%direction == OBC_DIRECTION_S)
       allocate(normal_trans_bt(segment%HI%isd:segment%HI%ied,segment%HI%JsdB:segment%HI%JedB), source=0.0)
@@ -3933,7 +3933,7 @@ subroutine update_OBC_segment_data(G, GV, US, OBC, tv, h, Time)
           segment%Htot(i,J) = segment%Htot(i,J) + segment%h(i,J,k)
           segment%dZtot(i,J) = segment%dZtot(i,J) + dz(i,j+jshift,k)
         enddo
-        segment%Cg(i,J) = sqrt(GV%g_prime(1) * segment%dZtot(i,J))
+        segment%Cg(i,J) = sqrt(GV%g_prime(1) * max(0.0, segment%dZtot(i,J)))
       enddo
     endif
 

--- a/src/core/MOM_open_boundary.F90
+++ b/src/core/MOM_open_boundary.F90
@@ -854,7 +854,7 @@ subroutine initialize_segment_data(G, GV, US, OBC, PF)
 !       if (siz(4) == 1) segment%values_needed = .false.
         if (segment%on_pe) then
           if (OBC%brushcutter_mode .and. (modulo(siz(1),2) == 0 .or. modulo(siz(2),2) == 0)) then
-            write(mesg,'("Brushcutter mode sizes ", I6, I6))') siz(1), siz(2)
+            write(mesg,'("Brushcutter mode sizes ", I6, I6)') siz(1), siz(2)
             call MOM_error(WARNING, mesg // " " // trim(filename) // " " // trim(fieldname))
             call MOM_error(FATAL,'segment data are not on the supergrid')
           endif

--- a/src/core/MOM_open_boundary.F90
+++ b/src/core/MOM_open_boundary.F90
@@ -91,28 +91,36 @@ type, public :: OBC_segment_data_type
   character(len=32) :: name                 !< a name identifier for the segment data
   character(len=8)  :: genre                !< an identifier for the segment data
   real              :: scale                !< A scaling factor for converting input data to
-                                            !! the internal units of this field
-  real, allocatable :: buffer_src(:,:,:)    !< buffer for segment data located at cell faces
-                                            !! and on the original vertical grid.  The values for tracers should
-                                            !! have the same units as the field they are being applied to?
+                                            !! the internal units of this field.  For salinity this would
+                                            !! be in units of [S ppt-1 ~> 1]
+  real, allocatable :: buffer_src(:,:,:)    !< buffer for segment data located at cell faces and on
+                                            !! the original vertical grid in the internally scaled
+                                            !! units for the field in question, such as [L T-1 ~> m s-1]
+                                            !! for a velocity or [S ~> ppt] for salinity.
   integer           :: nk_src               !< Number of vertical levels in the source data
   real, allocatable :: dz_src(:,:,:)        !< vertical grid cell spacing of the incoming segment
-                                            !! data, set in [Z ~> m] then scaled to [H ~> m or kg m-2]
-  real, allocatable :: buffer_dst(:,:,:)    !< buffer src data remapped to the target vertical grid.
-                                            !! The values for tracers should have the same units as the field
-                                            !! they are being applied to?
-  real              :: value                !< constant value if not read from file
-  real              :: resrv_lfac_in = 1.   !< reservoir inverse length scale factor for IN direction per field
-                                            !< the general 1/Lscale_IN is multiplied by this factor for each tracer
-  real              :: resrv_lfac_out= 1.   !< reservoir inverse length scale factor for OUT direction per field
-                                            !< the general 1/Lscale_OUT is multiplied by this factor for each tracer
+                                            !! data in [Z ~> m].
+  real, allocatable :: buffer_dst(:,:,:)    !< buffer src data remapped to the target vertical grid
+                                            !! in the internally scaled units for the field in
+                                            !! question, such as [L T-1 ~> m s-1] for a velocity or
+                                            !! [S ~> ppt] for salinity.
+  real              :: value                !< A constant value for the inflow concentration if not read
+                                            !! from file, in the internal units of a field, such as [S ~> ppt]
+                                            !! for salinity.
+  real              :: resrv_lfac_in = 1.   !< The reservoir inverse length scale factor for the inward
+                                            !! direction per field [nondim].  The general 1/Lscale_in is
+                                            !! multiplied by this factor for a specific tracer.
+  real              :: resrv_lfac_out= 1.   !< The reservoir inverse length scale factor for the outward
+                                            !! direction per field [nondim].  The general 1/Lscale_out is
+                                            !! multiplied by this factor for a specific tracer.
 end type OBC_segment_data_type
 
 !> Tracer on OBC segment data structure, for putting into a segment tracer registry.
 type, public :: OBC_segment_tracer_type
   real, allocatable          :: t(:,:,:)              !< tracer concentration array in rescaled units,
                                                       !! like [S ~> ppt] for salinity.
-  real                       :: OBC_inflow_conc = 0.0 !< tracer concentration for generic inflows
+  real                       :: OBC_inflow_conc = 0.0 !< tracer concentration for generic inflows in rescaled units,
+                                                      !! like [S ~> ppt] for salinity.
   character(len=32)          :: name                  !< tracer name used for error messages
   type(tracer_type), pointer :: Tr => NULL()          !< metadata describing the tracer
   real, allocatable          :: tres(:,:,:)           !< tracer reservoir array in rescaled units,
@@ -380,7 +388,7 @@ end type ocean_OBC_type
 !> Control structure for open boundaries that read from files.
 !! Probably lots to update here.
 type, public :: file_OBC_CS ; private
-  real :: tide_flow = 3.0e6         !< Placeholder for now...
+  real :: tide_flow = 3.0e6         !< Placeholder for now..., perhaps in [m3 s-1]?
 end type file_OBC_CS
 
 !> Type to carry something (what??) for the OBC registry.
@@ -402,8 +410,8 @@ type, private :: external_tracers_segments_props
    character(len=128) :: tracer_name      !< tracer name
    character(len=128) :: tracer_src_file  !< tracer source file for BC
    character(len=128) :: tracer_src_field !< name of the field in source file to extract BC
-   real               :: lfac_in  !< multiplicative factor for inbound  tracer reservoir length scale
-   real               :: lfac_out !< multiplicative factor for outbound tracer reservoir length scale
+   real               :: lfac_in  !< multiplicative factor for inbound  tracer reservoir length scale [nondim]
+   real               :: lfac_out !< multiplicative factor for outbound tracer reservoir length scale [nondim]
 end type external_tracers_segments_props
 integer :: id_clock_pass !< A CPU time clock
 
@@ -811,7 +819,7 @@ subroutine initialize_segment_data(G, GV, US, OBC, PF)
 
     obgc_segments_props_list => OBC%obgc_segments_props !pointer to the head node
     do m=1,segment%num_fields
-      if (m .le. num_fields) then
+      if (m <= num_fields) then
         !These are tracers with segments specified in MOM6 style override files
         call parse_segment_data_str(trim(segstr), m, trim(fields(m)), value, filename, fieldname)
       else
@@ -824,8 +832,8 @@ subroutine initialize_segment_data(G, GV, US, OBC, PF)
                                      segment%field(m)%resrv_lfac_in,segment%field(m)%resrv_lfac_out)
         !Make sure the obgc tracer is not specified in the MOM6 param file too.
         do mm=1,num_fields
-          if(trim(fields(m)) == trim(fields(mm))) then
-            if(is_root_pe()) &
+          if (trim(fields(m)) == trim(fields(mm))) then
+            if (is_root_pe()) &
               call MOM_error(FATAL,"MOM_open_boundary:initialize_segment_data(): obgc tracer " //trim(fields(m))// &
                                " appears in OBC_SEGMENT_XXX_DATA string in MOM6 param file. This is not supported!")
           endif
@@ -858,24 +866,24 @@ subroutine initialize_segment_data(G, GV, US, OBC, PF)
             call MOM_error(WARNING, mesg // " " // trim(filename) // " " // trim(fieldname))
             call MOM_error(FATAL,'segment data are not on the supergrid')
           endif
-          siz2(1)=1
+          siz2(1) = 1
 
           if (siz(1)>1) then
             if (OBC%brushcutter_mode) then
-              siz2(1)=(siz(1)-1)/2
+              siz2(1) = (siz(1)-1)/2
             else
-              siz2(1)=siz(1)
+              siz2(1) = siz(1)
             endif
           endif
-          siz2(2)=1
+          siz2(2) = 1
           if (siz(2)>1) then
             if (OBC%brushcutter_mode) then
-              siz2(2)=(siz(2)-1)/2
+              siz2(2) = (siz(2)-1)/2
             else
-              siz2(2)=siz(2)
+              siz2(2) = siz(2)
             endif
           endif
-          siz2(3)=siz(3)
+          siz2(3) = siz(3)
 
           if (segment%is_E_or_W) then
             if (segment%field(m)%name == 'V') then
@@ -986,7 +994,7 @@ subroutine initialize_segment_data(G, GV, US, OBC, PF)
                   allocate(segment%field(m)%dz_src(isd:ied,JsdB:JedB,siz(3)))
                 endif
               endif
-              segment%field(m)%dz_src(:,:,:)=0.0
+              segment%field(m)%dz_src(:,:,:) = 0.0
               segment%field(m)%nk_src=siz(3)
               segment%field(m)%dz_handle = init_external_field(trim(filename), trim(fieldname), &
                         ignore_axis_atts=.true., threading=SINGLE_FILE)
@@ -1746,7 +1754,8 @@ subroutine parse_segment_data_str(segment_str, idx, var, value, filename, fieldn
   character(len=*), intent(out) :: filename     !< The name of the input file if using "file" method
   character(len=*), intent(out) :: fieldname    !< The name of the variable in the input file if using
                                                 !! "file" method
-  real, optional, intent(out)  :: value         !< A constant value if using the "value" method
+  real, optional, intent(out)  :: value         !< A constant value if using the "value" method in various
+                                                !! units but without the internal rescaling [various units]
 
   ! Local variables
   character(len=128) :: word1, word2, word3, method
@@ -1814,8 +1823,7 @@ subroutine parse_for_tracer_reservoirs(OBC, PF, use_temperature)
 
     ! At this point, just search for TEMP and SALT as tracers 1 and 2.
     do m=1,num_fields
-      call parse_segment_data_str(trim(segstr), m, trim(fields(m)), &
-          value, filename, fieldname)
+      call parse_segment_data_str(trim(segstr), m, trim(fields(m)), value, filename, fieldname)
       if (trim(filename) /= 'none') then
         if (fields(m) == 'TEMP') then
           if (segment%is_E_or_W_2) then
@@ -1877,8 +1885,6 @@ subroutine open_boundary_init(G, GV, US, param_file, OBC, restart_CS)
   type(MOM_restart_CS),    intent(in) :: restart_CS !< Restart structure, data intent(inout)
 
   ! Local variables
-  real :: vel2_rescale ! A rescaling factor for squared velocities from the representation in
-                       ! a restart file to the internal representation in this run.
   integer :: i, j, k, isd, ied, jsd, jed, nz, m
   integer :: IsdB, IedB, JsdB, JedB
   isd  = G%isd  ; ied  = G%ied  ; jsd  = G%jsd  ; jed  = G%jed ; nz = GV%ke
@@ -1972,9 +1978,9 @@ end subroutine open_boundary_end
 
 !> Sets the slope of bathymetry normal to an open boundary to zero.
 subroutine open_boundary_impose_normal_slope(OBC, G, depth)
-  type(ocean_OBC_type),             pointer       :: OBC !< Open boundary control structure
-  type(dyn_horgrid_type),           intent(in)    :: G !< Ocean grid structure
-  real, dimension(SZI_(G),SZJ_(G)), intent(inout) :: depth !< Bathymetry at h-points
+  type(ocean_OBC_type),             pointer       :: OBC   !< Open boundary control structure
+  type(dyn_horgrid_type),           intent(in)    :: G     !< Ocean grid structure
+  real, dimension(SZI_(G),SZJ_(G)), intent(inout) :: depth !< Bathymetry at h-points, in [Z ~> m] or other units
   ! Local variables
   integer :: i, j, n
   type(OBC_segment_type), pointer :: segment => NULL()
@@ -3367,11 +3373,11 @@ end subroutine open_boundary_apply_normal_flow
 !> Applies zero values to 3d u,v fields on OBC segments
 subroutine open_boundary_zero_normal_flow(OBC, G, GV, u, v)
   ! Arguments
-  type(ocean_OBC_type),                      pointer       :: OBC !< Open boundary control structure
-  type(ocean_grid_type),                     intent(inout) :: G   !< Ocean grid structure
-  type(verticalGrid_type),                   intent(in)    :: GV  !< The ocean's vertical grid structure
-  real, dimension(SZIB_(G),SZJ_(G),SZK_(GV)), intent(inout) :: u   !< u field to update on open boundaries
-  real, dimension(SZI_(G),SZJB_(G),SZK_(GV)), intent(inout) :: v   !< v field to update on open boundaries
+  type(ocean_OBC_type),                       pointer       :: OBC !< Open boundary control structure
+  type(ocean_grid_type),                      intent(inout) :: G   !< Ocean grid structure
+  type(verticalGrid_type),                    intent(in)    :: GV  !< The ocean's vertical grid structure
+  real, dimension(SZIB_(G),SZJ_(G),SZK_(GV)), intent(inout) :: u   !< u field to update on open boundaries [arbitrary]
+  real, dimension(SZI_(G),SZJB_(G),SZK_(GV)), intent(inout) :: v   !< v field to update on open boundaries [arbitrary]
   ! Local variables
   integer :: i, j, k, n
   type(OBC_segment_type), pointer :: segment => NULL()
@@ -3528,7 +3534,7 @@ subroutine set_tracer_data(OBC, tv, h, G, GV, PF)
   type(verticalGrid_type),                   intent(in)    :: GV  !< The ocean's vertical grid structure
   type(ocean_OBC_type),              target, intent(in)    :: OBC !< Open boundary structure
   type(thermo_var_ptrs),                     intent(inout) :: tv  !< Thermodynamics structure
-  real, dimension(SZI_(G),SZJ_(G),SZK_(GV)), intent(inout) :: h   !< Thickness
+  real, dimension(SZI_(G),SZJ_(G),SZK_(GV)), intent(inout) :: h   !< Layer thicknesses [H ~> m or kg m-2]
   type(param_file_type),                     intent(in)    :: PF  !< Parameter file handle
 
   type(OBC_segment_type), pointer :: segment  => NULL() ! pointer to segment type list
@@ -3791,7 +3797,7 @@ subroutine open_boundary_test_extern_h(G, GV, OBC, h)
 
   if (.not. associated(OBC)) return
 
-  silly_h = GV%Z_to_H * OBC%silly_h
+  silly_h = GV%Z_to_H * OBC%silly_h  ! This rescaling is here because GV was initialized after OBC.
 
   do n = 1, OBC%number_of_segments
     do k = 1, GV%ke
@@ -3844,18 +3850,18 @@ subroutine update_OBC_segment_data(G, GV, US, OBC, tv, h, Time)
   integer :: ishift, jshift  ! offsets for staggered locations
   real, dimension(SZI_(G),SZJ_(G),SZK_(GV))  :: dz ! Distance between the interfaces around a layer [Z ~> m]
   real, dimension(:,:,:), allocatable, target :: tmp_buffer ! A buffer for input data [various units]
-  real, dimension(:), allocatable :: h_stack  ! Thicknesses at corner points [H ~> m or kg m-2]
+  real, dimension(:), allocatable :: dz_stack  ! Distance between the interfaces at corner points [Z ~> m]
   integer :: is_obc2, js_obc2
   integer :: i_seg_offset, j_seg_offset
-  real :: net_H_src   ! Total thickness of the incoming flow in the source field [H ~> m or kg m-2]
-  real :: net_H_int   ! Total thickness of the incoming flow in the model [H ~> m or kg m-2]
+  real :: net_dz_src  ! Total vertical extent of the incoming flow in the source field [Z ~> m]
+  real :: net_dz_int  ! Total vertical extent of the incoming flow in the model [Z ~> m]
   real :: scl_fac     ! A scaling factor to compensate for differences in total thicknesses [nondim]
   real :: tidal_vel   ! Interpolated tidal velocity at the OBC points [L T-1 ~> m s-1]
   real :: tidal_elev  ! Interpolated tidal elevation at the OBC points [Z ~> m]
   real, allocatable :: normal_trans_bt(:,:) ! barotropic transport [H L2 T-1 ~> m3 s-1]
   integer :: turns    ! Number of index quarter turns
   real :: time_delta  ! Time since tidal reference date [T ~> s]
-  real :: h_neglect, h_neglect_edge ! Small thicknesses [H ~> m or kg m-2]
+  real :: dz_neglect, dz_neglect_edge ! Small thicknesses [Z ~> m]
 
   is = G%isc ; ie = G%iec ; js = G%jsc ; je = G%jec
   isd = G%isd ; ied = G%ied ; jsd = G%jsd ; jed = G%jed
@@ -3868,12 +3874,12 @@ subroutine update_OBC_segment_data(G, GV, US, OBC, tv, h, Time)
 
   if (OBC%add_tide_constituents) time_delta = US%s_to_T * time_type_to_real(Time - OBC%time_ref)
 
-  if (OBC%remap_answer_date >= 20190101) then
-    h_neglect = GV%H_subroundoff ; h_neglect_edge = GV%H_subroundoff
-  elseif (GV%Boussinesq) then
-    h_neglect = GV%m_to_H * 1.0e-30 ; h_neglect_edge = GV%m_to_H * 1.0e-10
+  if (GV%Boussinesq .and. (OBC%remap_answer_date < 20190101)) then
+    dz_neglect = US%m_to_Z * 1.0e-30 ; dz_neglect_edge = US%m_to_Z * 1.0e-10
+  elseif (GV%semi_Boussinesq .and. (OBC%remap_answer_date < 20190101)) then
+    dz_neglect = GV%kg_m2_to_H*GV%H_to_Z * 1.0e-30 ; dz_neglect_edge = GV%kg_m2_to_H*GV%H_to_Z * 1.0e-10
   else
-    h_neglect = GV%kg_m2_to_H * 1.0e-30 ; h_neglect_edge = GV%kg_m2_to_H * 1.0e-10
+    dz_neglect = GV%dZ_subroundoff ; dz_neglect_edge = GV%dZ_subroundoff
   endif
 
   if (OBC%number_of_segments >= 1) then
@@ -3937,16 +3943,16 @@ subroutine update_OBC_segment_data(G, GV, US, OBC, tv, h, Time)
       enddo
     endif
 
-    allocate(h_stack(GV%ke), source=0.0)
+    allocate(dz_stack(GV%ke), source=0.0)
     do m = 1,segment%num_fields
       !This field may not require a high frequency OBC segment update and might be allowed
       !a less frequent update as set by the parameter update_OBC_period_max in MOM.F90.
       !Cycle if it is not the time to update OBC segment data for this field.
       if (trim(segment%field(m)%genre) == 'obgc' .and. (.not. OBC%update_OBC_seg_data)) cycle
       if (segment%field(m)%use_IO) then
-        siz(1)=size(segment%field(m)%buffer_src,1)
-        siz(2)=size(segment%field(m)%buffer_src,2)
-        siz(3)=size(segment%field(m)%buffer_src,3)
+        siz(1) = size(segment%field(m)%buffer_src,1)
+        siz(2) = size(segment%field(m)%buffer_src,2)
+        siz(3) = size(segment%field(m)%buffer_src,3)
         if (.not.allocated(segment%field(m)%buffer_dst)) then
           if (siz(3) /= segment%field(m)%nk_src) call MOM_error(FATAL,'nk_src inconsistency')
           if (segment%field(m)%nk_src > 1) then
@@ -3990,7 +3996,7 @@ subroutine update_OBC_segment_data(G, GV, US, OBC, tv, h, Time)
               endif
             endif
           endif
-          segment%field(m)%buffer_dst(:,:,:)=0.0
+          segment%field(m)%buffer_dst(:,:,:) = 0.0
         endif
         ! read source data interpolated to the current model time
         ! NOTE: buffer is sized for vertex points, but may be used for faces
@@ -4149,6 +4155,7 @@ subroutine update_OBC_segment_data(G, GV, US, OBC, tv, h, Time)
             endif
           endif
 
+          ! The units of ...%dz_src are no longer changed from [Z ~> m] to [H ~> m or kg m-2] here.
           call adjustSegmentEtaToFitBathymetry(G,GV,US,segment,m)
 
           if (segment%is_E_or_W) then
@@ -4160,44 +4167,44 @@ subroutine update_OBC_segment_data(G, GV, US, OBC, tv, h, Time)
               do J=max(js_obc,jsd),min(je_obc,jed-1)
                 ! Using the h remapping approach
                 ! Pretty sure we need to check for source/target grid consistency here
-                segment%field(m)%buffer_dst(I,J,:)=0.0  ! initialize remap destination buffer
+                segment%field(m)%buffer_dst(I,J,:) = 0.0  ! initialize remap destination buffer
                 if (G%mask2dCu(I,j)>0. .and. G%mask2dCu(I,j+1)>0.) then
-                  h_stack(:) = 0.5*(h(i+ishift,j,:) + h(i+ishift,j+1,:))
+                  dz_stack(:) = 0.5*(dz(i+ishift,j,:) + dz(i+ishift,j+1,:))
                   call remapping_core_h(OBC%remap_CS, &
-                       segment%field(m)%nk_src,segment%field(m)%dz_src(I,J,:), &
+                       segment%field(m)%nk_src, segment%field(m)%dz_src(I,J,:), &
                        segment%field(m)%buffer_src(I,J,:), &
-                       GV%ke, h_stack, segment%field(m)%buffer_dst(I,J,:), &
-                       h_neglect, h_neglect_edge)
+                       GV%ke, dz_stack, segment%field(m)%buffer_dst(I,J,:), &
+                       dz_neglect, dz_neglect_edge)
                 elseif (G%mask2dCu(I,j)>0.) then
-                  h_stack(:) = h(i+ishift,j,:)
+                  dz_stack(:) = dz(i+ishift,j,:)
                   call remapping_core_h(OBC%remap_CS, &
-                       segment%field(m)%nk_src,segment%field(m)%dz_src(I,J,:), &
+                       segment%field(m)%nk_src, segment%field(m)%dz_src(I,J,:), &
                        segment%field(m)%buffer_src(I,J,:), &
-                       GV%ke, h_stack, segment%field(m)%buffer_dst(I,J,:), &
-                       h_neglect, h_neglect_edge)
+                       GV%ke, dz_stack, segment%field(m)%buffer_dst(I,J,:), &
+                       dz_neglect, dz_neglect_edge)
                 elseif (G%mask2dCu(I,j+1)>0.) then
-                  h_stack(:) = h(i+ishift,j+1,:)
+                  dz_stack(:) = dz(i+ishift,j+1,:)
                   call remapping_core_h(OBC%remap_CS, &
-                       segment%field(m)%nk_src,segment%field(m)%dz_src(I,j,:), &
+                       segment%field(m)%nk_src, segment%field(m)%dz_src(I,j,:), &
                        segment%field(m)%buffer_src(I,J,:), &
-                       GV%ke, h_stack, segment%field(m)%buffer_dst(I,J,:), &
-                       h_neglect, h_neglect_edge)
+                       GV%ke, dz_stack, segment%field(m)%buffer_dst(I,J,:), &
+                       dz_neglect, dz_neglect_edge)
                 endif
               enddo
             else
               do j=js_obc+1,je_obc
                 ! Using the h remapping approach
                 ! Pretty sure we need to check for source/target grid consistency here
-                segment%field(m)%buffer_dst(I,j,:)=0.0  ! initialize remap destination buffer
+                segment%field(m)%buffer_dst(I,j,:) = 0.0  ! initialize remap destination buffer
                 if (G%mask2dCu(I,j)>0.) then
-                  net_H_src = sum( segment%field(m)%dz_src(I,j,:) )
-                  net_H_int = sum( h(i+ishift,j,:) )
-                  scl_fac = net_H_int / net_H_src
+                  net_dz_src = sum( segment%field(m)%dz_src(I,j,:) )
+                  net_dz_int = sum( dz(i+ishift,j,:) )
+                  scl_fac = net_dz_int / net_dz_src
                   call remapping_core_h(OBC%remap_CS, &
-                       segment%field(m)%nk_src, scl_fac*segment%field(m)%dz_src(I,j,:), &
+                       segment%field(m)%nk_src,  scl_fac*segment%field(m)%dz_src(I,j,:), &
                        segment%field(m)%buffer_src(I,j,:), &
-                       GV%ke, h(i+ishift,j,:), segment%field(m)%buffer_dst(I,j,:), &
-                       h_neglect, h_neglect_edge)
+                       GV%ke, dz(i+ishift,j,:), segment%field(m)%buffer_dst(I,j,:), &
+                       dz_neglect, dz_neglect_edge)
                 endif
               enddo
             endif
@@ -4208,46 +4215,46 @@ subroutine update_OBC_segment_data(G, GV, US, OBC, tv, h, Time)
             if (segment%field(m)%name == 'U' .or. segment%field(m)%name == 'DUDY') then
               ! Do q points for the whole segment
               do I=max(is_obc,isd),min(ie_obc,ied-1)
-                segment%field(m)%buffer_dst(I,J,:)=0.0  ! initialize remap destination buffer
+                segment%field(m)%buffer_dst(I,J,:) = 0.0  ! initialize remap destination buffer
                 if (G%mask2dCv(i,J)>0. .and. G%mask2dCv(i+1,J)>0.) then
               ! Using the h remapping approach
               ! Pretty sure we need to check for source/target grid consistency here
-                  h_stack(:) = 0.5*(h(i,j+jshift,:) + h(i+1,j+jshift,:))
+                  dz_stack(:) = 0.5*(dz(i,j+jshift,:) + dz(i+1,j+jshift,:))
                   call remapping_core_h(OBC%remap_CS, &
-                       segment%field(m)%nk_src,segment%field(m)%dz_src(I,J,:), &
+                       segment%field(m)%nk_src, segment%field(m)%dz_src(I,J,:), &
                        segment%field(m)%buffer_src(I,J,:), &
-                       GV%ke, h_stack, segment%field(m)%buffer_dst(I,J,:), &
-                       h_neglect, h_neglect_edge)
+                       GV%ke, dz_stack, segment%field(m)%buffer_dst(I,J,:), &
+                       dz_neglect, dz_neglect_edge)
                 elseif (G%mask2dCv(i,J)>0.) then
-                  h_stack(:) = h(i,j+jshift,:)
+                  dz_stack(:) = dz(i,j+jshift,:)
                   call remapping_core_h(OBC%remap_CS, &
-                       segment%field(m)%nk_src,segment%field(m)%dz_src(I,J,:), &
+                       segment%field(m)%nk_src, segment%field(m)%dz_src(I,J,:), &
                        segment%field(m)%buffer_src(I,J,:), &
-                       GV%ke, h_stack, segment%field(m)%buffer_dst(I,J,:), &
-                       h_neglect, h_neglect_edge)
+                       GV%ke, dz_stack, segment%field(m)%buffer_dst(I,J,:), &
+                       dz_neglect, dz_neglect_edge)
                 elseif (G%mask2dCv(i+1,J)>0.) then
-                  h_stack(:) = h(i+1,j+jshift,:)
+                  dz_stack(:) = dz(i+1,j+jshift,:)
                   call remapping_core_h(OBC%remap_CS, &
-                       segment%field(m)%nk_src,segment%field(m)%dz_src(I,J,:), &
+                       segment%field(m)%nk_src, segment%field(m)%dz_src(I,J,:), &
                        segment%field(m)%buffer_src(I,J,:), &
-                       GV%ke, h_stack, segment%field(m)%buffer_dst(I,J,:), &
-                       h_neglect, h_neglect_edge)
+                       GV%ke, dz_stack, segment%field(m)%buffer_dst(I,J,:), &
+                       dz_neglect, dz_neglect_edge)
                 endif
               enddo
             else
               do i=is_obc+1,ie_obc
               ! Using the h remapping approach
               ! Pretty sure we need to check for source/target grid consistency here
-                segment%field(m)%buffer_dst(i,J,:)=0.0  ! initialize remap destination buffer
+                segment%field(m)%buffer_dst(i,J,:) = 0.0  ! initialize remap destination buffer
                 if (G%mask2dCv(i,J)>0.) then
-                  net_H_src = sum( segment%field(m)%dz_src(i,J,:) )
-                  net_H_int = sum( h(i,j+jshift,:) )
-                  scl_fac = net_H_int / net_H_src
+                  net_dz_src = sum( segment%field(m)%dz_src(i,J,:) )
+                  net_dz_int = sum( dz(i,j+jshift,:) )
+                  scl_fac = net_dz_int / net_dz_src
                   call remapping_core_h(OBC%remap_CS, &
-                       segment%field(m)%nk_src, scl_fac*segment%field(m)%dz_src(i,J,:), &
+                       segment%field(m)%nk_src, scl_fac* segment%field(m)%dz_src(i,J,:), &
                        segment%field(m)%buffer_src(i,J,:), &
-                       GV%ke, h(i,j+jshift,:), segment%field(m)%buffer_dst(i,J,:), &
-                       h_neglect, h_neglect_edge)
+                       GV%ke, dz(i,j+jshift,:), segment%field(m)%buffer_dst(i,J,:), &
+                       dz_neglect, dz_neglect_edge)
                 endif
               enddo
             endif
@@ -4496,7 +4503,7 @@ subroutine update_OBC_segment_data(G, GV, US, OBC, tv, h, Time)
         endif
       elseif (trim(segment%field(m)%genre) == 'obgc') then
         nt=get_tracer_index(segment,trim(segment%field(m)%name))
-        if(nt .lt. 0) then
+        if (nt < 0) then
           call MOM_error(FATAL,"update_OBC_segment_data: Did not find tracer "//trim(segment%field(m)%name))
         endif
         if (allocated(segment%field(m)%buffer_dst)) then
@@ -4516,7 +4523,7 @@ subroutine update_OBC_segment_data(G, GV, US, OBC, tv, h, Time)
       endif
 
     enddo ! end field loop
-    deallocate(h_stack)
+    deallocate(dz_stack)
     deallocate(normal_trans_bt)
 
   enddo ! end segment loop
@@ -4698,16 +4705,19 @@ subroutine register_segment_tracer(tr_ptr, ntr_index, param_file, GV, segment, &
   type(OBC_segment_type), intent(inout) :: segment    !< current segment data structure
   real,         optional, intent(in)    :: OBC_scalar !< If present, use scalar value for segment tracer
                                                       !! inflow concentration, including any rescaling to
-                                                      !! put the tracer concentration into its internal units.
+                                                      !! put the tracer concentration into its internal units,
+                                                      !! like [S ~> ppt] for salinity.
   logical,      optional, intent(in)    :: OBC_array  !< If true, use array values for segment tracer
                                                       !! inflow concentration.
   real,         optional, intent(in)    :: scale      !< A scaling factor that should be used with any
-                                                      !! data that is read in, to convert it to the internal
-                                                      !! units of this tracer.
+                                                      !! data that is read in to convert it to the internal
+                                                      !! units of this tracer, in units like [S ppt-1 ~> 1]
+                                                      !! for salinity.
   integer,      optional, intent(in)    :: fd_index   !< index of segment tracer in the input field
 
 ! Local variables
-  real :: rescale ! A multiplicative correction to the scaling factor.
+  real :: rescale ! A multiplicatively corrected scaling factor, in units like [S ppt-1 ~> 1] for
+                  ! salinity, or other various units depending on what rescaling has occurred previously.
   integer :: ntseg, m, isd, ied, jsd, jed, IsdB, IedB, JsdB, JedB
   character(len=256) :: mesg    ! Message for error messages.
 
@@ -4824,8 +4834,8 @@ subroutine set_obgc_segments_props(OBC,tr_name,obc_src_file_name,obc_src_field_n
   character(len=*),  intent(in) :: tr_name            !< Tracer name
   character(len=*),  intent(in) :: obc_src_file_name  !< OBC source file name
   character(len=*),  intent(in) :: obc_src_field_name !< name of the field in the source file
-  real,              intent(in) :: lfac_in            !< factors for tracer reservoir length scales
-  real,              intent(in) :: lfac_out           !< factors for tracer reservoir length scales
+  real,              intent(in) :: lfac_in            !< factors for tracer reservoir inbound length scales [nondim]
+  real,              intent(in) :: lfac_out           !< factors for tracer reservoir outbound length scales [nondim]
 
   type(external_tracers_segments_props),pointer :: node_ptr => NULL() !pointer to type that keeps
                                                                     ! the tracer segment properties
@@ -4848,8 +4858,8 @@ subroutine get_obgc_segments_props(node, tr_name,obc_src_file_name,obc_src_field
   character(len=*), intent(out) :: tr_name            !< Tracer name
   character(len=*), intent(out) :: obc_src_file_name  !< OBC source file name
   character(len=*), intent(out) :: obc_src_field_name !< name of the field in the source file
-  real,             intent(out) :: lfac_in   !< multiplicative factor for inbound  reservoir length scale
-  real,             intent(out) :: lfac_out  !< multiplicative factor for outbound reservoir length scale
+  real,             intent(out) :: lfac_in   !< multiplicative factor for inbound  reservoir length scale [nondim]
+  real,             intent(out) :: lfac_out  !< multiplicative factor for outbound reservoir length scale [nondim]
   tr_name = trim(node%tracer_name)
   obc_src_file_name = trim(node%tracer_src_file)
   obc_src_field_name = trim(node%tracer_src_field)
@@ -4890,13 +4900,14 @@ subroutine fill_obgc_segments(G, GV, OBC, tr_ptr, tr_name)
   type(ocean_grid_type),      intent(inout) :: G      !< Ocean grid structure
   type(verticalGrid_type),    intent(in)    :: GV     !< ocean vertical grid structure
   type(ocean_OBC_type),       pointer       :: OBC    !< Open boundary structure
-  real, dimension(:,:,:),     pointer       :: tr_ptr !< Pointer to tracer field
-  character(len=*),           intent(in)    :: tr_name!< Tracer name
+  real, dimension(:,:,:),     pointer       :: tr_ptr !< Pointer to tracer field in scaled concentration
+                                                      !! units, like [S ~> ppt] for salinity.
+  character(len=*),           intent(in)    :: tr_name !< Tracer name
 ! Local variables
   integer :: isd, ied, IsdB, IedB, jsd, jed, JsdB, JedB, n, nz, nt
   integer :: i, j, k
   type(OBC_segment_type), pointer :: segment => NULL() ! pointer to segment type list
-  real :: I_scale
+  real :: I_scale  ! A factor that unscales the internal units of a tracer, like [ppt S-1 ~> 1] for salinity
 
   if (.not. associated(OBC)) return
   call pass_var(tr_ptr, G%Domain)
@@ -4905,7 +4916,7 @@ subroutine fill_obgc_segments(G, GV, OBC, tr_ptr, tr_name)
     segment => OBC%segment(n)
     if (.not. segment%on_pe) cycle
     nt=get_tracer_index(segment,tr_name)
-    if(nt .lt. 0) then
+    if (nt < 0) then
       call MOM_error(FATAL,"fill_obgc_segments: Did not find tracer "// tr_name)
     endif
     isd = segment%HI%isd ; ied = segment%HI%ied
@@ -5414,7 +5425,7 @@ subroutine update_segment_tracer_reservoirs(G, GV, uhr, vhr, h, OBC, dt, Reg)
         do m=1,segment%tr_Reg%ntseg
           ntr_id = segment%tr_reg%Tr(m)%ntr_index
           fd_id = segment%tr_reg%Tr(m)%fd_index
-          if(fd_id == -1) then
+          if (fd_id == -1) then
             resrv_lfac_out = 1.0
             resrv_lfac_in  = 1.0
           else
@@ -5458,7 +5469,7 @@ subroutine update_segment_tracer_reservoirs(G, GV, uhr, vhr, h, OBC, dt, Reg)
         do m=1,segment%tr_Reg%ntseg
           ntr_id = segment%tr_reg%Tr(m)%ntr_index
           fd_id = segment%tr_reg%Tr(m)%fd_index
-          if(fd_id == -1) then
+          if (fd_id == -1) then
             resrv_lfac_out = 1.0
             resrv_lfac_in  = 1.0
           else
@@ -5500,7 +5511,8 @@ subroutine remap_OBC_fields(G, GV, h_old, h_new, OBC, PCM_cell)
   ! Local variables
   type(OBC_segment_type), pointer :: segment => NULL() ! A pointer to the various segments, used just for shorthand.
 
-  real :: tr_column(GV%ke)  ! A column of updated tracer concentrations [CU ~> Conc]
+  real :: tr_column(GV%ke)  ! A column of updated tracer concentrations in internally scaled units.
+                        ! For salinity the units would be [S ~> ppt].
   real :: r_norm_col(GV%ke) ! A column of updated radiation rates, in grid points per timestep [nondim]
   real :: rxy_col(GV%ke) ! A column of updated radiation rates for oblique OBCs [L2 T-2 ~> m2 s-2]
   real :: h1(GV%ke)     ! A column of source grid layer thicknesses [H ~> m or kg m-2]
@@ -5706,14 +5718,14 @@ subroutine adjustSegmentEtaToFitBathymetry(G, GV, US, segment,fld)
   allocate(eta(is:ie,js:je,nz+1))
   contractions=0; dilations=0
   do j=js,je ; do i=is,ie
-    eta(i,j,1)=0.0   ! segment data are assumed to be located on a static grid
+    eta(i,j,1) = 0.0  ! segment data are assumed to be located on a static grid
     ! For remapping calls, the entire column will be dilated
     ! by a factor equal to the ratio of the sum of the geopotential referenced
     ! source data thicknesses, and the current model thicknesses. This could be
     ! an issue to be addressed, for instance if we are placing open boundaries
     ! under ice shelf cavities.
     do k=2,nz+1
-      eta(i,j,k)=eta(i,j,k-1)-segment%field(fld)%dz_src(i,j,k-1)
+      eta(i,j,k) = eta(i,j,k-1) - segment%field(fld)%dz_src(i,j,k-1)
     enddo
     ! The normal slope at the boundary is zero by a
     ! previous call to open_boundary_impose_normal_slope
@@ -5741,7 +5753,7 @@ subroutine adjustSegmentEtaToFitBathymetry(G, GV, US, segment,fld)
       dilations = dilations + 1
       ! expand bottom-most cell only
       eta(i,j,nz+1) = -segment%dZtot(i,j)
-      segment%field(fld)%dz_src(i,j,nz)= eta(i,j,nz)-eta(i,j,nz+1)
+      segment%field(fld)%dz_src(i,j,nz) = eta(i,j,nz) - eta(i,j,nz+1)
       ! if (eta(i,j,1) <= eta(i,j,nz+1)) then
       !   do k=1,nz ; segment%field(fld)%dz_src(i,j,k) = (eta(i,j,1) + G%bathyT(i,j)) / real(nz) ; enddo
       ! else
@@ -5750,10 +5762,6 @@ subroutine adjustSegmentEtaToFitBathymetry(G, GV, US, segment,fld)
       ! endif
       !do k=nz,2,-1 ; eta(i,j,K) = eta(i,j,K+1) + segment%field(fld)%dz_src(i,j,k) ; enddo
     endif
-    ! Now convert thicknesses to units of H.
-    do k=1,nz
-      segment%field(fld)%dz_src(i,j,k) = segment%field(fld)%dz_src(i,j,k)*GV%Z_to_H
-    enddo
   enddo ; enddo
 
   ! can not do communication call here since only PEs on the current segment are here

--- a/src/core/MOM_porous_barriers.F90
+++ b/src/core/MOM_porous_barriers.F90
@@ -168,9 +168,10 @@ subroutine porous_widths_layer(h, tv, G, GV, US, pbv, CS, eta_bt)
 
   if (CS%debug) then
     call uvchksum("Interface height used by porous barrier for layer weights", &
-                  eta_u, eta_v, G%HI, haloshift=0)
+                  eta_u, eta_v, G%HI, haloshift=0, scalar_pair=.true.)
     call uvchksum("Porous barrier layer-averaged weights: por_face_area[UV]", &
-                  pbv%por_face_areaU, pbv%por_face_areaV, G%HI, haloshift=0)
+                  pbv%por_face_areaU, pbv%por_face_areaV, G%HI, haloshift=0, &
+                  scalar_pair=.true.)
   endif
 
   if (CS%id_por_face_areaU > 0) call post_data(CS%id_por_face_areaU, pbv%por_face_areaU, CS%diag)
@@ -256,9 +257,10 @@ subroutine porous_widths_interface(h, tv, G, GV, US, pbv, CS, eta_bt)
 
   if (CS%debug) then
     call uvchksum("Interface height used by porous barrier for interface weights", &
-                  eta_u, eta_v, G%HI, haloshift=0)
+                  eta_u, eta_v, G%HI, haloshift=0, scalar_pair=.true.)
     call uvchksum("Porous barrier weights at the layer-interface: por_layer_width[UV]", &
-                  pbv%por_layer_widthU, pbv%por_layer_widthV, G%HI, haloshift=0)
+                  pbv%por_layer_widthU, pbv%por_layer_widthV, G%HI, &
+                  haloshift=0, scalar_pair=.true.)
   endif
 
   if (CS%id_por_layer_widthU > 0) call post_data(CS%id_por_layer_widthU, pbv%por_layer_widthU, CS%diag)

--- a/src/core/MOM_unit_tests.F90
+++ b/src/core/MOM_unit_tests.F90
@@ -4,15 +4,16 @@ module MOM_unit_tests
 ! This file is part of MOM6. See LICENSE.md for the license.
 
 use MOM_error_handler,              only : MOM_error, FATAL, is_root_pe
-
-use MOM_string_functions,           only : string_functions_unit_tests
-use MOM_remapping,                  only : remapping_unit_tests
+use MOM_hor_bnd_diffusion,          only : near_boundary_unit_tests
+use MOM_intrinsic_functions,        only : intrinsic_functions_unit_tests
+use MOM_mixed_layer_restrat,        only : mixedlayer_restrat_unit_tests
 use MOM_neutral_diffusion,          only : neutral_diffusion_unit_tests
 use MOM_random,                     only : random_unit_tests
-use MOM_hor_bnd_diffusion,          only : near_boundary_unit_tests
+use MOM_remapping,                  only : remapping_unit_tests
+use MOM_string_functions,           only : string_functions_unit_tests
 use MOM_CFC_cap,                    only : CFC_cap_unit_tests
 use MOM_EOS,                        only : EOS_unit_tests
-use MOM_mixed_layer_restrat,        only : mixedlayer_restrat_unit_tests
+
 implicit none ; private
 
 public unit_tests
@@ -36,6 +37,8 @@ subroutine unit_tests(verbosity)
        "MOM_unit_tests: EOS_unit_tests FAILED")
     if (remapping_unit_tests(verbose)) call MOM_error(FATAL, &
        "MOM_unit_tests: remapping_unit_tests FAILED")
+    if (intrinsic_functions_unit_tests(verbose)) call MOM_error(FATAL, &
+       "MOM_unit_tests: intrinsic_functions_unit_tests FAILED")
     if (neutral_diffusion_unit_tests(verbose)) call MOM_error(FATAL, &
        "MOM_unit_tests: neutralDiffusionUnitTests FAILED")
     if (random_unit_tests(verbose)) call MOM_error(FATAL, &

--- a/src/core/MOM_variables.F90
+++ b/src/core/MOM_variables.F90
@@ -263,7 +263,8 @@ type, public :: vertvisc_type
     Ray_v       !< The Rayleigh drag velocity to be applied to each layer at v-points [H T-1 ~> m s-1 or Pa s m-1].
 
   ! The following elements are pointers so they can be used as targets for pointers in the restart registry.
-  real, pointer, dimension(:,:) :: MLD => NULL() !< Instantaneous active mixing layer depth [Z ~> m].
+  real, pointer, dimension(:,:) :: MLD => NULL()  !< Instantaneous active mixing layer depth [Z ~> m].
+  real, pointer, dimension(:,:) :: h_ML => NULL() !< Instantaneous active mixing layer thickness [H ~> m or kg m-2].
   real, pointer, dimension(:,:) :: sfc_buoy_flx => NULL() !< Surface buoyancy flux (derived) [Z2 T-3 ~> m2 s-3].
   real, pointer, dimension(:,:,:) :: Kd_shear => NULL()
                 !< The shear-driven turbulent diapycnal diffusivity at the interfaces between layers

--- a/src/core/MOM_variables.F90
+++ b/src/core/MOM_variables.F90
@@ -6,6 +6,7 @@ module MOM_variables
 use MOM_array_transform, only : rotate_array, rotate_vector
 use MOM_coupler_types, only : coupler_1d_bc_type, coupler_2d_bc_type
 use MOM_coupler_types, only : coupler_type_spawn, coupler_type_destructor, coupler_type_initialized
+use MOM_coupler_types, only : coupler_type_copy_data
 use MOM_debugging,     only : hchksum
 use MOM_domains,       only : MOM_domain_type, get_domain_extent, group_pass_type
 use MOM_EOS,           only : EOS_type
@@ -499,9 +500,11 @@ subroutine rotate_surface_state(sfc_state_in, sfc_state, G, turns)
   sfc_state%T_is_conT = sfc_state_in%T_is_conT
   sfc_state%S_is_absS = sfc_state_in%S_is_absS
 
-  ! TODO: tracer field rotation
-  if (coupler_type_initialized(sfc_state_in%tr_fields)) &
-    call MOM_error(FATAL, "Rotation of surface state tracers is not yet implemented.")
+  ! NOTE: Tracer fields are handled by FMS, so are left unrotated.  Any
+  ! reads/writes to tr_fields must be appropriately rotated.
+  if (coupler_type_initialized(sfc_state_in%tr_fields)) then
+    call coupler_type_copy_data(sfc_state_in%tr_fields, sfc_state%tr_fields)
+  endif
 end subroutine rotate_surface_state
 
 !> Allocates the arrays contained within a BT_cont_type and initializes them to 0.

--- a/src/core/MOM_verticalGrid.F90
+++ b/src/core/MOM_verticalGrid.F90
@@ -35,8 +35,12 @@ type, public :: verticalGrid_type
   character(len=40) :: zAxisUnits !< The units that vertical coordinates are written in
   character(len=40) :: zAxisLongName !< Coordinate name to appear in files,
                                   !! e.g. "Target Potential Density" or "Height"
-  real, allocatable, dimension(:) :: sLayer !< Coordinate values of layer centers
-  real, allocatable, dimension(:) :: sInterface !< Coordinate values on interfaces
+  real, allocatable, dimension(:) :: sLayer !< Coordinate values of layer centers, in unscaled
+                        !! units that depend on the vertical coordinate, such as [kg m-3] for an
+                        !! isopycnal or some hybrid coordinates, [m] for a Z* coordinate,
+                        !! or [nondim] for a sigma coordinate.
+  real, allocatable, dimension(:) :: sInterface !< Coordinate values on interfaces, in the same
+                        !! unscale units as sLayer [various].
   integer :: direction = 1 !< Direction defaults to 1, positive up.
 
   ! The following variables give information about the vertical grid.
@@ -326,9 +330,11 @@ end function get_tr_flux_units
 
 !> This sets the coordinate data for the "layer mode" of the isopycnal model.
 subroutine setVerticalGridAxes( Rlay, GV, scale )
-  type(verticalGrid_type), intent(inout) :: GV   !< The container for vertical grid data
-  real, dimension(GV%ke),  intent(in)    :: Rlay !< The layer target density [R ~> kg m-3]
-  real,                    intent(in)    :: scale !< A unit scaling factor for Rlay
+  type(verticalGrid_type), intent(inout) :: GV    !< The container for vertical grid data
+  real, dimension(GV%ke),  intent(in)    :: Rlay  !< The layer target density [R ~> kg m-3]
+  real,                    intent(in)    :: scale !< A unit scaling factor for Rlay to convert
+                                                  !! it into the units of sInterface, usually
+                                                  !! [kg m-3 R-1 ~> 1] when used in layer mode.
   ! Local variables
   integer :: k, nk
 

--- a/src/diagnostics/MOM_PointAccel.F90
+++ b/src/diagnostics/MOM_PointAccel.F90
@@ -95,9 +95,10 @@ subroutine write_u_accel(I, j, um, hin, ADp, CDp, dt, G, GV, US, CS, vel_rpt, st
   real    :: du               ! A velocity change [L T-1 ~> m s-1]
   real    :: Inorm(SZK_(GV))  ! The inverse of the normalized velocity change [L T-1 ~> m s-1]
   real    :: e(SZK_(GV)+1)    ! Simple estimates of interface heights based on the sum of thicknesses [m]
-  real    :: h_scale          ! A scaling factor for thicknesses [m H-1 ~> 1 or m3 kg-1]
+  real    :: h_scale          ! A scaling factor for thicknesses [m H-1 ~> 1] or [kg m-2 H-1 ~> 1]
   real    :: vel_scale        ! A scaling factor for velocities [m T s-1 L-1 ~> 1]
-  real    :: uh_scale         ! A scaling factor for transport per unit length [m2 T s-1 L-1 H-1 ~> 1 or m3 kg-1]
+  real    :: uh_scale         ! A scaling factor for transport per unit length [m2 T s-1 L-1 H-1 ~> 1]
+                              ! or [kg T m-1 s-1 L-1 H-1 ~> 1]
   real    :: temp_scale       ! A scaling factor for temperatures [degC C-1 ~> 1]
   real    :: saln_scale       ! A scaling factor for salinities [ppt S-1 ~> 1]
   integer :: yr, mo, day, hr, minute, sec, yearday
@@ -108,7 +109,7 @@ subroutine write_u_accel(I, j, um, hin, ADp, CDp, dt, G, GV, US, CS, vel_rpt, st
   integer :: file
 
   Angstrom = GV%Angstrom_H + GV%H_subroundoff
-  h_scale = GV%H_to_m ; vel_scale = US%L_T_to_m_s ; uh_scale = GV%H_to_m*US%L_T_to_m_s
+  h_scale = GV%H_to_mks ; vel_scale = US%L_T_to_m_s ; uh_scale = h_scale*vel_scale
   temp_scale = US%C_to_degC ; saln_scale = US%S_to_ppt
 
 !  if (.not.associated(CS)) return
@@ -232,7 +233,7 @@ subroutine write_u_accel(I, j, um, hin, ADp, CDp, dt, G, GV, US, CS, vel_rpt, st
       do k=ks,ke ; if (do_k(k)) write(file,'(ES10.3," ")', advance='no') h_scale*hv(I,j,k) ; enddo
     endif
     if (present(str)) then
-      write(file,'(/,"Stress:  ",ES10.3)', advance='no') vel_scale*US%Z_to_m * (str*dt / GV%Rho0)
+      write(file,'(/,"Stress:  ",ES10.3)', advance='no') (uh_scale*GV%RZ_to_H) * (str*dt)
     endif
 
     if (associated(CS%u_accel_bt)) then
@@ -435,9 +436,10 @@ subroutine write_v_accel(i, J, vm, hin, ADp, CDp, dt, G, GV, US, CS, vel_rpt, st
   real    :: dv               ! A velocity change [L T-1 ~> m s-1]
   real    :: Inorm(SZK_(GV))  ! The inverse of the normalized velocity change [L T-1 ~> m s-1]
   real    :: e(SZK_(GV)+1)    ! Simple estimates of interface heights based on the sum of thicknesses [m]
-  real    :: h_scale          ! A scaling factor for thicknesses [m H-1 ~> 1 or m3 kg-1]
+  real    :: h_scale          ! A scaling factor for thicknesses [m H-1 ~> 1] or [kg m-2 H-1 ~> 1]
   real    :: vel_scale        ! A scaling factor for velocities [m T s-1 L-1 ~> 1]
-  real    :: uh_scale         ! A scaling factor for transport per unit length [m2 T s-1 L-1 H-1 ~> 1 or m3 kg-1]
+  real    :: uh_scale         ! A scaling factor for transport per unit length [m2 T s-1 L-1 H-1 ~> 1]
+                              ! or [kg T m-1 s-1 L-1 H-1 ~> 1]
   real    :: temp_scale       ! A scaling factor for temperatures [degC C-1 ~> 1]
   real    :: saln_scale       ! A scaling factor for salinities [ppt S-1 ~> 1]
   integer :: yr, mo, day, hr, minute, sec, yearday
@@ -448,7 +450,7 @@ subroutine write_v_accel(i, J, vm, hin, ADp, CDp, dt, G, GV, US, CS, vel_rpt, st
   integer :: file
 
   Angstrom = GV%Angstrom_H + GV%H_subroundoff
-  h_scale = GV%H_to_m ; vel_scale = US%L_T_to_m_s ; uh_scale = GV%H_to_m*US%L_T_to_m_s
+  h_scale = GV%H_to_mks ; vel_scale = US%L_T_to_m_s ; uh_scale = h_scale*vel_scale
   temp_scale = US%C_to_degC ; saln_scale = US%S_to_ppt
 
 !  if (.not.associated(CS)) return
@@ -576,7 +578,7 @@ subroutine write_v_accel(i, J, vm, hin, ADp, CDp, dt, G, GV, US, CS, vel_rpt, st
       do k=ks,ke ; if (do_k(k)) write(file,'(ES10.3," ")', advance='no') h_scale*hv(i,J,k) ; enddo
     endif
     if (present(str)) then
-      write(file,'(/,"Stress:  ",ES10.3)', advance='no') vel_scale*US%Z_to_m * (str*dt / GV%Rho0)
+      write(file,'(/,"Stress:  ",ES10.3)', advance='no') (uh_scale*GV%RZ_to_H) * (str*dt)
     endif
 
     if (associated(CS%v_accel_bt)) then

--- a/src/diagnostics/MOM_diagnostics.F90
+++ b/src/diagnostics/MOM_diagnostics.F90
@@ -136,6 +136,7 @@ type, public :: surface_diag_IDs ; private
   integer :: id_sst  = -1, id_sst_sq = -1, id_sstcon = -1
   integer :: id_sss  = -1, id_sss_sq = -1, id_sssabs = -1
   integer :: id_ssu  = -1, id_ssv    = -1
+  integer :: id_ssu_east = -1, id_ssv_north = -1
 
   ! Diagnostic IDs for  heat and salt flux fields
   integer :: id_fraz         = -1
@@ -1283,6 +1284,8 @@ subroutine post_surface_dyn_diags(IDs, G, diag, sfc_state, ssh)
 
   ! Local variables
   real, dimension(SZI_(G),SZJ_(G)) :: speed  ! The surface speed [L T-1 ~> m s-1]
+  real :: ssu_east(SZI_(G),SZJ_(G))        ! Surface velocity due east component [L T-1 ~> m s-1]
+  real :: ssv_north(SZI_(G),SZJ_(G))       ! Surface velocity due north component [L T-1 ~> m s-1]
   integer :: i, j, is, ie, js, je
 
   is = G%isc ; ie = G%iec ; js = G%jsc ; je = G%jec
@@ -1302,6 +1305,17 @@ subroutine post_surface_dyn_diags(IDs, G, diag, sfc_state, ssh)
                         0.5*(sfc_state%v(i,J-1)**2 + sfc_state%v(i,J)**2))
     enddo ; enddo
     call post_data(IDs%id_speed, speed, diag, mask=G%mask2dT)
+  endif
+
+  if (IDs%id_ssu_east > 0 .or. IDs%id_ssv_north > 0) then
+    do j=js,je ; do i=is,ie
+      ssu_east(i,j) = ((0.5*(sfc_state%u(I-1,j) + sfc_state%u(I,j))) * G%cos_rot(i,j)) + &
+                      ((0.5*(sfc_state%v(i,J-1) + sfc_state%v(i,J))) * G%sin_rot(i,j))
+      ssv_north(i,j) = ((0.5*(sfc_state%v(i,J-1) + sfc_state%v(i,J))) * G%cos_rot(i,j)) - &
+                       ((0.5*(sfc_state%u(I-1,j) + sfc_state%u(I,j))) * G%sin_rot(i,j))
+    enddo ; enddo
+    if (IDs%id_ssu_east > 0 ) call post_data(IDs%id_ssu_east, ssu_east, diag, mask=G%mask2dT)
+    if (IDs%id_ssv_north > 0 ) call post_data(IDs%id_ssv_north, ssv_north, diag, mask=G%mask2dT)
   endif
 
 end subroutine post_surface_dyn_diags
@@ -1912,6 +1926,10 @@ subroutine register_surface_diags(Time, G, US, IDs, diag, tv)
       'Sea Surface Meridional Velocity', 'm s-1', conversion=US%L_T_to_m_s)
   IDs%id_speed = register_diag_field('ocean_model', 'speed', diag%axesT1, Time, &
       'Sea Surface Speed', 'm s-1', conversion=US%L_T_to_m_s)
+  IDs%id_ssu_east = register_diag_field('ocean_model', 'ssu_east', diag%axesT1, Time, &
+      'Eastward velocity', 'm s-1', conversion=US%L_T_to_m_s)
+  IDs%id_ssv_north = register_diag_field('ocean_model', 'ssv_north', diag%axesT1, Time, &
+      'Northward velocity', 'm s-1', conversion=US%L_T_to_m_s)
 
   if (associated(tv%T)) then
     IDs%id_sst = register_diag_field('ocean_model', 'SST', diag%axesT1, Time, &

--- a/src/diagnostics/MOM_diagnostics.F90
+++ b/src/diagnostics/MOM_diagnostics.F90
@@ -999,7 +999,7 @@ subroutine calculate_energy_diagnostics(u, v, h, uh, vh, ADp, CDp, G, GV, US, CS
         call do_group_pass(CS%pass_KE_uv, G%domain)
       do j=js,je ; do i=is,ie
         KE_term(i,j,k) = KE_h(i,j) + 0.5 * G%IareaT(i,j) &
-            * (KE_u(I,j) + KE_u(I-1,j) + KE_v(i,J) + KE_v(i,J-1))
+            * ((KE_u(I,j) + KE_u(I-1,j)) + (KE_v(i,J) + KE_v(i,J-1)))
       enddo ; enddo
     enddo
     call post_data(CS%id_dKEdt, KE_term, CS%diag)
@@ -1018,7 +1018,7 @@ subroutine calculate_energy_diagnostics(u, v, h, uh, vh, ADp, CDp, G, GV, US, CS
         call do_group_pass(CS%pass_KE_uv, G%domain)
       do j=js,je ; do i=is,ie
         KE_term(i,j,k) = 0.5 * G%IareaT(i,j) &
-            * (KE_u(I,j) + KE_u(I-1,j) + KE_v(i,J) + KE_v(i,J-1))
+            * ((KE_u(I,j) + KE_u(I-1,j)) + (KE_v(i,J) + KE_v(i,J-1)))
       enddo ; enddo
     enddo
     if (CS%id_PE_to_KE > 0) call post_data(CS%id_PE_to_KE, KE_term, CS%diag)
@@ -1037,7 +1037,7 @@ subroutine calculate_energy_diagnostics(u, v, h, uh, vh, ADp, CDp, G, GV, US, CS
         call do_group_pass(CS%pass_KE_uv, G%domain)
       do j=js,je ; do i=is,ie
         KE_term(i,j,k) = 0.5 * G%IareaT(i,j) &
-            * (KE_u(I,j) + KE_u(I-1,j) + KE_v(i,J) + KE_v(i,J-1))
+            * ((KE_u(I,j) + KE_u(I-1,j)) + (KE_v(i,J) + KE_v(i,J-1)))
       enddo ; enddo
     enddo
     call post_data(CS%id_KE_BT, KE_term, CS%diag)
@@ -1056,13 +1056,13 @@ subroutine calculate_energy_diagnostics(u, v, h, uh, vh, ADp, CDp, G, GV, US, CS
       enddo ; enddo
       do j=js,je ; do i=is,ie
         KE_h(i,j) = -KE(i,j,k) * G%IareaT(i,j) &
-            * (uh(I,j,k) - uh(I-1,j,k) + vh(i,J,k) - vh(i,J-1,k))
+            * ((uh(I,j,k) - uh(I-1,j,k)) + (vh(i,J,k) - vh(i,J-1,k)))
       enddo ; enddo
       if (.not.G%symmetric) &
         call do_group_pass(CS%pass_KE_uv, G%domain)
       do j=js,je ; do i=is,ie
         KE_term(i,j,k) = KE_h(i,j) + 0.5 * G%IareaT(i,j) &
-            * (KE_u(I,j) + KE_u(I-1,j) + KE_v(i,J) + KE_v(i,J-1))
+            * ((KE_u(I,j) + KE_u(I-1,j)) + (KE_v(i,J) + KE_v(i,J-1)))
       enddo ; enddo
     enddo
     call post_data(CS%id_KE_Coradv, KE_term, CS%diag)
@@ -1085,13 +1085,13 @@ subroutine calculate_energy_diagnostics(u, v, h, uh, vh, ADp, CDp, G, GV, US, CS
       enddo ; enddo
       do j=js,je ; do i=is,ie
         KE_h(i,j) = -KE(i,j,k) * G%IareaT(i,j) &
-            * (uh(I,j,k) - uh(I-1,j,k) + vh(i,J,k) - vh(i,J-1,k))
+            * ((uh(I,j,k) - uh(I-1,j,k)) + (vh(i,J,k) - vh(i,J-1,k)))
       enddo ; enddo
       if (.not.G%symmetric) &
         call do_group_pass(CS%pass_KE_uv, G%domain)
       do j=js,je ; do i=is,ie
         KE_term(i,j,k) = KE_h(i,j) + 0.5 * G%IareaT(i,j) &
-            * (KE_u(I,j) + KE_u(I-1,j) + KE_v(i,J) + KE_v(i,J-1))
+            * ((KE_u(I,j) + KE_u(I-1,j)) + (KE_v(i,J) + KE_v(i,J-1)))
       enddo ; enddo
     enddo
     call post_data(CS%id_KE_adv, KE_term, CS%diag)
@@ -1110,7 +1110,7 @@ subroutine calculate_energy_diagnostics(u, v, h, uh, vh, ADp, CDp, G, GV, US, CS
         call do_group_pass(CS%pass_KE_uv, G%domain)
       do j=js,je ; do i=is,ie
         KE_term(i,j,k) = 0.5 * G%IareaT(i,j) &
-            * (KE_u(I,j) + KE_u(I-1,j) + KE_v(i,J) + KE_v(i,J-1))
+            * ((KE_u(I,j) + KE_u(I-1,j)) + (KE_v(i,J) + KE_v(i,J-1)))
       enddo ; enddo
     enddo
     call post_data(CS%id_KE_visc, KE_term, CS%diag)
@@ -1167,7 +1167,7 @@ subroutine calculate_energy_diagnostics(u, v, h, uh, vh, ADp, CDp, G, GV, US, CS
         call do_group_pass(CS%pass_KE_uv, G%domain)
       do j=js,je ; do i=is,ie
         KE_term(i,j,k) = 0.5 * G%IareaT(i,j) &
-            * (KE_u(I,j) + KE_u(I-1,j) + KE_v(i,J) + KE_v(i,J-1))
+            * ((KE_u(I,j) + KE_u(I-1,j)) + (KE_v(i,J) + KE_v(i,J-1)))
       enddo ; enddo
     enddo
     call post_data(CS%id_KE_horvisc, KE_term, CS%diag)
@@ -1189,7 +1189,7 @@ subroutine calculate_energy_diagnostics(u, v, h, uh, vh, ADp, CDp, G, GV, US, CS
         call do_group_pass(CS%pass_KE_uv, G%domain)
       do j=js,je ; do i=is,ie
         KE_term(i,j,k) = KE_h(i,j) + 0.5 * G%IareaT(i,j) &
-            * (KE_u(I,j) + KE_u(I-1,j) + KE_v(i,J) + KE_v(i,J-1))
+            * ((KE_u(I,j) + KE_u(I-1,j)) + (KE_v(i,J) + KE_v(i,J-1)))
       enddo ; enddo
     enddo
     call post_data(CS%id_KE_dia, KE_term, CS%diag)

--- a/src/diagnostics/MOM_obsolete_params.F90
+++ b/src/diagnostics/MOM_obsolete_params.F90
@@ -152,6 +152,9 @@ subroutine find_obsolete_params(param_file)
   call obsolete_logical(param_file, "VERT_FRICTION_2018_ANSWERS", &
                         hint="Instead use VERT_FRICTION_ANSWER_DATE.")
 
+  call obsolete_logical(param_file, "USE_GRID_SPACE_DIAGNOSTIC_AXES", &
+                        hint="Instead use USE_INDEX_DIAGNOSTIC_AXIS.")
+
   ! Write the file version number to the model log.
   call log_version(param_file, mdl, version)
 

--- a/src/diagnostics/MOM_obsolete_params.F90
+++ b/src/diagnostics/MOM_obsolete_params.F90
@@ -89,7 +89,8 @@ subroutine find_obsolete_params(param_file)
   if (test_logic .and. .not.split) call MOM_ERROR(FATAL, &
     "find_obsolete_params: #define DYNAMIC_SURFACE_PRESSURE is not yet "//&
     "implemented without #define SPLIT.")
-
+  call obsolete_char(param_file, "CONTINUITY_SCHEME", warning_val="PPM", &
+                     hint="Only one continuity scheme is available so this need not be specified.")
   call obsolete_real(param_file, "ETA_TOLERANCE_AUX", only_warn=.true.)
   call obsolete_real(param_file, "BT_MASS_SOURCE_LIMIT", 0.0)
   call obsolete_real(param_file, "FIRST_GUESS_SURFACE_LAYER_DEPTH")

--- a/src/diagnostics/MOM_spatial_means.F90
+++ b/src/diagnostics/MOM_spatial_means.F90
@@ -166,7 +166,7 @@ function global_area_integral(var, G, scale, area, tmp_scale)
   ! In the following comments, [A] is used to indicate the arbitrary, possibly rescaled units of the
   ! input array while [a] indicates the unscaled (e.g., mks) units that can be used with the reproducing sums
   real, dimension(SZI_(G),SZJ_(G)) :: tmpForSumming ! An unscaled cell integral [a m2]
-  real :: scalefac  ! An overall scaling factor for the areas and variable.
+  real :: scalefac  ! An overall scaling factor for the areas and variable, perhaps in [m2 a A-1 L-2 ~> 1]
   real :: temp_scale ! A temporary scaling factor [a A-1 ~> 1] or [1]
   integer :: i, j, is, ie, js, je
   is = G%isc ; ie = G%iec ; js = G%jsc ; je = G%jec
@@ -493,7 +493,7 @@ subroutine global_j_mean(array, j_mean, G, mask, scale, tmp_scale)
                                                             !! arbitrary, possibly rescaled units [A ~> a]
   real, dimension(SZI_(G)),         intent(out)   :: j_mean !<  Global mean of array along its j-axis [a] or [A ~> a]
   real, dimension(SZI_(G),SZJ_(G)), &
-                          optional, intent(in)    :: mask  !< An array used for weighting the j-mean
+                          optional, intent(in)    :: mask  !< An array used for weighting the j-mean [nondim]
   real,                   optional, intent(in)    :: scale !< A rescaling factor for the output variable [a A-1 ~> 1]
                                                            !! that converts it back to unscaled (e.g., mks)
                                                            !! units to enable the use of the reproducing sums

--- a/src/diagnostics/MOM_spatial_means.F90
+++ b/src/diagnostics/MOM_spatial_means.F90
@@ -211,11 +211,13 @@ function global_layer_mean(var, h, G, GV, scale, tmp_scale)
   ! Local variables
   ! In the following comments, [A] is used to indicate the arbitrary, possibly rescaled units of the
   ! input array while [a] indicates the unscaled (e.g., mks) units that can be used with the reproducing sums
-  real, dimension(G%isc:G%iec,G%jsc:G%jec,SZK_(GV)) :: tmpForSumming  ! An unscaled cell integral [a m3]
-  real, dimension(G%isc:G%iec,G%jsc:G%jec,SZK_(GV)) :: weight  ! The volume of each cell, used as a weight [m3]
+  real, dimension(G%isc:G%iec,G%jsc:G%jec,SZK_(GV)) :: tmpForSumming  ! An unscaled cell integral [a m3] or [a kg]
+  real, dimension(G%isc:G%iec,G%jsc:G%jec,SZK_(GV)) :: weight  ! The volume or mass of each cell, depending on
+                                                    ! whether the model is Boussinesq, used as a weight [m3] or [kg]
   type(EFP_type), dimension(2*SZK_(GV)) :: laysums
-  real, dimension(SZK_(GV)) :: global_temp_scalar    ! The global integral of the tracer in each layer [a m3]
-  real, dimension(SZK_(GV)) :: global_weight_scalar  ! The global integral of the volume of each layer [m3]
+  real, dimension(SZK_(GV)) :: global_temp_scalar   ! The global integral of the tracer in each layer [a m3] or [a kg]
+  real, dimension(SZK_(GV)) :: global_weight_scalar ! The global integral of the volume or mass of each
+                                                    ! layer [m3] or [kg]
   real :: temp_scale ! A temporary scaling factor [a A-1 ~> 1] or [1]
   real :: scalefac  ! A scaling factor for the variable [a A-1 ~> 1]
   integer :: i, j, k, is, ie, js, je, nz
@@ -226,7 +228,7 @@ function global_layer_mean(var, h, G, GV, scale, tmp_scale)
   tmpForSumming(:,:,:) = 0. ; weight(:,:,:) = 0.
 
   do k=1,nz ; do j=js,je ; do i=is,ie
-    weight(i,j,k)  =  (GV%H_to_m * h(i,j,k)) * (G%US%L_to_m**2*G%areaT(i,j) * G%mask2dT(i,j))
+    weight(i,j,k)  =  (GV%H_to_MKS * h(i,j,k)) * (G%US%L_to_m**2*G%areaT(i,j) * G%mask2dT(i,j))
     tmpForSumming(i,j,k) =  scalefac * var(i,j,k) * weight(i,j,k)
   enddo ; enddo ; enddo
 
@@ -262,9 +264,9 @@ function global_volume_mean(var, h, G, GV, scale, tmp_scale)
   ! input array while [a] indicates the unscaled (e.g., mks) units that can be used with the reproducing sums
   real :: temp_scale ! A temporary scaling factor [a A-1 ~> 1] or [1]
   real :: scalefac   ! A scaling factor for the variable [a A-1 ~> 1]
-  real :: weight_here ! The volume of a grid cell [m3]
-  real, dimension(SZI_(G),SZJ_(G)) :: tmpForSumming ! The volume integral of the variable in a column [a m3]
-  real, dimension(SZI_(G),SZJ_(G)) :: sum_weight  ! The volume of each column of water [m3]
+  real :: weight_here ! The volume or mass of a grid cell [m3] or [kg]
+  real, dimension(SZI_(G),SZJ_(G)) :: tmpForSumming ! The volume integral of the variable in a column [a m3] or [a kg]
+  real, dimension(SZI_(G),SZJ_(G)) :: sum_weight  ! The volume or mass of each column of water [m3] or [kg]
   integer :: i, j, k, is, ie, js, je, nz
   is = G%isc ; ie = G%iec ; js = G%jsc ; je = G%jec ; nz = GV%ke
 
@@ -273,7 +275,7 @@ function global_volume_mean(var, h, G, GV, scale, tmp_scale)
   tmpForSumming(:,:) = 0. ; sum_weight(:,:) = 0.
 
   do k=1,nz ; do j=js,je ; do i=is,ie
-    weight_here  =  (GV%H_to_m * h(i,j,k)) * (G%US%L_to_m**2*G%areaT(i,j) * G%mask2dT(i,j))
+    weight_here  =  (GV%H_to_MKS * h(i,j,k)) * (G%US%L_to_m**2*G%areaT(i,j) * G%mask2dT(i,j))
     tmpForSumming(i,j) = tmpForSumming(i,j) + scalefac * var(i,j,k) * weight_here
     sum_weight(i,j) = sum_weight(i,j) + weight_here
   enddo ; enddo ; enddo

--- a/src/diagnostics/MOM_wave_speed.F90
+++ b/src/diagnostics/MOM_wave_speed.F90
@@ -197,10 +197,10 @@ subroutine wave_speed(h, tv, G, GV, US, cg1, CS, halo_size, use_ebt_mode, mono_N
     enddo ; enddo ; enddo
   endif
 
-  g_Rho0 = GV%g_Earth*GV%H_to_Z / GV%Rho0
+  nonBous = .not.(GV%Boussinesq .or. GV%semi_Boussinesq)
   H_to_pres = GV%H_to_RZ * GV%g_Earth
   ! Note that g_Rho0 = H_to_pres / GV%Rho0**2
-  nonBous = .not.(GV%Boussinesq .or. GV%semi_Boussinesq)
+  if (.not.nonBous) g_Rho0 = GV%g_Earth*GV%H_to_Z / GV%Rho0
   use_EOS = associated(tv%eqn_of_state)
 
   better_est = CS%better_cg1_est
@@ -900,9 +900,9 @@ subroutine wave_speeds(h, tv, G, GV, US, nmodes, cn, CS, w_struct, u_struct, u_s
     is = G%isc - halo ; ie = G%iec + halo ; js = G%jsc - halo ; je = G%jec + halo
   endif
 
-  g_Rho0 = GV%g_Earth * GV%H_to_Z / GV%Rho0
-  H_to_pres = GV%H_to_RZ * GV%g_Earth
   nonBous = .not.(GV%Boussinesq .or. GV%semi_Boussinesq)
+  H_to_pres = GV%H_to_RZ * GV%g_Earth
+  if (.not.nonBous) g_Rho0 = GV%g_Earth * GV%H_to_Z / GV%Rho0
   use_EOS = associated(tv%eqn_of_state)
 
   if (CS%c1_thresh < 0.0) &
@@ -1057,7 +1057,6 @@ subroutine wave_speeds(h, tv, G, GV, US, nmodes, cn, CS, w_struct, u_struct, u_s
               enddo
             endif
           endif
-          cg1_est = g_Rho0 * drxh_sum
         else  ! Not use_EOS
           drxh_sum = 0.0 ; dSpVxh_sum = 0.0
           if (better_est) then

--- a/src/equation_of_state/MOM_EOS.F90
+++ b/src/equation_of_state/MOM_EOS.F90
@@ -1703,7 +1703,7 @@ subroutine convert_temp_salt_for_TEOS10(T, S, HI, kd, mask_z, EOS)
   do k=1,kd ; do j=HI%jsc,HI%jec ; do i=HI%isc,HI%iec
     if (mask_z(i,j,k) >= 1.0) then
       S(i,j,k) = Sref_Sprac * S(i,j,k)
-      T(i,j,k) = EOS%degC_to_C*poTemp_to_consTemp(EOS%S_to_ppt*S(i,j,k), EOS%S_to_ppt*T(i,j,k))
+      T(i,j,k) = EOS%degC_to_C*poTemp_to_consTemp(EOS%C_to_degC*T(i,j,k), EOS%S_to_ppt*S(i,j,k))
     endif
   enddo ; enddo ; enddo
 end subroutine convert_temp_salt_for_TEOS10

--- a/src/equation_of_state/MOM_EOS.F90
+++ b/src/equation_of_state/MOM_EOS.F90
@@ -1526,6 +1526,7 @@ subroutine EOS_init(param_file, EOS, US)
                  "If true, use a bug in the calculation of the second derivatives of density "//&
                  "with temperature and with temperature and pressure that causes some terms "//&
                  "to be only 2/3 of what they should be.", default=.false.)
+    call EOS_manual_init(EOS, form_of_EOS=EOS_WRIGHT, use_Wright_2nd_deriv_bug=EOS%use_Wright_2nd_deriv_bug)
   endif
 
   EOS_quad_default = .not.((EOS%form_of_EOS == EOS_LINEAR) .or. &
@@ -1645,6 +1646,8 @@ subroutine EOS_manual_init(EOS, form_of_EOS, form_of_TFreeze, EOS_quadrature, Co
     select type (t => EOS%type)
       type is (linear_EOS)
         call t%set_params_linear(Rho_T0_S0, dRho_dT, dRho_dS)
+      type is (buggy_Wright_EOS)
+        call t%set_params_buggy_Wright(use_Wright_2nd_deriv_bug)
     end select
   endif
   if (present(form_of_TFreeze))  EOS%form_of_TFreeze = form_of_TFreeze

--- a/src/equation_of_state/MOM_EOS.F90
+++ b/src/equation_of_state/MOM_EOS.F90
@@ -3,50 +3,20 @@ module MOM_EOS
 
 ! This file is part of MOM6. See LICENSE.md for the license.
 
-use MOM_EOS_linear, only : calculate_density_linear, calculate_spec_vol_linear
-use MOM_EOS_linear, only : calculate_density_derivs_linear
-use MOM_EOS_linear, only : calculate_specvol_derivs_linear, int_density_dz_linear
-use MOM_EOS_linear, only : calculate_density_second_derivs_linear, EoS_fit_range_linear
-use MOM_EOS_linear, only : calculate_compress_linear, int_spec_vol_dp_linear
-use MOM_EOS_linear, only : avg_spec_vol_linear
-use MOM_EOS_Wright, only : calculate_density_wright, calculate_spec_vol_wright
-use MOM_EOS_Wright, only : calculate_density_derivs_wright
-use MOM_EOS_Wright, only : calculate_specvol_derivs_wright, int_density_dz_wright
-use MOM_EOS_Wright, only : calculate_compress_wright, int_spec_vol_dp_wright
-use MOM_EOS_Wright, only : calculate_density_second_derivs_wright, calc_density_second_derivs_wright_buggy
-use MOM_EOS_Wright, only : EoS_fit_range_Wright, avg_spec_vol_Wright
-use MOM_EOS_Wright_full, only : calculate_density_wright_full, calculate_spec_vol_wright_full
-use MOM_EOS_Wright_full, only : calculate_density_derivs_wright_full
-use MOM_EOS_Wright_full, only : calculate_specvol_derivs_wright_full, int_density_dz_wright_full
-use MOM_EOS_Wright_full, only : calculate_compress_wright_full, int_spec_vol_dp_wright_full
-use MOM_EOS_Wright_full, only : calculate_density_second_derivs_wright_full
-use MOM_EOS_Wright_full, only : EoS_fit_range_Wright_full, avg_spec_vol_Wright_full
-use MOM_EOS_Wright_red,  only : calculate_density_wright_red, calculate_spec_vol_wright_red
-use MOM_EOS_Wright_red,  only : calculate_density_derivs_wright_red
-use MOM_EOS_Wright_red,  only : calculate_specvol_derivs_wright_red, int_density_dz_wright_red
-use MOM_EOS_Wright_red,  only : calculate_compress_wright_red, int_spec_vol_dp_wright_red
-use MOM_EOS_Wright_red,  only : calculate_density_second_derivs_wright_red
-use MOM_EOS_Wright_red,  only : EoS_fit_range_Wright_red, avg_spec_vol_Wright_red
-use MOM_EOS_Jackett06, only : calculate_density_Jackett06, calculate_spec_vol_Jackett06
-use MOM_EOS_Jackett06, only : calculate_density_derivs_Jackett06, calculate_specvol_derivs_Jackett06
-use MOM_EOS_Jackett06, only : calculate_compress_Jackett06, calculate_density_second_derivs_Jackett06
-use MOM_EOS_Jackett06, only : EoS_fit_range_Jackett06
-use MOM_EOS_UNESCO, only : calculate_density_unesco, calculate_spec_vol_unesco
-use MOM_EOS_UNESCO, only : calculate_density_derivs_unesco, calculate_specvol_derivs_UNESCO
-use MOM_EOS_UNESCO, only : calculate_density_second_derivs_UNESCO, calculate_compress_unesco
-use MOM_EOS_UNESCO, only : EoS_fit_range_UNESCO
-use MOM_EOS_Roquet_rho, only : calculate_density_Roquet_rho
-use MOM_EOS_Roquet_rho, only : calculate_density_derivs_Roquet_rho
-use MOM_EOS_Roquet_rho, only : calculate_density_second_derivs_Roquet_rho, calculate_compress_Roquet_rho
-use MOM_EOS_Roquet_rho, only : EoS_fit_range_Roquet_rho
-use MOM_EOS_Roquet_SpV, only : calculate_density_Roquet_SpV, calculate_spec_vol_Roquet_SpV
-use MOM_EOS_Roquet_SpV, only : calculate_density_derivs_Roquet_SpV, calculate_specvol_derivs_Roquet_SpV
-use MOM_EOS_Roquet_SpV, only : calculate_compress_Roquet_SpV, calculate_density_second_derivs_Roquet_SpV
-use MOM_EOS_Roquet_SpV, only : EoS_fit_range_Roquet_SpV
-use MOM_EOS_TEOS10, only : calculate_density_teos10, calculate_spec_vol_teos10
-use MOM_EOS_TEOS10, only : calculate_density_derivs_teos10, calculate_specvol_derivs_teos10
-use MOM_EOS_TEOS10, only : calculate_density_second_derivs_teos10, calculate_compress_teos10
-use MOM_EOS_TEOS10, only : EoS_fit_range_TEOS10
+use MOM_EOS_base_type, only : EOS_base
+use MOM_EOS_linear, only : linear_EOS, avg_spec_vol_linear
+use MOM_EOS_linear, only : int_density_dz_linear, int_spec_vol_dp_linear
+use MOM_EOS_Wright, only : buggy_Wright_EOS, avg_spec_vol_buggy_Wright
+use MOM_EOS_Wright, only : int_density_dz_wright, int_spec_vol_dp_wright
+use MOM_EOS_Wright_full, only : Wright_full_EOS, avg_spec_vol_Wright_full
+use MOM_EOS_Wright_full, only : int_density_dz_wright_full, int_spec_vol_dp_wright_full
+use MOM_EOS_Wright_red,  only : Wright_red_EOS, avg_spec_vol_Wright_red
+use MOM_EOS_Wright_red,  only : int_density_dz_wright_red, int_spec_vol_dp_wright_red
+use MOM_EOS_Jackett06, only : Jackett06_EOS
+use MOM_EOS_UNESCO, only : UNESCO_EOS
+use MOM_EOS_Roquet_rho, only : Roquet_rho_EOS
+use MOM_EOS_Roquet_SpV, only : Roquet_SpV_EOS
+use MOM_EOS_TEOS10, only : TEOS10_EOS
 use MOM_EOS_TEOS10, only : gsw_sp_from_sr, gsw_pt_from_ct
 use MOM_temperature_convert, only : poTemp_to_consTemp, consTemp_to_poTemp
 use MOM_TFreeze,    only : calculate_TFreeze_linear, calculate_TFreeze_Millero
@@ -54,7 +24,7 @@ use MOM_TFreeze,    only : calculate_TFreeze_teos10, calculate_TFreeze_TEOS_poly
 use MOM_error_handler, only : MOM_error, FATAL, WARNING, MOM_mesg
 use MOM_file_parser, only : get_param, log_version, param_file_type
 use MOM_hor_index,   only : hor_index_type
-use MOM_io,          only : stdout
+use MOM_io,          only : stdout, stderr
 use MOM_string_functions, only : uppercase
 use MOM_unit_scaling, only : unit_scale_type
 
@@ -71,6 +41,7 @@ public analytic_int_density_dz
 public analytic_int_specific_vol_dp
 public average_specific_vol
 public calculate_compress
+public calculate_density_elem
 public calculate_density
 public calculate_density_derivs
 public calculate_density_second_derivs
@@ -78,7 +49,6 @@ public calculate_spec_vol
 public calculate_specific_vol_derivs
 public calculate_TFreeze
 public convert_temp_salt_for_TEOS10
-public extract_member_EOS
 public cons_temp_to_pot_temp
 public abs_saln_to_prac_saln
 public gsw_sp_from_sr
@@ -169,7 +139,9 @@ type, public :: EOS_type ; private
   real :: ppt_to_S = 1.    !< A constant that translates parts per thousand to the units of salinity [S ppt-1 ~> 1]
   real :: S_to_ppt = 1.    !< A constant that translates the units of salinity to parts per thousand [ppt S-1 ~> 1]
 
-!  logical :: test_EOS = .true. ! If true, test the equation of state
+  !> The instance of the actual equation of state
+  class(EOS_base), allocatable :: type
+
 end type EOS_type
 
 ! The named integers that might be stored in eqn_of_state_type%form_of_EOS.
@@ -213,6 +185,42 @@ character*(10), parameter :: TFREEZE_TEOS10_STRING = "TEOS10" !< A string for sp
 
 contains
 
+!> Density of sea water (in-situ if pressure is local) [R ~> kg m-3]
+!!
+!! If rho_ref is present, the anomaly with respect to rho_ref is returned.  The pressure and
+!! density can be rescaled with the values stored in EOS.  If the scale argument is present the density
+!! scaling uses the product of the two scaling factors.
+real elemental function calculate_density_elem(EOS, T, S, pressure, rho_ref, scale)
+  type(EOS_type), intent(in)  :: EOS      !< Equation of state structure
+  real,           intent(in)  :: T        !< Potential temperature referenced to the surface [C ~> degC]
+  real,           intent(in)  :: S        !< Salinity [S ~> ppt]
+  real,           intent(in)  :: pressure !< Pressure [R L2 T-2 ~> Pa]
+  real, optional, intent(in)  :: rho_ref  !< A reference density [R ~> kg m-3]
+  real, optional, intent(in)  :: scale    !< A multiplicative factor by which to scale output density in
+                                          !! combination with scaling stored in EOS [various]
+  real :: Ta      ! An array of temperatures [degC]
+  real :: Sa      ! An array of salinities [ppt]
+  real :: pres    ! An mks version of the pressure to use [Pa]
+  real :: rho_mks ! An mks version of the density to be returned [kg m-3]
+  real :: rho_scale  ! A factor to convert density from kg m-3 to the desired units [R m3 kg-1 ~> 1]
+
+  pres = EOS%RL2_T2_to_Pa * pressure
+  Ta = EOS%C_to_degC * T
+  Sa = EOS%S_to_ppt * S
+
+  if (present(rho_ref)) then
+    rho_mks = EOS%type%density_anomaly_elem(Ta, Sa, pres, EOS%R_to_kg_m3*rho_ref)
+  else
+    rho_mks = EOS%type%density_elem(Ta, Sa, pres)
+  endif
+
+  ! Rescale the output density to the desired units.
+  rho_scale = EOS%kg_m3_to_R
+  if (present(scale)) rho_scale = rho_scale * scale
+  calculate_density_elem = rho_scale * rho_mks
+
+end function  calculate_density_elem
+
 !> Calls the appropriate subroutine to calculate density of sea water for scalar inputs.
 !! If rho_ref is present, the anomaly with respect to rho_ref is returned.  The pressure and
 !! density can be rescaled with the values stored in EOS.  If the scale argument is present the density
@@ -227,24 +235,26 @@ subroutine calculate_density_scalar(T, S, pressure, rho, EOS, rho_ref, scale)
   real, optional, intent(in)  :: scale    !< A multiplicative factor by which to scale output density in
                                           !! combination with scaling stored in EOS [various]
 
-  real :: Ta(1)      ! An array of temperatures [degC]
-  real :: Sa(1)      ! An array of salinities [ppt]
-  real :: pres(1)    ! An mks version of the pressure to use [Pa]
-  real :: rho_mks(1) ! An mks version of the density to be returned [kg m-3]
+  real :: Ta      ! An array of temperatures [degC]
+  real :: Sa      ! An array of salinities [ppt]
+  real :: pres    ! An mks version of the pressure to use [Pa]
+  real :: rho_mks ! An mks version of the density to be returned [kg m-3]
   real :: rho_scale  ! A factor to convert density from kg m-3 to the desired units [R m3 kg-1 ~> 1]
 
-  pres(1) = EOS%RL2_T2_to_Pa * pressure
-  Ta(1) = EOS%C_to_degC * T ; Sa(1) = EOS%S_to_ppt * S
+  pres = EOS%RL2_T2_to_Pa * pressure
+  Ta = EOS%C_to_degC * T
+  Sa = EOS%S_to_ppt * S
+
   if (present(rho_ref)) then
-    call calculate_density_array(Ta, Sa, pres, rho_mks, 1, 1, EOS, EOS%R_to_kg_m3*rho_ref)
+    rho_mks = EOS%type%density_anomaly_elem(Ta, Sa, pres, EOS%R_to_kg_m3*rho_ref)
   else
-    call calculate_density_array(Ta, Sa, pres, rho_mks, 1, 1, EOS)
+    rho_mks = EOS%type%density_elem(Ta, Sa, pres)
   endif
 
   ! Rescale the output density to the desired units.
   rho_scale = EOS%kg_m3_to_R
   if (present(scale)) rho_scale = rho_scale * scale
-  rho = rho_scale * rho_mks(1)
+  rho = rho_scale * rho_mks
 
 end subroutine calculate_density_scalar
 
@@ -283,52 +293,6 @@ subroutine calculate_stanley_density_scalar(T, S, pressure, Tvar, TScov, Svar, r
 
 end subroutine calculate_stanley_density_scalar
 
-!> Calls the appropriate subroutine to calculate the density of sea water for 1-D array inputs.
-!! If rho_ref is present, the anomaly with respect to rho_ref is returned.
-subroutine calculate_density_array(T, S, pressure, rho, start, npts, EOS, rho_ref, scale)
-  real, dimension(:), intent(in)    :: T        !< Potential temperature referenced to the surface [degC]
-  real, dimension(:), intent(in)    :: S        !< Salinity [ppt]
-  real, dimension(:), intent(in)    :: pressure !< Pressure [Pa]
-  real, dimension(:), intent(inout) :: rho      !< Density (in-situ if pressure is local) [kg m-3] or other
-                                                !! units if rescaled via a scale argument
-  integer,            intent(in)    :: start    !< Start index for computation
-  integer,            intent(in)    :: npts     !< Number of point to compute
-  type(EOS_type),     intent(in)    :: EOS      !< Equation of state structure
-  real,     optional, intent(in)    :: rho_ref  !< A reference density [kg m-3]
-  real,     optional, intent(in)    :: scale    !< A multiplicative factor by which to scale the output
-                                                !! density, perhaps to other units than kg m-3 [various]
-  integer :: j
-
-  select case (EOS%form_of_EOS)
-    case (EOS_LINEAR)
-      call calculate_density_linear(T, S, pressure, rho, start, npts, &
-                                    EOS%Rho_T0_S0, EOS%dRho_dT, EOS%dRho_dS, rho_ref)
-    case (EOS_UNESCO)
-      call calculate_density_UNESCO(T, S, pressure, rho, start, npts, rho_ref)
-    case (EOS_WRIGHT)
-      call calculate_density_wright(T, S, pressure, rho, start, npts, rho_ref)
-    case (EOS_WRIGHT_FULL)
-      call calculate_density_wright_full(T, S, pressure, rho, start, npts, rho_ref)
-    case (EOS_WRIGHT_REDUCED)
-      call calculate_density_wright_red(T, S, pressure, rho, start, npts, rho_ref)
-    case (EOS_TEOS10)
-      call calculate_density_teos10(T, S, pressure, rho, start, npts, rho_ref)
-    case (EOS_ROQUET_RHO)
-      call calculate_density_Roquet_rho(T, S, pressure, rho, start, npts, rho_ref)
-    case (EOS_ROQUET_SPV)
-      call calculate_density_Roquet_SpV(T, S, pressure, rho, start, npts, rho_ref)
-    case (EOS_JACKETT06)
-      call calculate_density_Jackett06(T, S, pressure, rho, start, npts, rho_ref)
-    case default
-      call MOM_error(FATAL, "calculate_density_array: EOS%form_of_EOS is not valid.")
-  end select
-
-  if (present(scale)) then ; if (scale /= 1.0) then ; do j=start,start+npts-1
-    rho(j) = scale * rho(j)
-  enddo ; endif ; endif
-
-end subroutine calculate_density_array
-
 !> Calls the appropriate subroutine to calculate the density of sea water for 1-D array inputs,
 !! potentially limiting the domain of indices that are worked on.
 !! If rho_ref is present, the anomaly with respect to rho_ref is returned.
@@ -358,7 +322,7 @@ subroutine calculate_density_1d(T, S, pressure, rho, EOS, dom, rho_ref, scale)
 
   if ((EOS%RL2_T2_to_Pa == 1.0) .and. (EOS%R_to_kg_m3 == 1.0) .and. &
       (EOS%C_to_degC == 1.0) .and. (EOS%S_to_ppt == 1.0)) then
-    call calculate_density_array(T, S, pressure, rho, is, npts, EOS, rho_ref=rho_ref)
+    call EOS%type%calculate_density_array(T, S, pressure, rho, is, npts, rho_ref=rho_ref)
   else ! This is the same as above, but with some extra work to rescale variables.
     do i=is,ie
       pres(i) = EOS%RL2_T2_to_Pa * pressure(i)
@@ -366,9 +330,9 @@ subroutine calculate_density_1d(T, S, pressure, rho, EOS, dom, rho_ref, scale)
       Sa(i) = EOS%S_to_ppt * S(i)
     enddo
     if (present(rho_ref)) then
-      call calculate_density_array(Ta, Sa, pres, rho, is, npts, EOS, rho_ref=EOS%R_to_kg_m3*rho_ref)
+      call EOS%type%calculate_density_array(Ta, Sa, pres, rho, is, npts, rho_ref=EOS%R_to_kg_m3*rho_ref)
     else
-      call calculate_density_array(Ta, Sa, pres, rho, is, npts, EOS)
+      call EOS%type%calculate_density_array(Ta, Sa, pres, rho, is, npts)
     endif
   endif
 
@@ -446,34 +410,10 @@ subroutine calculate_spec_vol_array(T, S, pressure, specvol, start, npts, EOS, s
   real, dimension(size(specvol))  :: rho   ! Density [kg m-3]
   integer :: j
 
-  select case (EOS%form_of_EOS)
-    case (EOS_LINEAR)
-      call calculate_spec_vol_linear(T, S, pressure, specvol, start, npts, &
-               EOS%rho_T0_S0, EOS%drho_dT, EOS%drho_dS, spv_ref)
-    case (EOS_UNESCO)
-      call calculate_spec_vol_UNESCO(T, S, pressure, specvol, start, npts, spv_ref)
-    case (EOS_WRIGHT)
-      call calculate_spec_vol_wright(T, S, pressure, specvol, start, npts, spv_ref)
-    case (EOS_WRIGHT_FULL)
-      call calculate_spec_vol_wright_full(T, S, pressure, specvol, start, npts, spv_ref)
-    case (EOS_WRIGHT_REDUCED)
-      call calculate_spec_vol_wright_red(T, S, pressure, specvol, start, npts, spv_ref)
-    case (EOS_TEOS10)
-      call calculate_spec_vol_teos10(T, S, pressure, specvol, start, npts, spv_ref)
-    case (EOS_ROQUET_RHO)
-      call calculate_density_Roquet_rho(T, S, pressure, rho, start, npts)
-      if (present(spv_ref)) then
-        specvol(:) = 1.0 / rho(:) - spv_ref
-      else
-        specvol(:) = 1.0 / rho(:)
-      endif
-    case (EOS_ROQUET_SpV)
-      call calculate_spec_vol_Roquet_SpV(T, S, pressure, specvol, start, npts, spv_ref)
-    case (EOS_JACKETT06)
-      call calculate_spec_vol_Jackett06(T, S, pressure, specvol, start, npts, spv_ref)
-    case default
-      call MOM_error(FATAL, "calculate_spec_vol_array: EOS%form_of_EOS is not valid.")
-  end select
+  if (.not. allocated(EOS%type)) call MOM_error(FATAL, &
+              "calculate_spec_vol_array: EOS%form_of_EOS is not valid.")
+
+  call EOS%type%calculate_spec_vol_array(T, S, pressure, specvol, start, npts, spv_ref)
 
   if (present(scale)) then ; if (scale /= 1.0) then ; do j=start,start+npts-1
     specvol(j) = scale * specvol(j)
@@ -751,29 +691,10 @@ subroutine calculate_density_derivs_array(T, S, pressure, drho_dT, drho_dS, star
   ! Local variables
   integer :: j
 
-  select case (EOS%form_of_EOS)
-    case (EOS_LINEAR)
-      call calculate_density_derivs_linear(T, S, pressure, drho_dT, drho_dS, EOS%Rho_T0_S0, &
-                                           EOS%dRho_dT, EOS%dRho_dS, start, npts)
-    case (EOS_UNESCO)
-      call calculate_density_derivs_UNESCO(T, S, pressure, drho_dT, drho_dS, start, npts)
-    case (EOS_WRIGHT)
-      call calculate_density_derivs_wright(T, S, pressure, drho_dT, drho_dS, start, npts)
-    case (EOS_WRIGHT_FULL)
-      call calculate_density_derivs_wright_full(T, S, pressure, drho_dT, drho_dS, start, npts)
-    case (EOS_WRIGHT_REDUCED)
-      call calculate_density_derivs_wright_red(T, S, pressure, drho_dT, drho_dS, start, npts)
-    case (EOS_TEOS10)
-      call calculate_density_derivs_teos10(T, S, pressure, drho_dT, drho_dS, start, npts)
-    case (EOS_ROQUET_RHO)
-      call calculate_density_derivs_Roquet_rho(T, S, pressure, drho_dT, drho_dS, start, npts)
-    case (EOS_ROQUET_SPV)
-      call calculate_density_derivs_Roquet_SpV(T, S, pressure, drho_dT, drho_dS, start, npts)
-    case (EOS_JACKETT06)
-      call calculate_density_derivs_Jackett06(T, S, pressure, drho_dT, drho_dS, start, npts)
-    case default
-      call MOM_error(FATAL, "calculate_density_derivs_array: EOS%form_of_EOS is not valid.")
-  end select
+  if (.not. allocated(EOS%type)) call MOM_error(FATAL, &
+              "calculate_density_derivs_array: EOS%form_of_EOS is not valid.")
+
+  call EOS%type%calculate_density_derivs_array(T, S, pressure, drho_dT, drho_dS, start, npts)
 
   if (present(scale)) then ; if (scale /= 1.0) then ; do j=start,start+npts-1
     drho_dT(j) = scale * drho_dT(j)
@@ -864,25 +785,7 @@ subroutine calculate_density_derivs_scalar(T, S, pressure, drho_dT, drho_dS, EOS
   Ta(1) = EOS%C_to_degC * T
   Sa(1) = EOS%S_to_ppt * S
 
-  select case (EOS%form_of_EOS)
-    case (EOS_LINEAR)
-      call calculate_density_derivs_linear(Ta(1), Sa(1), pres(1),drho_dT, drho_dS, &
-                                           EOS%Rho_T0_S0, EOS%dRho_dT, EOS%dRho_dS)
-    case (EOS_WRIGHT)
-      call calculate_density_derivs_wright(Ta(1), Sa(1), pres(1),drho_dT, drho_dS)
-    case (EOS_WRIGHT_FULL)
-      call calculate_density_derivs_wright_full(Ta(1), Sa(1), pres(1),drho_dT, drho_dS)
-    case (EOS_WRIGHT_REDUCED)
-      call calculate_density_derivs_wright_red(Ta(1), Sa(1), pres(1),drho_dT, drho_dS)
-    case (EOS_TEOS10)
-      call calculate_density_derivs_teos10(Ta(1), Sa(1), pres(1), drho_dT, drho_dS)
-    case (EOS_JACKETT06)
-      call calculate_density_derivs_Jackett06(Ta(1), Sa(1), pres(1),drho_dT, drho_dS)
-    case default
-      ! Some equations of state do not have a scalar form of calculate_density_derivs, so try the array form.
-      call calculate_density_derivs_array(Ta, Sa, pres, dR_dT, dR_dS, 1, 1, EOS)
-      drho_dT = dR_dT(1); drho_dS = dR_dS(1)
-  end select
+  call EOS%type%calculate_density_derivs_scalar(Ta(1), Sa(1), pres(1), drho_dT, drho_dS)
 
   rho_scale = EOS%kg_m3_to_R
   if (present(scale)) rho_scale = rho_scale * scale
@@ -923,6 +826,9 @@ subroutine calculate_density_second_derivs_1d(T, S, pressure, drho_dS_dS, drho_d
   real :: rho_scale ! A factor to convert density from kg m-3 to the desired units [R m3 kg-1 ~> 1]
   integer :: i, is, ie, npts
 
+  if (.not. allocated(EOS%type)) call MOM_error(FATAL, &
+              "calculate_density_second_derivs: EOS%form_of_EOS is not valid.")
+
   if (present(dom)) then
     is = dom(1) ; ie = dom(2) ; npts = 1 + ie - is
   else
@@ -930,84 +836,16 @@ subroutine calculate_density_second_derivs_1d(T, S, pressure, drho_dS_dS, drho_d
   endif
 
   if ((EOS%RL2_T2_to_Pa == 1.0) .and. (EOS%C_to_degC == 1.0) .and. (EOS%S_to_ppt == 1.0)) then
-    select case (EOS%form_of_EOS)
-      case (EOS_LINEAR)
-        call calculate_density_second_derivs_linear(T, S, pressure, drho_dS_dS, drho_dS_dT, &
-                                                    drho_dT_dT, drho_dS_dP, drho_dT_dP, is, npts)
-      case (EOS_WRIGHT)
-        if (EOS%use_Wright_2nd_deriv_bug) then
-          call calc_density_second_derivs_wright_buggy(T, S, pressure, drho_dS_dS, drho_dS_dT, &
-                                                    drho_dT_dT, drho_dS_dP, drho_dT_dP, is, npts)
-        else
-          call calculate_density_second_derivs_wright(T, S, pressure, drho_dS_dS, drho_dS_dT, &
-                                                    drho_dT_dT, drho_dS_dP, drho_dT_dP, is, npts)
-        endif
-      case (EOS_WRIGHT_FULL)
-        call calculate_density_second_derivs_wright_full(T, S, pressure, drho_dS_dS, drho_dS_dT, &
-                                                    drho_dT_dT, drho_dS_dP, drho_dT_dP, is, npts)
-      case (EOS_WRIGHT_REDUCED)
-        call calculate_density_second_derivs_wright_red(T, S, pressure, drho_dS_dS, drho_dS_dT, &
-                                                    drho_dT_dT, drho_dS_dP, drho_dT_dP, is, npts)
-      case (EOS_UNESCO)
-        call calculate_density_second_derivs_UNESCO(T, S, pressure, drho_dS_dS, drho_dS_dT, &
-                                                    drho_dT_dT, drho_dS_dP, drho_dT_dP, is, npts)
-      case (EOS_ROQUET_RHO)
-        call calculate_density_second_derivs_Roquet_rho(T, S, pressure, drho_dS_dS, drho_dS_dT, &
-                                                    drho_dT_dT, drho_dS_dP, drho_dT_dP, is, npts)
-      case (EOS_ROQUET_SPV)
-        call calculate_density_second_derivs_Roquet_SpV(T, S, pressure, drho_dS_dS, drho_dS_dT, &
-                                                    drho_dT_dT, drho_dS_dP, drho_dT_dP, is, npts)
-      case (EOS_TEOS10)
-        call calculate_density_second_derivs_teos10(T, S, pressure, drho_dS_dS, drho_dS_dT, &
-                                                    drho_dT_dT, drho_dS_dP, drho_dT_dP, is, npts)
-      case (EOS_JACKETT06)
-        call calculate_density_second_derivs_Jackett06(T, S, pressure, drho_dS_dS, drho_dS_dT, &
-                                                    drho_dT_dT, drho_dS_dP, drho_dT_dP, is, npts)
-      case default
-        call MOM_error(FATAL, "calculate_density_second_derivs: EOS%form_of_EOS is not valid.")
-    end select
+    call EOS%type%calculate_density_second_derivs_array(T, S, pressure, &
+                        drho_dS_dS, drho_dS_dT, drho_dT_dT, drho_dS_dP, drho_dT_dP, is, npts)
   else
     do i=is,ie
       pres(i) = EOS%RL2_T2_to_Pa * pressure(i)
       Ta(i) = EOS%C_to_degC * T(i)
       Sa(i) = EOS%S_to_ppt * S(i)
     enddo
-    select case (EOS%form_of_EOS)
-      case (EOS_LINEAR)
-        call calculate_density_second_derivs_linear(Ta, Sa, pres, drho_dS_dS, drho_dS_dT, &
-                                                    drho_dT_dT, drho_dS_dP, drho_dT_dP, is, npts)
-      case (EOS_WRIGHT)
-        if (EOS%use_Wright_2nd_deriv_bug) then
-          call calc_density_second_derivs_wright_buggy(Ta, Sa, pres, drho_dS_dS, drho_dS_dT, &
-                                                    drho_dT_dT, drho_dS_dP, drho_dT_dP, is, npts)
-        else
-          call calculate_density_second_derivs_wright(Ta, Sa, pres, drho_dS_dS, drho_dS_dT, &
-                                                    drho_dT_dT, drho_dS_dP, drho_dT_dP, is, npts)
-        endif
-      case (EOS_WRIGHT_FULL)
-        call calculate_density_second_derivs_wright_full(Ta, Sa, pres, drho_dS_dS, drho_dS_dT, &
-                                                    drho_dT_dT, drho_dS_dP, drho_dT_dP, is, npts)
-      case (EOS_WRIGHT_REDUCED)
-        call calculate_density_second_derivs_wright_red(Ta, Sa, pres, drho_dS_dS, drho_dS_dT, &
-                                                    drho_dT_dT, drho_dS_dP, drho_dT_dP, is, npts)
-      case (EOS_UNESCO)
-        call calculate_density_second_derivs_UNESCO(Ta, Sa, pres, drho_dS_dS, drho_dS_dT, &
-                                                    drho_dT_dT, drho_dS_dP, drho_dT_dP, is, npts)
-      case (EOS_ROQUET_RHO)
-        call calculate_density_second_derivs_Roquet_rho(Ta, Sa, pres, drho_dS_dS, drho_dS_dT, &
-                                                    drho_dT_dT, drho_dS_dP, drho_dT_dP, is, npts)
-      case (EOS_ROQUET_SpV)
-        call calculate_density_second_derivs_Roquet_SpV(Ta, Sa, pres, drho_dS_dS, drho_dS_dT, &
-                                                    drho_dT_dT, drho_dS_dP, drho_dT_dP, is, npts)
-      case (EOS_TEOS10)
-        call calculate_density_second_derivs_teos10(Ta, Sa, pres, drho_dS_dS, drho_dS_dT, &
-                                                    drho_dT_dT, drho_dS_dP, drho_dT_dP, is, npts)
-      case (EOS_JACKETT06)
-        call calculate_density_second_derivs_Jackett06(Ta, Sa, pres, drho_dS_dS, drho_dS_dT, &
-                                                    drho_dT_dT, drho_dS_dP, drho_dT_dP, is, npts)
-      case default
-        call MOM_error(FATAL, "calculate_density_second_derivs: EOS%form_of_EOS is not valid.")
-    end select
+    call EOS%type%calculate_density_second_derivs_array(Ta, Sa, pres, drho_dS_dS, drho_dS_dT, &
+                                                drho_dT_dT, drho_dS_dP, drho_dT_dP, is, npts)
   endif
 
   rho_scale = EOS%kg_m3_to_R
@@ -1064,46 +902,15 @@ subroutine calculate_density_second_derivs_scalar(T, S, pressure, drho_dS_dS, dr
   real :: Ta    ! Temperature converted to [degC]
   real :: Sa    ! Salinity converted to [ppt]
 
+  if (.not. allocated(EOS%type)) call MOM_error(FATAL, &
+             "calculate_density_second_derivs: EOS%form_of_EOS is not valid.")
+
   pres = EOS%RL2_T2_to_Pa*pressure
   Ta = EOS%C_to_degC * T
   Sa = EOS%S_to_ppt * S
 
-  select case (EOS%form_of_EOS)
-    case (EOS_LINEAR)
-      call calculate_density_second_derivs_linear(Ta, Sa, pres, drho_dS_dS, drho_dS_dT, &
-                                                  drho_dT_dT, drho_dS_dP, drho_dT_dP)
-    case (EOS_WRIGHT)
-      if (EOS%use_Wright_2nd_deriv_bug) then
-        call calc_density_second_derivs_wright_buggy(Ta, Sa, pres, drho_dS_dS, drho_dS_dT, &
-                                                  drho_dT_dT, drho_dS_dP, drho_dT_dP)
-      else
-        call calculate_density_second_derivs_wright(Ta, Sa, pres, drho_dS_dS, drho_dS_dT, &
-                                                  drho_dT_dT, drho_dS_dP, drho_dT_dP)
-      endif
-    case (EOS_WRIGHT_FULL)
-      call calculate_density_second_derivs_wright_full(Ta, Sa, pres, drho_dS_dS, drho_dS_dT, &
-                                                  drho_dT_dT, drho_dS_dP, drho_dT_dP)
-    case (EOS_WRIGHT_REDUCED)
-      call calculate_density_second_derivs_wright_red(Ta, Sa, pres, drho_dS_dS, drho_dS_dT, &
-                                                  drho_dT_dT, drho_dS_dP, drho_dT_dP)
-    case (EOS_UNESCO)
-      call calculate_density_second_derivs_UNESCO(Ta, Sa, pres, drho_dS_dS, drho_dS_dT, &
-                                                  drho_dT_dT, drho_dS_dP, drho_dT_dP)
-    case (EOS_ROQUET_RHO)
-      call calculate_density_second_derivs_Roquet_rho(Ta, Sa, pres, drho_dS_dS, drho_dS_dT, &
-                                                  drho_dT_dT, drho_dS_dP, drho_dT_dP)
-    case (EOS_ROQUET_SPV)
-      call calculate_density_second_derivs_Roquet_SpV(Ta, Sa, pres, drho_dS_dS, drho_dS_dT, &
-                                                  drho_dT_dT, drho_dS_dP, drho_dT_dP)
-    case (EOS_TEOS10)
-      call calculate_density_second_derivs_teos10(Ta, Sa, pres, drho_dS_dS, drho_dS_dT, &
-                                                  drho_dT_dT, drho_dS_dP, drho_dT_dP)
-    case (EOS_JACKETT06)
-      call calculate_density_second_derivs_Jackett06(Ta, Sa, pres, drho_dS_dS, drho_dS_dT, &
-                                                  drho_dT_dT, drho_dS_dP, drho_dT_dP)
-    case default
-      call MOM_error(FATAL, "calculate_density_second_derivs: EOS%form_of_EOS is not valid.")
-  end select
+  call EOS%type%calculate_density_second_derivs_scalar(Ta, Sa, pres, drho_dS_dS, drho_dS_dT, &
+                                              drho_dT_dT, drho_dS_dP, drho_dT_dP)
 
   rho_scale = EOS%kg_m3_to_R
   if (present(scale)) rho_scale = rho_scale * scale
@@ -1147,40 +954,10 @@ subroutine calculate_spec_vol_derivs_array(T, S, pressure, dSV_dT, dSV_dS, start
   integer,            intent(in)  :: npts   !< The number of values to calculate
   type(EOS_type),     intent(in)  :: EOS    !< Equation of state structure
 
-  ! Local variables
-  real, dimension(size(T)) :: rho     ! In situ density [kg m-3]
-  real, dimension(size(T)) :: dRho_dT ! Derivative of density with temperature [kg m-3 degC-1]
-  real, dimension(size(T)) :: dRho_dS ! Derivative of density with salinity [kg m-3 ppt-1]
-  integer :: j
+  if (.not. allocated(EOS%type)) call MOM_error(FATAL, &
+              "calculate_spec_vol_derivs_array: EOS%form_of_EOS is not valid.")
 
-  select case (EOS%form_of_EOS)
-    case (EOS_LINEAR)
-      call calculate_specvol_derivs_linear(T, S, pressure, dSV_dT, dSV_dS, start, &
-                                           npts, EOS%Rho_T0_S0, EOS%dRho_dT, EOS%dRho_dS)
-    case (EOS_UNESCO)
-      call calculate_specvol_derivs_UNESCO(T, S, pressure, dSV_dT, dSV_dS, start, npts)
-    case (EOS_WRIGHT)
-      call calculate_specvol_derivs_wright(T, S, pressure, dSV_dT, dSV_dS, start, npts)
-    case (EOS_WRIGHT_FULL)
-      call calculate_specvol_derivs_wright_full(T, S, pressure, dSV_dT, dSV_dS, start, npts)
-    case (EOS_WRIGHT_REDUCED)
-      call calculate_specvol_derivs_wright_red(T, S, pressure, dSV_dT, dSV_dS, start, npts)
-    case (EOS_TEOS10)
-      call calculate_specvol_derivs_teos10(T, S, pressure, dSV_dT, dSV_dS, start, npts)
-    case (EOS_ROQUET_RHO)
-      call calculate_density_Roquet_rho(T, S, pressure, rho, start, npts)
-      call calculate_density_derivs_Roquet_rho(T, S, pressure, drho_dT, drho_dS, start, npts)
-      do j=start,start+npts-1
-        dSV_dT(j) = -dRho_DT(j)/(rho(j)**2)
-        dSV_dS(j) = -dRho_DS(j)/(rho(j)**2)
-      enddo
-    case (EOS_ROQUET_SPV)
-      call calculate_specvol_derivs_Roquet_SpV(T, S, pressure, dSV_dT, dSV_dS, start, npts)
-    case (EOS_JACKETT06)
-      call calculate_specvol_derivs_Jackett06(T, S, pressure, dSV_dT, dSV_dS, start, npts)
-    case default
-      call MOM_error(FATAL, "calculate_spec_vol_derivs_array: EOS%form_of_EOS is not valid.")
-  end select
+  call EOS%type%calculate_specvol_derivs_array(T, S, pressure, dSV_dT, dSV_dS, start, npts)
 
 end subroutine calculate_spec_vol_derivs_array
 
@@ -1258,6 +1035,9 @@ subroutine calculate_compress_1d(T, S, pressure, rho, drho_dp, EOS, dom)
   real, dimension(size(T)) :: Sa    ! Salinity converted to [ppt]
   integer :: i, is, ie, npts
 
+  if (.not. allocated(EOS%type)) call MOM_error(FATAL, &
+              "calculate_compress_1d: EOS%form_of_EOS is not valid.")
+
   if (present(dom)) then
     is = dom(1) ; ie = dom(2) ; npts = 1 + ie - is
   else
@@ -1270,29 +1050,7 @@ subroutine calculate_compress_1d(T, S, pressure, rho, drho_dp, EOS, dom)
     Sa(i) = EOS%S_to_ppt * S(i)
   enddo
 
-  select case (EOS%form_of_EOS)
-    case (EOS_LINEAR)
-      call calculate_compress_linear(Ta, Sa, pres, rho, drho_dp, is, npts, &
-                                     EOS%Rho_T0_S0, EOS%dRho_dT, EOS%dRho_dS)
-    case (EOS_UNESCO)
-      call calculate_compress_UNESCO(Ta, Sa, pres, rho, drho_dp, is, npts)
-    case (EOS_WRIGHT)
-      call calculate_compress_wright(Ta, Sa, pres, rho, drho_dp, is, npts)
-    case (EOS_WRIGHT_FULL)
-      call calculate_compress_wright_full(Ta, Sa, pres, rho, drho_dp, is, npts)
-    case (EOS_WRIGHT_REDUCED)
-      call calculate_compress_wright_red(Ta, Sa, pres, rho, drho_dp, is, npts)
-    case (EOS_TEOS10)
-      call calculate_compress_teos10(Ta, Sa, pres, rho, drho_dp, is, npts)
-    case (EOS_ROQUET_RHO)
-      call calculate_compress_Roquet_rho(Ta, Sa, pres, rho, drho_dp, is, npts)
-    case (EOS_ROQUET_SpV)
-      call calculate_compress_Roquet_SpV(Ta, Sa, pres, rho, drho_dp, is, npts)
-    case (EOS_JACKETT06)
-      call calculate_compress_Jackett06(Ta, Sa, pres, rho, drho_dp, is, npts)
-    case default
-      call MOM_error(FATAL, "calculate_compress: EOS%form_of_EOS is not valid.")
-  end select
+  call EOS%type%calculate_compress_array(Ta, Sa, pres, rho, drho_dp, is, npts)
 
   if (EOS%kg_m3_to_R /= 1.0) then ; do i=is,ie
     rho(i) = EOS%kg_m3_to_R * rho(i)
@@ -1383,7 +1141,7 @@ subroutine average_specific_vol(T, S, p_t, dp, SpV_avg, EOS, dom, scale)
         call avg_spec_vol_linear(T, S, p_t, dp, SpV_avg, is, npts, EOS%Rho_T0_S0, &
                                  EOS%dRho_dT, EOS%dRho_dS)
       case (EOS_WRIGHT)
-        call avg_spec_vol_wright(T, S, p_t, dp, SpV_avg, is, npts)
+        call avg_spec_vol_buggy_wright(T, S, p_t, dp, SpV_avg, is, npts)
       case (EOS_WRIGHT_FULL)
         call avg_spec_vol_wright_full(T, S, p_t, dp, SpV_avg, is, npts)
       case (EOS_WRIGHT_REDUCED)
@@ -1403,7 +1161,7 @@ subroutine average_specific_vol(T, S, p_t, dp, SpV_avg, EOS, dom, scale)
         call avg_spec_vol_linear(Ta, Sa, pres, dpres, SpV_avg, is, npts, EOS%Rho_T0_S0, &
                                  EOS%dRho_dT, EOS%dRho_dS)
       case (EOS_WRIGHT)
-        call avg_spec_vol_wright(Ta, Sa, pres, dpres, SpV_avg, is, npts)
+        call avg_spec_vol_buggy_wright(Ta, Sa, pres, dpres, SpV_avg, is, npts)
       case (EOS_WRIGHT_FULL)
         call avg_spec_vol_wright_full(Ta, Sa, pres, dpres, SpV_avg, is, npts)
       case (EOS_WRIGHT_REDUCED)
@@ -1434,28 +1192,10 @@ subroutine EoS_fit_range(EOS, T_min, T_max, S_min, S_max, p_min, p_max)
   real, optional, intent(out) :: p_min !< The minimum pressure over which this EoS is fitted [Pa]
   real, optional, intent(out) :: p_max !< The maximum pressure over which this EoS is fitted [Pa]
 
-  select case (EOS%form_of_EOS)
-    case (EOS_LINEAR)
-      call EoS_fit_range_linear(T_min, T_max, S_min, S_max, p_min, p_max)
-    case (EOS_UNESCO)
-      call EoS_fit_range_UNESCO(T_min, T_max, S_min, S_max, p_min, p_max)
-    case (EOS_WRIGHT)
-      call EoS_fit_range_Wright(T_min, T_max, S_min, S_max, p_min, p_max)
-    case (EOS_WRIGHT_FULL)
-      call EoS_fit_range_Wright_full(T_min, T_max, S_min, S_max, p_min, p_max)
-    case (EOS_WRIGHT_REDUCED)
-      call EoS_fit_range_Wright_red(T_min, T_max, S_min, S_max, p_min, p_max)
-    case (EOS_TEOS10)
-      call EoS_fit_range_TEOS10(T_min, T_max, S_min, S_max, p_min, p_max)
-    case (EOS_ROQUET_RHO)
-      call EoS_fit_range_Roquet_rho(T_min, T_max, S_min, S_max, p_min, p_max)
-    case (EOS_ROQUET_SpV)
-      call EoS_fit_range_Roquet_SpV(T_min, T_max, S_min, S_max, p_min, p_max)
-    case (EOS_JACKETT06)
-      call EoS_fit_range_Jackett06(T_min, T_max, S_min, S_max, p_min, p_max)
-    case default
-      call MOM_error(FATAL, "calculate_compress: EOS%form_of_EOS is not valid.")
-  end select
+  if (.not. allocated(EOS%type)) call MOM_error(FATAL, &
+                  "calculate_compress: EOS%form_of_EOS is not valid.")
+
+  call EOS%type%EoS_fit_range(T_min, T_max, S_min, S_max, p_min, p_max)
 
 end subroutine EoS_fit_range
 
@@ -1738,27 +1478,27 @@ subroutine EOS_init(param_file, EOS, US)
                  'and "TEOS10".  This is only used if USE_EOS is true.', default=EOS_DEFAULT)
   select case (uppercase(tmpstr))
     case (EOS_LINEAR_STRING)
-      EOS%form_of_EOS = EOS_LINEAR
+      call EOS_manual_init(EOS, form_of_EOS=EOS_LINEAR)
     case (EOS_UNESCO_STRING)
-      EOS%form_of_EOS = EOS_UNESCO
+      call EOS_manual_init(EOS, form_of_EOS=EOS_UNESCO)
     case (EOS_JACKETT_STRING)
-      EOS%form_of_EOS = EOS_UNESCO
+      call EOS_manual_init(EOS, form_of_EOS=EOS_UNESCO)
     case (EOS_WRIGHT_STRING)
-      EOS%form_of_EOS = EOS_WRIGHT
+      call EOS_manual_init(EOS, form_of_EOS=EOS_WRIGHT)
     case (EOS_WRIGHT_RED_STRING)
-      EOS%form_of_EOS = EOS_WRIGHT_REDUCED
+      call EOS_manual_init(EOS, form_of_EOS=EOS_WRIGHT_REDUCED)
     case (EOS_WRIGHT_FULL_STRING)
-      EOS%form_of_EOS = EOS_WRIGHT_FULL
+      call EOS_manual_init(EOS, form_of_EOS=EOS_WRIGHT_FULL)
     case (EOS_TEOS10_STRING)
-      EOS%form_of_EOS = EOS_TEOS10
+      call EOS_manual_init(EOS, form_of_EOS=EOS_TEOS10)
     case (EOS_NEMO_STRING)
-      EOS%form_of_EOS = EOS_ROQUET_RHO
+      call EOS_manual_init(EOS, form_of_EOS=EOS_ROQUET_RHO)
     case (EOS_ROQUET_RHO_STRING)
-      EOS%form_of_EOS = EOS_ROQUET_RHO
+      call EOS_manual_init(EOS, form_of_EOS=EOS_ROQUET_RHO)
     case (EOS_ROQUET_SPV_STRING)
-      EOS%form_of_EOS = EOS_ROQUET_SPV
+      call EOS_manual_init(EOS, form_of_EOS=EOS_ROQUET_SPV)
     case (EOS_JACKETT06_STRING)
-      EOS%form_of_EOS = EOS_JACKETT06
+      call EOS_manual_init(EOS, form_of_EOS=EOS_JACKETT06)
     case default
       call MOM_error(FATAL, "interpret_eos_selection: EQN_OF_STATE "//&
                               trim(tmpstr) // " in input file is invalid.")
@@ -1779,6 +1519,7 @@ subroutine EOS_init(param_file, EOS, US)
                  "When EQN_OF_STATE="//trim(EOS_LINEAR_STRING)//", "//&
                  "this is the partial derivative of density with "//&
                  "salinity.", units="kg m-3 PSU-1", default=0.8)
+    call EOS_manual_init(EOS, form_of_EOS=EOS_LINEAR, Rho_T0_S0=EOS%Rho_T0_S0, dRho_dT=EOS%dRho_dT, dRho_dS=EOS%dRho_dS)
   endif
   if (EOS%form_of_EOS == EOS_WRIGHT) then
     call get_param(param_file, mdl, "USE_WRIGHT_2ND_DERIV_BUG", EOS%use_Wright_2nd_deriv_bug, &
@@ -1857,7 +1598,8 @@ end subroutine EOS_init
 
 !> Manually initialized an EOS type (intended for unit testing of routines which need a specific EOS)
 subroutine EOS_manual_init(EOS, form_of_EOS, form_of_TFreeze, EOS_quadrature, Compressible, &
-                           Rho_T0_S0, drho_dT, dRho_dS, TFr_S0_P0, dTFr_dS, dTFr_dp)
+                           Rho_T0_S0, drho_dT, dRho_dS, TFr_S0_P0, dTFr_dS, dTFr_dp, &
+                           use_Wright_2nd_deriv_bug)
   type(EOS_type),    intent(inout) :: EOS !< Equation of state structure
   integer, optional, intent(in) :: form_of_EOS !< A coded integer indicating the equation of state to use.
   integer, optional, intent(in) :: form_of_TFreeze !< A coded integer indicating the expression for
@@ -1875,8 +1617,36 @@ subroutine EOS_manual_init(EOS, form_of_EOS, form_of_TFreeze, EOS_quadrature, Co
                                              !! in [degC ppt-1]
   real   , optional, intent(in) :: dTFr_dp   !< The derivative of freezing point with pressure
                                              !! in [degC Pa-1]
+  logical, optional, intent(in) :: use_Wright_2nd_deriv_bug !< Allow the Wright 2nd deriv bug
 
-  if (present(form_of_EOS    ))  EOS%form_of_EOS     = form_of_EOS
+  if (present(form_of_EOS)) then
+    EOS%form_of_EOS     = form_of_EOS
+    if (allocated(EOS%type)) deallocate(EOS%type) ! Needed during testing which re-initializes
+    select case (EOS%form_of_EOS)
+      case (EOS_LINEAR)
+        allocate(linear_EOS :: EOS%type)
+      case (EOS_UNESCO)
+        allocate(UNESCO_EOS :: EOS%type)
+      case (EOS_WRIGHT)
+        allocate(buggy_Wright_EOS :: EOS%type)
+      case (EOS_WRIGHT_FULL)
+        allocate(Wright_full_EOS :: EOS%type)
+      case (EOS_WRIGHT_REDUCED)
+        allocate(Wright_red_EOS :: EOS%type)
+      case (EOS_JACKETT06)
+        allocate(Jackett06_EOS :: EOS%type)
+      case (EOS_TEOS10)
+        allocate(TEOS10_EOS :: EOS%type)
+      case (EOS_ROQUET_RHO)
+        allocate(Roquet_rho_EOS :: EOS%type)
+      case (EOS_ROQUET_SPV)
+        allocate(Roquet_SpV_EOS :: EOS%type)
+    end select
+    select type (t => EOS%type)
+      type is (linear_EOS)
+        call t%set_params_linear(Rho_T0_S0, dRho_dT, dRho_dS)
+    end select
+  endif
   if (present(form_of_TFreeze))  EOS%form_of_TFreeze = form_of_TFreeze
   if (present(EOS_quadrature ))  EOS%EOS_quadrature  = EOS_quadrature
   if (present(Compressible   ))  EOS%Compressible    = Compressible
@@ -1886,6 +1656,7 @@ subroutine EOS_manual_init(EOS, form_of_EOS, form_of_TFreeze, EOS_quadrature, Co
   if (present(TFr_S0_P0      ))  EOS%TFr_S0_P0       = TFr_S0_P0
   if (present(dTFr_dS        ))  EOS%dTFr_dS         = dTFr_dS
   if (present(dTFr_dp        ))  EOS%dTFr_dp         = dTFr_dp
+  if (present(use_Wright_2nd_deriv_bug)) EOS%use_Wright_2nd_deriv_bug = use_Wright_2nd_deriv_bug
 
 end subroutine EOS_manual_init
 
@@ -1902,11 +1673,8 @@ subroutine EOS_use_linear(Rho_T0_S0, dRho_dT, dRho_dS, EOS, use_quadrature)
                                              !! code for the integrals of density.
   type(EOS_type),    intent(inout) :: EOS    !< Equation of state structure
 
-  EOS%form_of_EOS = EOS_LINEAR
+  call EOS_manual_init(EOS, form_of_EOS=EOS_LINEAR, Rho_T0_S0=Rho_T0_S0, dRho_dT=dRho_dT, dRho_dS=dRho_dS)
   EOS%Compressible = .false.
-  EOS%Rho_T0_S0 = Rho_T0_S0
-  EOS%dRho_dT = dRho_dT
-  EOS%dRho_dS = dRho_dS
   EOS%EOS_quadrature = .false.
   if (present(use_quadrature)) EOS%EOS_quadrature = use_quadrature
 
@@ -2125,40 +1893,6 @@ logical function EOS_quadrature(EOS)
 
 end function EOS_quadrature
 
-!> Extractor routine for the EOS type if the members need to be accessed outside this module
-subroutine extract_member_EOS(EOS, form_of_EOS, form_of_TFreeze, EOS_quadrature, Compressible, &
-                              Rho_T0_S0, drho_dT, dRho_dS, TFr_S0_P0, dTFr_dS, dTFr_dp)
-  type(EOS_type),    intent(in)  :: EOS       !< Equation of state structure
-  integer, optional, intent(out) :: form_of_EOS !< A coded integer indicating the equation of state to use.
-  integer, optional, intent(out) :: form_of_TFreeze !< A coded integer indicating the expression for
-                                              !! the potential temperature of the freezing point.
-  logical, optional, intent(out) :: EOS_quadrature !< If true, always use the generic (quadrature)
-                                              !! code for the integrals of density.
-  logical, optional, intent(out) :: Compressible !< If true, in situ density is a function of pressure.
-  real   , optional, intent(out) :: Rho_T0_S0 !< Density at T=0 degC and S=0 ppt [kg m-3]
-  real   , optional, intent(out) :: drho_dT   !< Partial derivative of density with temperature
-                                              !! in [kg m-3 degC-1]
-  real   , optional, intent(out) :: dRho_dS   !< Partial derivative of density with salinity
-                                              !! in [kg m-3 ppt-1]
-  real   , optional, intent(out) :: TFr_S0_P0 !< The freezing potential temperature at S=0, P=0 [degC]
-  real   , optional, intent(out) :: dTFr_dS   !< The derivative of freezing point with salinity
-                                              !! [degC PSU-1]
-  real   , optional, intent(out) :: dTFr_dp   !< The derivative of freezing point with pressure
-                                              !! [degC Pa-1]
-
-  if (present(form_of_EOS    ))  form_of_EOS     = EOS%form_of_EOS
-  if (present(form_of_TFreeze))  form_of_TFreeze = EOS%form_of_TFreeze
-  if (present(EOS_quadrature ))  EOS_quadrature  = EOS%EOS_quadrature
-  if (present(Compressible   ))  Compressible    = EOS%Compressible
-  if (present(Rho_T0_S0      ))  Rho_T0_S0       = EOS%Rho_T0_S0
-  if (present(drho_dT        ))  drho_dT         = EOS%drho_dT
-  if (present(dRho_dS        ))  dRho_dS         = EOS%dRho_dS
-  if (present(TFr_S0_P0      ))  TFr_S0_P0       = EOS%TFr_S0_P0
-  if (present(dTFr_dS        ))  dTFr_dS         = EOS%dTFr_dS
-  if (present(dTFr_dp        ))  dTFr_dp         = EOS%dTFr_dp
-
-end subroutine extract_member_EOS
-
 !> Runs unit tests for consistency on the equations of state.
 !! This should only be called from a single/root thread.
 !! It returns True if any test fails, otherwise it returns False.
@@ -2202,11 +1936,13 @@ logical function EOS_unit_tests(verbose)
   ! if (verbose .and. fail) call MOM_error(WARNING, "WRIGHT_REDUCED EOS has failed some self-consistency tests.")
   ! EOS_unit_tests = EOS_unit_tests .or. fail
 
-  call EOS_manual_init(EOS_tmp, form_of_EOS=EOS_WRIGHT)
+  call EOS_manual_init(EOS_tmp, form_of_EOS=EOS_WRIGHT, use_Wright_2nd_deriv_bug=.true.)
   fail = test_EOS_consistency(25.0, 35.0, 1.0e7, EOS_tmp, verbose, "WRIGHT", &
                               rho_check=1027.54303596346*EOS_tmp%kg_m3_to_R, avg_Sv_check=.true.)
-  if (verbose .and. fail) call MOM_error(WARNING, "WRIGHT EOS has failed some self-consistency tests.")
-  EOS_unit_tests = EOS_unit_tests .or. fail
+  ! These last test is a known failure and since MPI is not necessarily initializaed when running these tests
+  ! we need to avoid flagging the fails.
+  !if (verbose .and. fail) call MOM_error(WARNING, "WRIGHT EOS has failed some self-consistency tests.")
+  !EOS_unit_tests = EOS_unit_tests .or. fail
 
   call EOS_manual_init(EOS_tmp, form_of_EOS=EOS_ROQUET_RHO)
   fail = test_EOS_consistency(25.0, 35.0, 1.0e7, EOS_tmp, verbose, "ROQUET_RHO", &
@@ -2416,9 +2152,9 @@ subroutine write_check_msg(var_name, val, val_chk, val_tol, test_OK)
   write(mesg, '(ES24.16," vs. ",ES24.16,", diff=",ES12.4,", tol=",ES12.4)') &
         val, val_chk, val-val_chk, val_tol
   if (test_OK) then
-    call MOM_mesg(trim(var_name)//" agrees with its check value :"//trim(mesg))
+    write(stdout,*) trim(var_name)//" agrees with its check value :"//trim(mesg)
   else
-    call MOM_error(WARNING, trim(var_name)//" disagrees with its check value :"//trim(mesg))
+    write(stderr,*) trim(var_name)//" disagrees with its check value :"//trim(mesg)
   endif
 end subroutine write_check_msg
 
@@ -2616,9 +2352,9 @@ logical function test_EOS_consistency(T_test, S_test, p_test, EOS, verbose, &
           rho_ref+rho(0,0,0,1), 1.0/(spv_ref + spv(0,0,0,1)), &
           (rho_ref+rho(0,0,0,1)) * (spv_ref + spv(0,0,0,1)) - 1.0
       if (test_OK) then
-        call MOM_mesg("The values of "//trim(EOS_name)//" rho and 1/spv agree.  "//trim(mesg))
+        write(stdout,*) "The values of "//trim(EOS_name)//" rho and 1/spv agree.  "//trim(mesg)
       else
-        call MOM_error(WARNING, "The values of "//trim(EOS_name)//" rho and 1/spv disagree.  "//trim(mesg))
+        write(stderr,*) "The values of "//trim(EOS_name)//" rho and 1/spv disagree.  "//trim(mesg)
       endif
     endif
   endif
@@ -2630,8 +2366,8 @@ logical function test_EOS_consistency(T_test, S_test, p_test, EOS, verbose, &
   if (verbose .and. .not.test_OK) then
     write(mesg, '(ES24.16," vs. ",ES24.16," with tolerance ",ES12.4)') &
           rho_ref+rho(0,0,0,1), rho_nooff, tol*rho_nooff
-    call MOM_error(WARNING, "For "//trim(EOS_name)//&
-                   " rho with and without a reference value disagree: "//trim(mesg))
+    write(stderr,*) "For "//trim(EOS_name)//&
+                   " rho with and without a reference value disagree: "//trim(mesg)
   endif
 
   ! Check that the specific volumes are consistent when the reference value is extracted
@@ -2641,8 +2377,8 @@ logical function test_EOS_consistency(T_test, S_test, p_test, EOS, verbose, &
   if (verbose .and. .not.test_OK) then
     write(mesg, '(ES24.16," vs. ",ES24.16," with tolerance ",ES12.4)') &
           spv_ref + spv(0,0,0,1), spv_nooff, tol*spv_nooff
-    call MOM_error(WARNING, "For "//trim(EOS_name)//&
-                   " spv with and without a reference value disagree: "//trim(mesg))
+    write(stderr,*) "For "//trim(EOS_name)//&
+                   " spv with and without a reference value disagree: "//trim(mesg)
   endif
 
   ! Account for the factors of terms in the numerator and denominator when estimating roundoff
@@ -2689,9 +2425,9 @@ logical function test_EOS_consistency(T_test, S_test, p_test, EOS, verbose, &
         2.0*(SpV_avg_a(1) - SpV_avg_q(1)) / (abs(SpV_avg_a(1)) + abs(SpV_avg_q(1)) + tiny(SpV_avg_a(1))), &
         tol_here
       if (verbose .and. .not.test_OK) then
-        call MOM_error(WARNING, "The values of "//trim(EOS_name)//" SpV_avg disagree. "//trim(mesg))
+        write(stderr,*) "The values of "//trim(EOS_name)//" SpV_avg disagree. "//trim(mesg)
       elseif (verbose) then
-        call MOM_mesg("The values of "//trim(EOS_name)//" SpV_avg agree: "//trim(mesg))
+        write(stdout,*) "The values of "//trim(EOS_name)//" SpV_avg agree: "//trim(mesg)
       endif
     endif
     OK = OK .and. test_OK
@@ -2776,9 +2512,9 @@ logical function test_EOS_consistency(T_test, S_test, p_test, EOS, verbose, &
     !       2.0*(val - val_fd(2)) / (abs(val) + abs(val_fd(2)) + tiny(val)), &
     !       (1.2*abs(val_fd(2) - val)/2**order + abs(tol))
     if (verbose .and. .not.check_FD) then
-      call MOM_error(WARNING, "The values of "//trim(field_name)//" disagree. "//trim(mesg))
+      write(stderr,*) "The values of "//trim(field_name)//" disagree. "//trim(mesg)
     elseif (verbose) then
-      call MOM_mesg("The values of "//trim(field_name)//" agree: "//trim(mesg))
+      write(stdout,*) "The values of "//trim(field_name)//" agree: "//trim(mesg)
     endif
   end function check_FD
 

--- a/src/equation_of_state/MOM_EOS.F90
+++ b/src/equation_of_state/MOM_EOS.F90
@@ -1517,8 +1517,8 @@ subroutine EOS_init(param_file, EOS, US)
                  "temperature.", units="kg m-3 K-1", default=-0.2)
     call get_param(param_file, mdl, "DRHO_DS", EOS%dRho_dS, &
                  "When EQN_OF_STATE="//trim(EOS_LINEAR_STRING)//", "//&
-                 "this is the partial derivative of density with "//&
-                 "salinity.", units="kg m-3 PSU-1", default=0.8)
+                 "this is the partial derivative of density with salinity.", &
+                 units="kg m-3 ppt-1", default=0.8)
     call EOS_manual_init(EOS, form_of_EOS=EOS_LINEAR, Rho_T0_S0=EOS%Rho_T0_S0, dRho_dT=EOS%dRho_dT, dRho_dS=EOS%dRho_dS)
   endif
   if (EOS%form_of_EOS == EOS_WRIGHT) then
@@ -1563,17 +1563,17 @@ subroutine EOS_init(param_file, EOS, US)
     call get_param(param_file, mdl, "TFREEZE_S0_P0",EOS%TFr_S0_P0, &
                  "When TFREEZE_FORM="//trim(TFREEZE_LINEAR_STRING)//", "//&
                  "this is the freezing potential temperature at "//&
-                 "S=0, P=0.", units="deg C", default=0.0)
+                 "S=0, P=0.", units="degC", default=0.0)
     call get_param(param_file, mdl, "DTFREEZE_DS",EOS%dTFr_dS, &
                  "When TFREEZE_FORM="//trim(TFREEZE_LINEAR_STRING)//", "//&
                  "this is the derivative of the freezing potential "//&
                  "temperature with salinity.", &
-                 units="deg C PSU-1", default=-0.054)
+                 units="degC ppt-1", default=-0.054)
     call get_param(param_file, mdl, "DTFREEZE_DP",EOS%dTFr_dP, &
                  "When TFREEZE_FORM="//trim(TFREEZE_LINEAR_STRING)//", "//&
                  "this is the derivative of the freezing potential "//&
                  "temperature with pressure.", &
-                 units="deg C Pa-1", default=0.0)
+                 units="degC Pa-1", default=0.0)
   endif
 
   if ((EOS%form_of_EOS == EOS_TEOS10 .or. EOS%form_of_EOS == EOS_ROQUET_RHO .or. &
@@ -1694,7 +1694,7 @@ subroutine convert_temp_salt_for_TEOS10(T, S, HI, kd, mask_z, EOS)
   type(EOS_type),        intent(in)    :: EOS !< Equation of state structure
 
   real, parameter :: Sref_Sprac = (35.16504/35.0) ! The TEOS 10 conversion factor to go from
-                                    ! practical salinity to reference salinity [nondim]
+                                    ! practical salinity to reference salinity [PSU ppt-1]
   integer :: i, j, k
 
   if ((EOS%form_of_EOS /= EOS_TEOS10) .and. (EOS%form_of_EOS /= EOS_ROQUET_RHO) .and. &
@@ -1808,20 +1808,20 @@ end subroutine pot_temp_to_cons_temp
 !! temperature uses this same scaling, but this can be replaced by the factor given by scale.
 subroutine abs_saln_to_prac_saln(S, prSaln, EOS, dom, scale)
   real, dimension(:), intent(in)    :: S        !< Absolute salinity [S ~> ppt]
-  real, dimension(:), intent(inout) :: prSaln   !< Practical salinity [S ~> ppt]
+  real, dimension(:), intent(inout) :: prSaln   !< Practical salinity [S ~> PSU]
   type(EOS_type),     intent(in)    :: EOS      !< Equation of state structure
   integer, dimension(2), optional, intent(in) :: dom  !< The domain of indices to work on, taking
                                                 !! into account that arrays start at 1.
   real,     optional, intent(in)    :: scale    !< A multiplicative factor by which to scale the output
-                                                !! practical in place of with scaling stored
+                                                !! practical salinities in place of with scaling stored
                                                 !! in EOS.  A value of 1.0 returns salinities in [PSU],
                                                 !! while the default is equivalent to EOS%ppt_to_S.
 
   ! Local variables
   real, dimension(size(S)) :: Sa    ! Salinity converted to [ppt]
-  real :: S_scale ! A factor to convert practical salinity from ppt to the desired units [S ppt-1 ~> 1]
+  real :: S_scale ! A factor to convert practical salinity from ppt to the desired units [S PSU-1 ~> 1]
   real, parameter :: Sprac_Sref = (35.0/35.16504) ! The TEOS 10 conversion factor to go from
-                                    ! reference salinity to practical salinity [nondim]
+                                    ! reference salinity to practical salinity [PSU ppt-1]
   integer :: i, is, ie
 
   if (present(dom)) then
@@ -1848,21 +1848,21 @@ end subroutine abs_saln_to_prac_saln
 !! use the dimensionally rescaling as specified within the EOS type.  The output potential
 !! temperature uses this same scaling, but this can be replaced by the factor given by scale.
 subroutine prac_saln_to_abs_saln(S, absSaln, EOS, dom, scale)
-  real, dimension(:), intent(in)    :: S        !< Practical salinity [S ~> ppt]
+  real, dimension(:), intent(in)    :: S        !< Practical salinity [S ~> PSU]
   real, dimension(:), intent(inout) :: absSaln  !< Absolute salinity [S ~> ppt]
   type(EOS_type),     intent(in)    :: EOS      !< Equation of state structure
   integer, dimension(2), optional, intent(in) :: dom  !< The domain of indices to work on, taking
                                                 !! into account that arrays start at 1.
   real,     optional, intent(in)    :: scale    !< A multiplicative factor by which to scale the output
-                                                !! practical in place of with scaling stored
-                                                !! in EOS.  A value of 1.0 returns salinities in [PSU],
+                                                !! absolute salnities in place of with scaling stored
+                                                !! in EOS.  A value of 1.0 returns salinities in [ppt],
                                                 !! while the default is equivalent to EOS%ppt_to_S.
 
   ! Local variables
   real, dimension(size(S)) :: Sp    ! Salinity converted to [ppt]
-  real :: S_scale ! A factor to convert practical salinity from ppt to the desired units [S ppt-1 ~> 1]
+  real :: S_scale ! A factor to convert absolute salinity from ppt to the desired units [S ppt-1 ~> 1]
   real, parameter :: Sref_Sprac = (35.16504/35.0) ! The TEOS 10 conversion factor to go from
-                                    ! practical salinity to reference salinity [nondim]
+                                    ! practical salinity to reference salinity [PSU ppt-1]
   integer :: i, is, ie
 
   if (present(dom)) then

--- a/src/equation_of_state/MOM_EOS_Jackett06.F90
+++ b/src/equation_of_state/MOM_EOS_Jackett06.F90
@@ -3,40 +3,11 @@ module MOM_EOS_Jackett06
 
 ! This file is part of MOM6. See LICENSE.md for the license.
 
-use MOM_hor_index, only : hor_index_type
+use MOM_EOS_base_type, only : EOS_base
 
 implicit none ; private
 
-public calculate_compress_Jackett06, calculate_density_Jackett06, calculate_spec_vol_Jackett06
-public calculate_density_derivs_Jackett06, calculate_specvol_derivs_Jackett06
-public calculate_density_second_derivs_Jackett06, EoS_fit_range_Jackett06
-
-!> Compute the in situ density of sea water (in [kg m-3]), or its anomaly with respect to
-!! a reference density, from salinity in practical salinity units ([PSU]), potential
-!! temperature (in degrees Celsius [degC]), and pressure [Pa], using the expressions from
-!! Jackett et al., 2006, J. Atmos. Ocean. Tech., 32, 1709-1728.
-interface calculate_density_Jackett06
-  module procedure calculate_density_scalar_Jackett, calculate_density_array_Jackett
-end interface calculate_density_Jackett06
-
-!> Compute the in situ specific volume of sea water (in [m3 kg-1]), or an anomaly with respect
-!! to a reference specific volume, from salinity in practical salinity units ([PSU]), potential
-!! temperature (in degrees Celsius [degC]), and pressure [Pa], using the expressions from
-!! Jackett et al., 2006, J. Atmos. Ocean. Tech., 32, 1709-1728.
-interface calculate_spec_vol_Jackett06
-  module procedure calculate_spec_vol_scalar_Jackett, calculate_spec_vol_array_Jackett
-end interface calculate_spec_vol_Jackett06
-
-!> Compute the derivatives of density with temperature and salinity
-interface calculate_density_derivs_Jackett06
-  module procedure calculate_density_derivs_scalar_Jackett, calculate_density_derivs_array_Jackett
-end interface calculate_density_derivs_Jackett06
-
-!> Compute the second derivatives of density with various combinations
-!! of temperature, salinity, and pressure
-interface calculate_density_second_derivs_Jackett06
-  module procedure calculate_density_second_derivs_scalar_Jackett, calculate_density_second_derivs_array_Jackett
-end interface calculate_density_second_derivs_Jackett06
+public Jackett06_EOS
 
 !>@{ Parameters in the Jackett et al. equation of state, which is a fit to the Fiestel (2003)
 !    equation of state for the range: -2 < theta < 40 [degC], 0 < S < 42 [PSU], 0 < p < 1e8 [Pa].
@@ -73,21 +44,76 @@ real, parameter :: &
   RD620 =  1.4716275472242334d-09    ! Density denominator S^1.5 T^2 coefficient [degC-2 PSU-1.5]
 !>@}
 
+!> The EOS_base implementation of the Jackett et al, 2006, equation of state
+type, extends (EOS_base) :: Jackett06_EOS
+
+contains
+  !> Implementation of the in-situ density as an elemental function [kg m-3]
+  procedure :: density_elem => density_elem_Jackett06
+  !> Implementation of the in-situ density anomaly as an elemental function [kg m-3]
+  procedure :: density_anomaly_elem => density_anomaly_elem_Jackett06
+  !> Implementation of the in-situ specific volume as an elemental function [m3 kg-1]
+  procedure :: spec_vol_elem => spec_vol_elem_Jackett06
+  !> Implementation of the in-situ specific volume anomaly as an elemental function [m3 kg-1]
+  procedure :: spec_vol_anomaly_elem => spec_vol_anomaly_elem_Jackett06
+  !> Implementation of the calculation of derivatives of density
+  procedure :: calculate_density_derivs_elem => calculate_density_derivs_elem_Jackett06
+  !> Implementation of the calculation of second derivatives of density
+  procedure :: calculate_density_second_derivs_elem => calculate_density_second_derivs_elem_Jackett06
+  !> Implementation of the calculation of derivatives of specific volume
+  procedure :: calculate_specvol_derivs_elem => calculate_specvol_derivs_elem_Jackett06
+  !> Implementation of the calculation of compressibility
+  procedure :: calculate_compress_elem => calculate_compress_elem_Jackett06
+  !> Implementation of the range query function
+  procedure :: EOS_fit_range => EOS_fit_range_Jackett06
+
+end type Jackett06_EOS
+
 contains
 
-!> Computes the in situ density of sea water for 1-d array inputs and outputs.
+!> In situ density of sea water using Jackett et al., 2006 [kg m-3]
 !!
-!! Returns the in situ density of sea water (rho in [kg m-3]) from salinity (S [PSU]),
-!! potential temperature (T [degC]), and pressure [Pa].  It uses the expression from
-!! Jackett et al., 2006, J. Atmos. Ocean. Tech., 32, 1709-1728.
-subroutine calculate_density_array_Jackett(T, S, pres, rho, start, npts, rho_ref)
-  real, dimension(:), intent(in)    :: T        !< Potential temperature relative to the surface [degC].
-  real, dimension(:), intent(in)    :: S        !< Salinity [PSU].
-  real, dimension(:), intent(in)    :: pres     !< Pressure [Pa].
-  real, dimension(:), intent(inout) :: rho      !< In situ density [kg m-3].
-  integer,            intent(in)    :: start    !< The starting point in the arrays.
-  integer,            intent(in)    :: npts     !< The number of values to calculate.
-  real,     optional, intent(in)    :: rho_ref  !< A reference density [kg m-3].
+!! This is an elemental function that can be applied to any combination of scalar and array inputs.
+real elemental function density_elem_Jackett06(this, T, S, pressure)
+  class(Jackett06_EOS), intent(in) :: this !< This EOS
+  real, intent(in) :: T        !< Potential temperature relative to the surface [degC].
+  real, intent(in) :: S        !< Salinity [PSU].
+  real, intent(in) :: pressure !< Pressure [Pa].
+
+  ! Local variables
+  real :: num_STP ! State dependent part of the numerator of the rational expresion
+                  ! for density [kg m-3]
+  real :: den     ! Denominator of the rational expresion for density [nondim]
+  real :: den_STP ! State dependent part of the denominator of the rational expresion
+                  ! for density [nondim]
+  real :: I_den   ! The inverse of the denominator of the rational expresion for density [nondim]
+  real :: T2      ! Temperature squared [degC2]
+  real :: S1_2    ! Limited square root of salinity [PSU1/2]
+
+  S1_2 = sqrt(max(0.0,s))
+  T2 = T*T
+
+  num_STP = (T*(RN010 + T*(RN020 + T*RN030)) + &
+             S*(RN100 + (T*RN110 + S*RN200)) ) + &
+            pressure*(RN001 + ((T2*RN021 + S*RN101) + pressure*(RN002 + T2*RN022)))
+  den = 1.0 + ((T*(RD010 + T*(RD020 + T*(RD030 + T* RD040))) + &
+                S*(RD100 + (T*(RD110 + T2*RD130) + S1_2*(RD600 + T2*RD620))) ) + &
+               pressure*(RD001 + pressure*T*(T2*RD032 + pressure*RD013)) )
+  I_den = 1.0 / den
+
+  density_elem_Jackett06 = (RN000 + num_STP)*I_den
+
+end function density_elem_Jackett06
+
+!> In situ density anomaly of sea water using Jackett et al., 2006 [kg m-3]
+!!
+!! This is an elemental function that can be applied to any combination of scalar and array inputs.
+real elemental function density_anomaly_elem_Jackett06(this, T, S, pressure, rho_ref)
+  class(Jackett06_EOS), intent(in) :: this !< This EOS
+  real, intent(in) :: T        !< Potential temperature relative to the surface [degC].
+  real, intent(in) :: S        !< Salinity [PSU].
+  real, intent(in) :: pressure !< Pressure [Pa].
+  real, intent(in) :: rho_ref  !< A reference density [kg m-3].
 
   ! Local variables
   real :: num_STP ! State dependent part of the numerator of the rational expresion
@@ -99,43 +125,32 @@ subroutine calculate_density_array_Jackett(T, S, pres, rho, start, npts, rho_ref
   real :: T2      ! Temperature squared [degC2]
   real :: S1_2    ! Limited square root of salinity [PSU1/2]
   real :: rho0    ! The surface density of fresh water at 0 degC, perhaps less the refernce density [kg m-3]
-  integer :: j
 
-  do j=start,start+npts-1
-    S1_2 = sqrt(max(0.0,s(j)))
-    T2 = T(j)*T(j)
+  S1_2 = sqrt(max(0.0,s))
+  T2 = T*T
 
-    num_STP = (T(j)*(RN010 + T(j)*(RN020 + T(j)*RN030)) + &
-               S(j)*(RN100 + (T(j)*RN110 + S(j)*RN200)) ) + &
-              pres(j)*(RN001 + ((T2*RN021 + S(j)*RN101) + pres(j)*(RN002 + T2*RN022)))
-    den = 1.0 + ((T(j)*(RD010 + T(j)*(RD020 + T(j)*(RD030 + T(j)* RD040))) + &
-                  S(j)*(RD100 + (T(j)*(RD110 + T2*RD130) + S1_2*(RD600 + T2*RD620))) ) + &
-                 pres(j)*(RD001 + pres(j)*T(j)*(T2*RD032 + pres(j)*RD013)) )
-    I_den = 1.0 / den
+  num_STP = (T*(RN010 + T*(RN020 + T*RN030)) + &
+             S*(RN100 + (T*RN110 + S*RN200)) ) + &
+            pressure*(RN001 + ((T2*RN021 + S*RN101) + pressure*(RN002 + T2*RN022)))
+  den = 1.0 + ((T*(RD010 + T*(RD020 + T*(RD030 + T* RD040))) + &
+                S*(RD100 + (T*(RD110 + T2*RD130) + S1_2*(RD600 + T2*RD620))) ) + &
+               pressure*(RD001 + pressure*T*(T2*RD032 + pressure*RD013)) )
+  I_den = 1.0 / den
 
-    rho0 = RN000
-    if (present(rho_ref)) rho0 = RN000 - rho_ref*den
+  rho0 = RN000 - rho_ref*den
 
-    rho(j) = (rho0 + num_STP)*I_den
-  enddo
+  density_anomaly_elem_Jackett06 = (rho0 + num_STP)*I_den
 
-end subroutine calculate_density_array_Jackett
+end function density_anomaly_elem_Jackett06
 
-!> Computes the Jackett et al. in situ specific volume of sea water for 1-d array inputs and outputs.
+!> In situ specific volume of sea water using Jackett et al., 2006 [m3 kg-1]
 !!
-!! Returns the in situ specific volume of sea water (specvol in [m3 kg-1]) from salinity (S [PSU]),
-!! potential temperature (T [degC]) and pressure [Pa].  It uses the expression from
-!! Jackett et al., 2006, J. Atmos. Ocean. Tech., 32, 1709-1728.
-!! If spv_ref is present, specvol is an anomaly from spv_ref.
-subroutine calculate_spec_vol_array_Jackett(T, S, pres, specvol, start, npts, spv_ref)
-  real, dimension(:), intent(in)    :: T        !< potential temperature relative to the
-                                                !! surface [degC].
-  real, dimension(:), intent(in)    :: S        !< salinity [PSU].
-  real, dimension(:), intent(in)    :: pres     !< pressure [Pa].
-  real, dimension(:), intent(inout) :: specvol  !< in situ specific volume [m3 kg-1].
-  integer,            intent(in)    :: start    !< the starting point in the arrays.
-  integer,            intent(in)    :: npts     !< the number of values to calculate.
-  real,     optional, intent(in)    :: spv_ref  !< A reference specific volume [m3 kg-1].
+!! This is an elemental function that can be applied to any combination of scalar and array inputs.
+real elemental function spec_vol_elem_Jackett06(this, T, S, pressure)
+  class(Jackett06_EOS), intent(in) :: this !< This EOS
+  real,           intent(in) :: T        !< potential temperature relative to the surface [degC].
+  real,           intent(in) :: S        !< salinity [PSU].
+  real,           intent(in) :: pressure !< pressure [Pa].
 
   ! Local variables
   real :: num_STP ! State dependent part of the numerator of the rational expresion
@@ -145,42 +160,68 @@ subroutine calculate_spec_vol_array_Jackett(T, S, pres, specvol, start, npts, sp
   real :: I_num   ! The inverse of the numerator of the rational expresion for density [nondim]
   real :: T2      ! Temperature squared [degC2]
   real :: S1_2    ! Limited square root of salinity [PSU1/2]
-  integer :: j
 
-  do j=start,start+npts-1
-    S1_2 = sqrt(max(0.0,s(j)))
-    T2 = T(j)*T(j)
+  S1_2 = sqrt(max(0.0,s))
+  T2 = T*T
 
-    num_STP = (T(j)*(RN010 + T(j)*(RN020 + T(j)*RN030)) + &
-               S(j)*(RN100 + (T(j)*RN110 + S(j)*RN200)) ) + &
-              pres(j)*(RN001 + ((T2*RN021 + S(j)*RN101) + pres(j)*(RN002 + T2*RN022)))
-    den_STP = (T(j)*(RD010 + T(j)*(RD020 + T(j)*(RD030 + T(j)* RD040))) + &
-               S(j)*(RD100 + (T(j)*(RD110 + T2*RD130) + S1_2*(RD600 + T2*RD620))) ) + &
-              pres(j)*(RD001 + pres(j)*T(j)*(T2*RD032 + pres(j)*RD013))
-    I_num = 1.0 / (RN000 + num_STP)
-    if (present(spv_ref)) then
-      ! This form is slightly more complicated, but it cancels the leading terms better.
-      specvol(j) = ((1.0 - spv_ref*RN000) + (den_STP - spv_ref*num_STP)) * I_num
-    else
-      specvol(j) = (1.0 + den_STP) * I_num
-    endif
-  enddo
+  num_STP = (T*(RN010 + T*(RN020 + T*RN030)) + &
+             S*(RN100 + (T*RN110 + S*RN200)) ) + &
+            pressure*(RN001 + ((T2*RN021 + S*RN101) + pressure*(RN002 + T2*RN022)))
+  den_STP = (T*(RD010 + T*(RD020 + T*(RD030 + T* RD040))) + &
+             S*(RD100 + (T*(RD110 + T2*RD130) + S1_2*(RD600 + T2*RD620))) ) + &
+            pressure*(RD001 + pressure*T*(T2*RD032 + pressure*RD013))
+  I_num = 1.0 / (RN000 + num_STP)
 
-end subroutine calculate_spec_vol_array_Jackett
+  spec_vol_elem_Jackett06 = (1.0 + den_STP) * I_num
 
-!> Return the thermal/haline expansion coefficients for 1-d array inputs and outputs
-subroutine calculate_density_derivs_array_Jackett(T, S, pres, drho_dT, drho_dS, start, npts)
-  real,    intent(in),    dimension(:) :: T        !< Potential temperature relative to the
-                                                   !! surface [degC].
-  real,    intent(in),    dimension(:) :: S        !< Salinity [PSU].
-  real,    intent(in),    dimension(:) :: pres     !< pressure [Pa].
-  real,    intent(inout), dimension(:) :: drho_dT  !< The partial derivative of density with potential
-                                                   !! temperature [kg m-3 degC-1].
-  real,    intent(inout), dimension(:) :: drho_dS  !< The partial derivative of density with salinity,
-                                                   !! in [kg m-3 PSU-1].
-  integer, intent(in)                  :: start    !< The starting point in the arrays.
-  integer, intent(in)                  :: npts     !< The number of values to calculate.
+end function spec_vol_elem_Jackett06
 
+!> In situ specific volume anomaly of sea water using Jackett et al., 2006 [m3 kg-1]
+!!
+!! This is an elemental function that can be applied to any combination of scalar and array inputs.
+real elemental function spec_vol_anomaly_elem_Jackett06(this, T, S, pressure, spv_ref)
+  class(Jackett06_EOS), intent(in) :: this !< This EOS
+  real,           intent(in) :: T        !< potential temperature relative to the surface [degC].
+  real,           intent(in) :: S        !< salinity [PSU].
+  real,           intent(in) :: pressure !< pressure [Pa].
+  real,           intent(in) :: spv_ref  !< A reference specific volume [m3 kg-1].
+
+  ! Local variables
+  real :: num_STP ! State dependent part of the numerator of the rational expresion
+                  ! for density (not specific volume) [kg m-3]
+  real :: den_STP ! State dependent part of the denominator of the rational expresion
+                  ! for density (not specific volume) [nondim]
+  real :: I_num   ! The inverse of the numerator of the rational expresion for density [nondim]
+  real :: T2      ! Temperature squared [degC2]
+  real :: S1_2    ! Limited square root of salinity [PSU1/2]
+
+  S1_2 = sqrt(max(0.0,s))
+  T2 = T*T
+
+  num_STP = (T*(RN010 + T*(RN020 + T*RN030)) + &
+             S*(RN100 + (T*RN110 + S*RN200)) ) + &
+            pressure*(RN001 + ((T2*RN021 + S*RN101) + pressure*(RN002 + T2*RN022)))
+  den_STP = (T*(RD010 + T*(RD020 + T*(RD030 + T* RD040))) + &
+             S*(RD100 + (T*(RD110 + T2*RD130) + S1_2*(RD600 + T2*RD620))) ) + &
+            pressure*(RD001 + pressure*T*(T2*RD032 + pressure*RD013))
+  I_num = 1.0 / (RN000 + num_STP)
+
+  ! This form is slightly more complicated, but it cancels the leading terms better.
+  spec_vol_anomaly_elem_Jackett06 = ((1.0 - spv_ref*RN000) + (den_STP - spv_ref*num_STP)) * I_num
+
+end function spec_vol_anomaly_elem_Jackett06
+
+!> Calculate the partial derivatives of density with potential temperature and salinity
+!! using Jackett et al., 2006
+elemental subroutine calculate_density_derivs_elem_Jackett06(this, T, S, pressure, drho_dT, drho_dS)
+  class(Jackett06_EOS), intent(in) :: this    !< This EOS
+  real,                 intent(in)  :: T        !< Potential temperature relative to the surface [degC]
+  real,                 intent(in)  :: S        !< Salinity [PSU]
+  real,                 intent(in)  :: pressure !< Pressure [Pa]
+  real,                 intent(out) :: drho_dT  !< The partial derivative of density with potential
+                                                !! temperature [kg m-3 degC-1]
+  real,                 intent(out) :: drho_dS  !< The partial derivative of density with salinity,
+                                                !! in [kg m-3 PSU-1]
   ! Local variables
   real :: num     ! Numerator of the rational expresion for density [kg m-3]
   real :: den     ! Denominator of the rational expresion for density [nondim]
@@ -192,147 +233,50 @@ subroutine calculate_density_derivs_array_Jackett(T, S, pres, drho_dT, drho_dS, 
   real :: dden_dS ! The derivative of den with salinity PSU-1]
   real :: T2      ! Temperature squared [degC2]
   real :: S1_2    ! Limited square root of salinity [PSU1/2]
-  integer :: j
 
-  do j=start,start+npts-1
-    S1_2 = sqrt(max(0.0,s(j)))
-    T2 = T(j)*T(j)
+  S1_2 = sqrt(max(0.0,s))
+  T2 = T*T
 
-    num = RN000 + ((T(j)*(RN010 + T(j)*(RN020 + T(j)*RN030)) + &
-                    S(j)*(RN100 + (T(j)*RN110 + S(j)*RN200)) ) + &
-                   pres(j)*(RN001 + ((T2*RN021 + S(j)*RN101) + pres(j)*(RN002 + T2*RN022))) )
-    den = 1.0 + ((T(j)*(RD010 + T(j)*(RD020 + T(j)*(RD030 + T(j)* RD040))) + &
-                  S(j)*(RD100 + (T(j)*(RD110 + T2*RD130) + S1_2*(RD600 + T2*RD620))) ) + &
-                 pres(j)*(RD001 + pres(j)*T(j)*(T2*RD032 + pres(j)*RD013)) )
+  num = RN000 + ((T*(RN010 + T*(RN020 + T*RN030)) + &
+                  S*(RN100 + (T*RN110 + S*RN200)) ) + &
+                 pressure*(RN001 + ((T2*RN021 + S*RN101) + pressure*(RN002 + T2*RN022))) )
+  den = 1.0 + ((T*(RD010 + T*(RD020 + T*(RD030 + T* RD040))) + &
+                S*(RD100 + (T*(RD110 + T2*RD130) + S1_2*(RD600 + T2*RD620))) ) + &
+               pressure*(RD001 + pressure*T*(T2*RD032 + pressure*RD013)) )
 
-    dnum_dT = ((RN010 + T(j)*(2.*RN020 + T(j)*(3.*RN030))) + S(j)*RN110) + &
-              pres(j)*T(j)*(2.*RN021 + pres(j)*(2.*RN022))
-    dnum_dS = (RN100 + (T(j)*RN110 + S(j)*(2.*RN200))) + pres(j)*RN101
-    dden_dT = ((RD010 + T(j)*((2.*RD020) + T(j)*((3.*RD030) + T(j)*(4.*RD040)))) + &
-               S(j)*((RD110 + T2*(3.*RD130)) + S1_2*T(j)*(2.*RD620)) ) + &
-              pres(j)**2*(T2*3.*RD032 + pres(j)*RD013)
-    dden_dS = RD100 + (T(j)*(RD110 + T2*RD130) + S1_2*(1.5*RD600 + T2*(1.5*RD620)))
-    I_denom2 = 1.0 / den**2
+  dnum_dT = ((RN010 + T*(2.*RN020 + T*(3.*RN030))) + S*RN110) + &
+            pressure*T*(2.*RN021 + pressure*(2.*RN022))
+  dnum_dS = (RN100 + (T*RN110 + S*(2.*RN200))) + pressure*RN101
+  dden_dT = ((RD010 + T*((2.*RD020) + T*((3.*RD030) + T*(4.*RD040)))) + &
+             S*((RD110 + T2*(3.*RD130)) + S1_2*T*(2.*RD620)) ) + &
+            pressure**2*(T2*3.*RD032 + pressure*RD013)
+  dden_dS = RD100 + (T*(RD110 + T2*RD130) + S1_2*(1.5*RD600 + T2*(1.5*RD620)))
+  I_denom2 = 1.0 / den**2
 
-    ! rho(j) = num / den
-    drho_dT(j) = (dnum_dT * den - num * dden_dT) * I_denom2
-    drho_dS(j) = (dnum_dS * den - num * dden_dS) * I_denom2
-  enddo
+  ! rho = num / den
+  drho_dT = (dnum_dT * den - num * dden_dT) * I_denom2
+  drho_dS = (dnum_dS * den - num * dden_dS) * I_denom2
 
-end subroutine calculate_density_derivs_array_Jackett
+end subroutine calculate_density_derivs_elem_Jackett06
 
-!> Return the partial derivatives of specific volume with temperature and salinity
-!! for 1-d array inputs and outputs
-subroutine calculate_specvol_derivs_Jackett06(T, S, pres, dSV_dT, dSV_dS, start, npts)
-  real,    intent(in),    dimension(:) :: T        !< Potential temperature relative to the surface [degC].
-  real,    intent(in),    dimension(:) :: S        !< Salinity [PSU].
-  real,    intent(in),    dimension(:) :: pres     !< Pressure [Pa].
-  real,    intent(inout), dimension(:) :: dSV_dT   !< The partial derivative of specific volume with
-                                                   !! potential temperature [m3 kg-1 degC-1].
-  real,    intent(inout), dimension(:) :: dSV_dS   !< The partial derivative of specific volume with
-                                                   !! salinity [m3 kg-1 PSU-1].
-  integer, intent(in)                  :: start    !< The starting point in the arrays.
-  integer, intent(in)                  :: npts     !< The number of values to calculate.
-
-  ! Local variables
-  real :: num     ! Numerator of the rational expresion for density (not specific volume) [kg m-3]
-  real :: den     ! Denominator of the rational expresion for density (not specific volume) [nondim]
-  real :: I_num2  ! The inverse of the square of the numerator of the rational expression
-                  ! for density [nondim]
-  real :: dnum_dT ! The derivative of num with potential temperature [kg m-3 degC-1]
-  real :: dnum_dS ! The derivative of num with salinity [kg m-3 PSU-1]
-  real :: dden_dT ! The derivative of den with potential temperature [degC-1]
-  real :: dden_dS ! The derivative of den with salinity PSU-1]
-  real :: T2      ! Temperature squared [degC2]
-  real :: S1_2    ! Limited square root of salinity [PSU1/2]
-  integer :: j
-
-  do j=start,start+npts-1
-    S1_2 = sqrt(max(0.0,s(j)))
-    T2 = T(j)*T(j)
-
-    num = RN000 + ((T(j)*(RN010 + T(j)*(RN020 + T(j)*RN030)) + &
-                    S(j)*(RN100 + (T(j)*RN110 + S(j)*RN200)) ) + &
-                   pres(j)*(RN001 + ((T2*RN021 + S(j)*RN101) + pres(j)*(RN002 + T2*RN022))) )
-    den = 1.0 + ((T(j)*(RD010 + T(j)*(RD020 + T(j)*(RD030 + T(j)* RD040))) + &
-                  S(j)*(RD100 + (T(j)*(RD110 + T2*RD130) + S1_2*(RD600 + T2*RD620))) ) + &
-                 pres(j)*(RD001 + pres(j)*T(j)*(T2*RD032 + pres(j)*RD013)) )
-
-    dnum_dT = ((RN010 + T(j)*(2.*RN020 + T(j)*(3.*RN030))) + S(j)*RN110) + &
-              pres(j)*T(j)*(2.*RN021 + pres(j)*(2.*RN022))
-    dnum_dS = (RN100 + (T(j)*RN110 + S(j)*(2.*RN200))) + pres(j)*RN101
-    dden_dT = ((RD010 + T(j)*((2.*RD020) + T(j)*((3.*RD030) + T(j)*(4.*RD040)))) + &
-               S(j)*((RD110 + T2*(3.*RD130)) + S1_2*T(j)*(2.*RD620)) ) + &
-              pres(j)**2*(T2*3.*RD032 + pres(j)*RD013)
-    dden_dS = RD100 + (T(j)*(RD110 + T2*RD130) + S1_2*(1.5*RD600 + T2*(1.5*RD620)))
-    I_num2 = 1.0 / num**2
-
-    ! SV(j) = den / num
-    dSV_dT(j) = (num * dden_dT - dnum_dT * den) * I_num2
-    dSV_dS(j) = (num * dden_dS - dnum_dS * den) * I_num2
-  enddo
-
-end subroutine calculate_specvol_derivs_Jackett06
-
-!> Computes the compressibility of seawater for 1-d array inputs and outputs
-subroutine calculate_compress_Jackett06(T, S, pres, rho, drho_dp, start, npts)
-  real,    intent(in),    dimension(:) :: T        !< Potential temperature relative to the surface [degC].
-  real,    intent(in),    dimension(:) :: S        !< Salinity [PSU].
-  real,    intent(in),    dimension(:) :: pres     !< Pressure [Pa].
-  real,    intent(inout), dimension(:) :: rho      !< In situ density [kg m-3].
-  real,    intent(inout), dimension(:) :: drho_dp  !< The partial derivative of density with pressure
-                                                   !! (also the inverse of the square of sound speed)
-                                                   !! [s2 m-2].
-  integer, intent(in)                  :: start    !< The starting point in the arrays.
-  integer, intent(in)                  :: npts     !< The number of values to calculate.
-
-  ! Local variables
-  real :: num     ! Numerator of the rational expresion for density [kg m-3]
-  real :: den     ! Denominator of the rational expresion for density [nondim]
-  real :: I_den   ! The inverse of the denominator of the rational expression for density [nondim]
-  real :: dnum_dp ! The derivative of num with pressure [kg m-3 dbar-1]
-  real :: dden_dp ! The derivative of den with pressure [dbar-1]
-  real :: T2      ! Temperature squared [degC2]
-  real :: S1_2    ! Limited square root of salinity [PSU1/2]
-  integer :: j
-
-  do j=start,start+npts-1
-    S1_2 = sqrt(max(0.0,s(j)))
-    T2 = T(j)*T(j)
-
-    num = RN000 + ((T(j)*(RN010 + T(j)*(RN020 + T(j)*RN030)) + &
-                    S(j)*(RN100 + (T(j)*RN110 + S(j)*RN200)) ) + &
-                   pres(j)*(RN001 + ((T2*RN021 + S(j)*RN101) + pres(j)*(RN002 + T2*RN022))) )
-    den = 1.0 + ((T(j)*(RD010 + T(j)*(RD020 + T(j)*(RD030 + T(j)* RD040))) + &
-                  S(j)*(RD100 + (T(j)*(RD110 + T2*RD130) + S1_2*(RD600 + T2*RD620))) ) + &
-                 pres(j)*(RD001 + pres(j)*T(j)*(T2*RD032 + pres(j)*RD013)) )
-    dnum_dp = RN001 + ((T2*RN021 + S(j)*RN101) + pres(j)*(2.*RN002 + T2*(2.*RN022)))
-    dden_dp = RD001 + pres(j)*T(j)*(T2*(2.*RD032) + pres(j)*(3.*RD013))
-
-    I_den  = 1.0 / den
-    rho(j) = num * I_den
-    drho_dp(j) = (dnum_dp * den - num * dden_dp) * I_den**2
-  enddo
-end subroutine calculate_compress_Jackett06
-
-!> Second derivatives of density with respect to temperature, salinity, and pressure for 1-d array inputs and outputs.
-subroutine calculate_density_second_derivs_array_Jackett(T, S, P, drho_ds_ds, drho_ds_dt, drho_dt_dt, &
-                                                         drho_ds_dp, drho_dt_dp, start, npts)
-  real, dimension(:), intent(in   ) :: T !< Potential temperature referenced to 0 dbar [degC]
-  real, dimension(:), intent(in   ) :: S !< Salinity [PSU]
-  real, dimension(:), intent(in   ) :: P !< Pressure [Pa]
-  real, dimension(:), intent(inout) :: drho_ds_ds !< Partial derivative of beta with respect
+!> Calculate second derivatives of density with respect to temperature, salinity, and pressure,
+!! using Jackett et al., 2006
+elemental subroutine calculate_density_second_derivs_elem_Jackett06(this, T, S, pressure, &
+                       drho_ds_ds, drho_ds_dt, drho_dt_dt, drho_ds_dp, drho_dt_dp)
+  class(Jackett06_EOS), intent(in)  :: this     !< This EOS
+  real,               intent(in)    :: T !< Potential temperature referenced to 0 dbar [degC]
+  real,               intent(in)    :: S !< Salinity [PSU]
+  real,               intent(in)    :: pressure !< Pressure [Pa]
+  real,               intent(inout) :: drho_ds_ds !< Partial derivative of beta with respect
                                                   !! to S [kg m-3 PSU-2]
-  real, dimension(:), intent(inout) :: drho_ds_dt !< Partial derivative of beta with respect
+  real,               intent(inout) :: drho_ds_dt !< Partial derivative of beta with respect
                                                   !! to T [kg m-3 PSU-1 degC-1]
-  real, dimension(:), intent(inout) :: drho_dt_dt !< Partial derivative of alpha with respect
+  real,               intent(inout) :: drho_dt_dt !< Partial derivative of alpha with respect
                                                   !! to T [kg m-3 degC-2]
-  real, dimension(:), intent(inout) :: drho_ds_dp !< Partial derivative of beta with respect
+  real,               intent(inout) :: drho_ds_dp !< Partial derivative of beta with respect
                                                   !! to pressure [kg m-3 PSU-1 Pa-1] = [s2 m-2 PSU-1]
-  real, dimension(:), intent(inout) :: drho_dt_dp !< Partial derivative of alpha with respect
+  real,               intent(inout) :: drho_dt_dp !< Partial derivative of alpha with respect
                                                   !! to pressure [kg m-3 degC-1 Pa-1] = [s2 m-2 degC-1]
-  integer,            intent(in   ) :: start !< Starting index in T,S,P
-  integer,            intent(in   ) :: npts  !< Number of points to loop over
 
   ! Local variables
   real :: num         ! Numerator of the rational expresion for density [kg m-3]
@@ -365,186 +309,159 @@ subroutine calculate_density_second_derivs_array_Jackett(T, S, P, drho_ds_ds, dr
                       ! for density [nondim]
   real :: I_denom3    ! The inverse of the cube of the denominator of the rational expression
                       ! for density [nondim]
+
+  S1_2 = sqrt(max(0.0,s))
+  T2 = T*T
+
+  num = RN000 + ((T*(RN010 + T*(RN020 + T*RN030)) + &
+                  S*(RN100 + (T*RN110 + S*RN200)) ) + &
+                 pressure*(RN001 + ((T2*RN021 + S*RN101) + pressure*(RN002 + T2*RN022))) )
+  den = 1.0 + ((T*(RD010 + T*(RD020 + T*(RD030 + T* RD040))) + &
+                S*(RD100 + (T*(RD110 + T2*RD130) + S1_2*(RD600 + T2*RD620))) ) + &
+               pressure*(RD001 + pressure*T*(T2*RD032 + pressure*RD013)) )
+  ! rho = num*I_den
+
+  dnum_dT = ((RN010 + T*(2.*RN020 + T*(3.*RN030))) + S*RN110) + &
+            pressure*T*(2.*RN021 + pressure*(2.*RN022))
+  dnum_dS = (RN100 + (T*RN110 + S*(2.*RN200))) + pressure*RN101
+  dnum_dp = RN001 + ((T2*RN021 + S*RN101) + pressure*(2.*RN002 + T2*(2.*RN022)))
+  d2num_dT2 = 2.*RN020 + T*(6.*RN030) + pressure*(2.*RN021 + pressure*(2.*RN022))
+  d2num_dT_dS = RN110
+  d2num_dS2 = 2.*RN200
+  d2num_dT_dp = T*(2.*RN021 + pressure*(4.*RN022))
+  d2num_dS_dp = RN101
+
+  dden_dT = ((RD010 + T*((2.*RD020) + T*((3.*RD030) + T*(4.*RD040)))) + &
+             S*((RD110 + T2*(3.*RD130)) + S1_2*T*(2.*RD620)) ) + &
+            pressure**2*(T2*3.*RD032 + pressure*RD013)
+  dden_dS = RD100 + (T*(RD110 + T2*RD130) + S1_2*(1.5*RD600 + T2*(1.5*RD620)))
+  dden_dp = RD001 + pressure*T*(T2*(2.*RD032) + pressure*(3.*RD013))
+
+  d2den_dT2 = (((2.*RD020) + T*((6.*RD030) + T*(12.*RD040))) + &
+               S*(T*(6.*RD130) + S1_2*(2.*RD620)) ) + pressure**2*(T*(6.*RD032))
+  d2den_dT_dS = (RD110 + T2*3.*RD130) + (T*S1_2)*(3.0*RD620)
+  d2den_dT_dp = pressure*(T2*(6.*RD032) + pressure*(3.*RD013))
+  d2den_dS_dp = 0.0
+
+  ! The Jackett et al. 2006 equation of state is a fit to density, but it chooses a form that
+  ! exhibits a singularity in the second derivatives with salinity for fresh water.  To avoid
+  ! this, the square root of salinity can be treated with a floor such that the contribution from
+  ! the S**1.5 terms to both the surface density and the secant bulk modulus are lost to roundoff.
+  ! This salinity is given by (~1e-16/RD600)**(2/3) ~= 7e-8 PSU, or S1_2 ~= 2.6e-4
+  I_S12 = 1.0 / (max(S1_2, 1.0e-4))
+  d2den_dS2 = (0.75*RD600 + T2*(0.75*RD620)) * I_S12
+
+  I_denom3 = 1.0 / den**3
+
+  ! In deriving the following, it is useful to note that:
+  !   drho_dp = (dnum_dp * den - num * dden_dp) / den**2
+  !   drho_dT = (dnum_dT * den - num * dden_dT) / den**2
+  !   drho_dS = (dnum_dS * den - num * dden_dS) / den**2
+  drho_dS_dS = (den*(den*d2num_dS2 - 2.*dnum_dS*dden_dS) + num*(2.*dden_dS**2 - den*d2den_dS2)) * I_denom3
+  drho_dS_dt = (den*(den*d2num_dT_dS - (dnum_dT*dden_dS + dnum_dS*dden_dT)) + &
+                   num*(2.*dden_dT*dden_dS - den*d2den_dT_dS)) * I_denom3
+  drho_dT_dT = (den*(den*d2num_dT2 - 2.*dnum_dT*dden_dT) + num*(2.*dden_dT**2 - den*d2den_dT2)) * I_denom3
+
+  drho_dS_dp = (den*(den*d2num_dS_dp - (dnum_dp*dden_dS + dnum_dS*dden_dp)) + &
+                   num*(2.*dden_dS*dden_dp - den*d2den_dS_dp)) * I_denom3
+  drho_dT_dp = (den*(den*d2num_dT_dp - (dnum_dp*dden_dT + dnum_dT*dden_dp)) + &
+                   num*(2.*dden_dT*dden_dp - den*d2den_dT_dp)) * I_denom3
+
+end subroutine calculate_density_second_derivs_elem_Jackett06
+
+!> Calculate second derivatives of density with respect to temperature, salinity, and pressure,
+!! using Jackett et al., 2006
+elemental subroutine calculate_specvol_derivs_elem_Jackett06(this, T, S, pressure, dSV_dT, dSV_dS)
+  class(Jackett06_EOS), intent(in)  :: this !< This EOS
+  real,               intent(in)    :: T        !< Potential temperature [degC]
+  real,               intent(in)    :: S        !< Salinity [PSU]
+  real,               intent(in)    :: pressure !< Pressure [Pa]
+  real,               intent(inout) :: dSV_dT   !< The partial derivative of specific volume with
+                                                !! potential temperature [m3 kg-1 degC-1]
+  real,               intent(inout) :: dSV_dS   !< The partial derivative of specific volume with
+                                                !! salinity [m3 kg-1 PSU-1]
+
+  ! Local variables
+  real :: num     ! Numerator of the rational expresion for density (not specific volume) [kg m-3]
+  real :: den     ! Denominator of the rational expresion for density (not specific volume) [nondim]
+  real :: I_num2  ! The inverse of the square of the numerator of the rational expression
+                  ! for density [nondim]
+  real :: dnum_dT ! The derivative of num with potential temperature [kg m-3 degC-1]
+  real :: dnum_dS ! The derivative of num with salinity [kg m-3 PSU-1]
+  real :: dden_dT ! The derivative of den with potential temperature [degC-1]
+  real :: dden_dS ! The derivative of den with salinity PSU-1]
+  real :: T2      ! Temperature squared [degC2]
+  real :: S1_2    ! Limited square root of salinity [PSU1/2]
+
+  S1_2 = sqrt(max(0.0,s))
+  T2 = T*T
+
+  num = RN000 + ((T*(RN010 + T*(RN020 + T*RN030)) + &
+                  S*(RN100 + (T*RN110 + S*RN200)) ) + &
+                 pressure*(RN001 + ((T2*RN021 + S*RN101) + pressure*(RN002 + T2*RN022))) )
+  den = 1.0 + ((T*(RD010 + T*(RD020 + T*(RD030 + T* RD040))) + &
+                S*(RD100 + (T*(RD110 + T2*RD130) + S1_2*(RD600 + T2*RD620))) ) + &
+               pressure*(RD001 + pressure*T*(T2*RD032 + pressure*RD013)) )
+
+  dnum_dT = ((RN010 + T*(2.*RN020 + T*(3.*RN030))) + S*RN110) + &
+            pressure*T*(2.*RN021 + pressure*(2.*RN022))
+  dnum_dS = (RN100 + (T*RN110 + S*(2.*RN200))) + pressure*RN101
+  dden_dT = ((RD010 + T*((2.*RD020) + T*((3.*RD030) + T*(4.*RD040)))) + &
+             S*((RD110 + T2*(3.*RD130)) + S1_2*T*(2.*RD620)) ) + &
+            pressure**2*(T2*3.*RD032 + pressure*RD013)
+  dden_dS = RD100 + (T*(RD110 + T2*RD130) + S1_2*(1.5*RD600 + T2*(1.5*RD620)))
+  I_num2 = 1.0 / num**2
+
+  ! SV = den / num
+  dSV_dT = (num * dden_dT - dnum_dT * den) * I_num2
+  dSV_dS = (num * dden_dS - dnum_dS * den) * I_num2
+
+end subroutine calculate_specvol_derivs_elem_Jackett06
+
+!> Compute the in situ density of sea water (rho) and the compressibility (drho/dp == C_sound^-2)
+!! at the given salinity, potential temperature and pressure using Jackett et al., 2006
+elemental subroutine calculate_compress_elem_Jackett06(this, T, S, pressure, rho, drho_dp)
+  class(Jackett06_EOS), intent(in) :: this    !< This EOS
+  real,               intent(in)  :: T        !< Potential temperature relative to the surface [degC]
+  real,               intent(in)  :: S        !< Salinity [PSU]
+  real,               intent(in)  :: pressure !< Pressure [Pa]
+  real,               intent(out) :: rho      !< In situ density [kg m-3]
+  real,               intent(out) :: drho_dp  !< The partial derivative of density with pressure
+                                              !! (also the inverse of the square of sound speed)
+                                              !! [s2 m-2]
+  ! Local variables
+  real :: num     ! Numerator of the rational expresion for density [kg m-3]
+  real :: den     ! Denominator of the rational expresion for density [nondim]
+  real :: I_den   ! The inverse of the denominator of the rational expression for density [nondim]
+  real :: dnum_dp ! The derivative of num with pressure [kg m-3 dbar-1]
+  real :: dden_dp ! The derivative of den with pressure [dbar-1]
+  real :: T2      ! Temperature squared [degC2]
+  real :: S1_2    ! Limited square root of salinity [PSU1/2]
   integer :: j
 
-  do j = start,start+npts-1
-    S1_2 = sqrt(max(0.0,s(j)))
-    T2 = T(j)*T(j)
+  S1_2 = sqrt(max(0.0,s))
+  T2 = T*T
 
-    num = RN000 + ((T(j)*(RN010 + T(j)*(RN020 + T(j)*RN030)) + &
-                    S(j)*(RN100 + (T(j)*RN110 + S(j)*RN200)) ) + &
-                   P(j)*(RN001 + ((T2*RN021 + S(j)*RN101) + P(j)*(RN002 + T2*RN022))) )
-    den = 1.0 + ((T(j)*(RD010 + T(j)*(RD020 + T(j)*(RD030 + T(j)* RD040))) + &
-                  S(j)*(RD100 + (T(j)*(RD110 + T2*RD130) + S1_2*(RD600 + T2*RD620))) ) + &
-                 P(j)*(RD001 + P(j)*T(j)*(T2*RD032 + P(j)*RD013)) )
-    ! rho(j) = num*I_den
+  num = RN000 + ((T*(RN010 + T*(RN020 + T*RN030)) + &
+                  S*(RN100 + (T*RN110 + S*RN200)) ) + &
+                 pressure*(RN001 + ((T2*RN021 + S*RN101) + pressure*(RN002 + T2*RN022))) )
+  den = 1.0 + ((T*(RD010 + T*(RD020 + T*(RD030 + T* RD040))) + &
+                S*(RD100 + (T*(RD110 + T2*RD130) + S1_2*(RD600 + T2*RD620))) ) + &
+               pressure*(RD001 + pressure*T*(T2*RD032 + pressure*RD013)) )
+  dnum_dp = RN001 + ((T2*RN021 + S*RN101) + pressure*(2.*RN002 + T2*(2.*RN022)))
+  dden_dp = RD001 + pressure*T*(T2*(2.*RD032) + pressure*(3.*RD013))
 
-    dnum_dT = ((RN010 + T(j)*(2.*RN020 + T(j)*(3.*RN030))) + S(j)*RN110) + &
-              P(j)*T(j)*(2.*RN021 + P(j)*(2.*RN022))
-    dnum_dS = (RN100 + (T(j)*RN110 + S(j)*(2.*RN200))) + P(j)*RN101
-    dnum_dp = RN001 + ((T2*RN021 + S(j)*RN101) + P(j)*(2.*RN002 + T2*(2.*RN022)))
-    d2num_dT2 = 2.*RN020 + T(j)*(6.*RN030) + P(j)*(2.*RN021 + P(j)*(2.*RN022))
-    d2num_dT_dS = RN110
-    d2num_dS2 = 2.*RN200
-    d2num_dT_dp = T(j)*(2.*RN021 + P(j)*(4.*RN022))
-    d2num_dS_dp = RN101
+  I_den  = 1.0 / den
+  rho = num * I_den
+  drho_dp = (dnum_dp * den - num * dden_dp) * I_den**2
 
-    dden_dT = ((RD010 + T(j)*((2.*RD020) + T(j)*((3.*RD030) + T(j)*(4.*RD040)))) + &
-               S(j)*((RD110 + T2*(3.*RD130)) + S1_2*T(j)*(2.*RD620)) ) + &
-              P(j)**2*(T2*3.*RD032 + P(j)*RD013)
-    dden_dS = RD100 + (T(j)*(RD110 + T2*RD130) + S1_2*(1.5*RD600 + T2*(1.5*RD620)))
-    dden_dp = RD001 + P(j)*T(j)*(T2*(2.*RD032) + P(j)*(3.*RD013))
-
-    d2den_dT2 = (((2.*RD020) + T(j)*((6.*RD030) + T(j)*(12.*RD040))) + &
-                 S(j)*(T(j)*(6.*RD130) + S1_2*(2.*RD620)) ) + P(j)**2*(T(j)*(6.*RD032))
-    d2den_dT_dS = (RD110 + T2*3.*RD130) + (T(j)*S1_2)*(3.0*RD620)
-    d2den_dT_dp = P(j)*(T2*(6.*RD032) + P(j)*(3.*RD013))
-    d2den_dS_dp = 0.0
-
-    ! The Jackett et al. 2006 equation of state is a fit to density, but it chooses a form that
-    ! exhibits a singularity in the second derivatives with salinity for fresh water.  To avoid
-    ! this, the square root of salinity can be treated with a floor such that the contribution from
-    ! the S**1.5 terms to both the surface density and the secant bulk modulus are lost to roundoff.
-    ! This salinity is given by (~1e-16/RD600)**(2/3) ~= 7e-8 PSU, or S1_2 ~= 2.6e-4
-    I_S12 = 1.0 / (max(S1_2, 1.0e-4))
-    d2den_dS2 = (0.75*RD600 + T2*(0.75*RD620)) * I_S12
-
-    I_denom3 = 1.0 / den**3
-
-    ! In deriving the following, it is useful to note that:
-    !   drho_dp(j) = (dnum_dp * den - num * dden_dp) / den**2
-    !   drho_dT(j) = (dnum_dT * den - num * dden_dT) / den**2
-    !   drho_dS(j) = (dnum_dS * den - num * dden_dS) / den**2
-    drho_dS_dS(j) = (den*(den*d2num_dS2 - 2.*dnum_dS*dden_dS) + num*(2.*dden_dS**2 - den*d2den_dS2)) * I_denom3
-    drho_dS_dt(j) = (den*(den*d2num_dT_dS - (dnum_dT*dden_dS + dnum_dS*dden_dT)) + &
-                     num*(2.*dden_dT*dden_dS - den*d2den_dT_dS)) * I_denom3
-    drho_dT_dT(j) = (den*(den*d2num_dT2 - 2.*dnum_dT*dden_dT) + num*(2.*dden_dT**2 - den*d2den_dT2)) * I_denom3
-
-    drho_dS_dp(j) = (den*(den*d2num_dS_dp - (dnum_dp*dden_dS + dnum_dS*dden_dp)) + &
-                     num*(2.*dden_dS*dden_dp - den*d2den_dS_dp)) * I_denom3
-    drho_dT_dp(j) = (den*(den*d2num_dT_dp - (dnum_dp*dden_dT + dnum_dT*dden_dp)) + &
-                     num*(2.*dden_dT*dden_dp - den*d2den_dT_dp)) * I_denom3
-  enddo
-
-end subroutine calculate_density_second_derivs_array_Jackett
-
-!> Computes the in situ density of sea water for scalar inputs and outputs.
-!!
-!! Returns the in situ density of sea water (rho in [kg m-3]) from salinity (S [PSU]),
-!! potential temperature (T [degC]), and pressure [Pa].  It uses the expression from
-!! Jackett et al., 2006, J. Atmos. Ocean. Tech., 32, 1709-1728.
-subroutine calculate_density_scalar_Jackett(T, S, pressure, rho, rho_ref)
-  real,           intent(in)  :: T        !< Potential temperature relative to the surface [degC].
-  real,           intent(in)  :: S        !< Salinity [PSU].
-  real,           intent(in)  :: pressure !< pressure [Pa].
-  real,           intent(out) :: rho      !< In situ density [kg m-3].
-  real, optional, intent(in)  :: rho_ref  !< A reference density [kg m-3].
-
-  ! Local variables
-  real, dimension(1) :: T0    ! A 1-d array with a copy of the potential temperature [degC]
-  real, dimension(1) :: S0    ! A 1-d array with a copy of the salinity [PSU]
-  real, dimension(1) :: pressure0 ! A 1-d array with a copy of the pressure [Pa]
-  real, dimension(1) :: rho0  ! A 1-d array with a copy of the density [kg m-3]
-
-  T0(1) = T ; S0(1) = S ; pressure0(1) = pressure
-  call calculate_density_array_Jackett(T0, S0, pressure0, rho0, 1, 1, rho_ref)
-  rho = rho0(1)
-
-end subroutine calculate_density_scalar_Jackett
-
-!> Computes the Jackett et al. 2006 in situ specific volume of sea water for scalar inputs and outputs.
-!!
-!! Returns the in situ specific volume of sea water (specvol in [m3 kg-1]) from salinity (S [PSU]),
-!! potential temperature (T [degC]) and pressure [Pa].  It uses the expression from
-!! Jackett et al., 2006, J. Atmos. Ocean. Tech., 32, 1709-1728.
-!! If spv_ref is present, specvol is an anomaly from spv_ref.
-subroutine calculate_spec_vol_scalar_Jackett(T, S, pressure, specvol, spv_ref)
-  real,           intent(in)  :: T        !< potential temperature relative to the surface [degC].
-  real,           intent(in)  :: S        !< salinity [PSU].
-  real,           intent(in)  :: pressure !< pressure [Pa].
-  real,           intent(out) :: specvol  !< in situ specific volume [m3 kg-1].
-  real, optional, intent(in)  :: spv_ref  !< A reference specific volume [m3 kg-1].
-
-  ! Local variables
-  real, dimension(1) :: T0    ! A 1-d array with a copy of the potential temperature [degC]
-  real, dimension(1) :: S0    ! A 1-d array with a copy of the salinity [PSU]
-  real, dimension(1) :: pressure0 ! A 1-d array with a copy of the pressure [Pa]
-  real, dimension(1) :: spv0  ! A 1-d array with a copy of the specific volume [m3 kg-1]
-
-  T0(1) = T ; S0(1) = S ; pressure0(1) = pressure
-  call calculate_spec_vol_array_Jackett(T0, S0, pressure0, spv0, 1, 1, spv_ref)
-  specvol = spv0(1)
-end subroutine calculate_spec_vol_scalar_Jackett
-
-!> Return the thermal/haline expansion coefficients for scalar inputs and outputs
-!!
-!! The scalar version of calculate_density_derivs promotes scalar inputs to 1-element array
-!! and then demotes the output back to a scalar
-subroutine calculate_density_derivs_scalar_Jackett(T, S, pressure, drho_dT, drho_dS)
-  real,    intent(in)  :: T        !< Potential temperature relative to the surface [degC].
-  real,    intent(in)  :: S        !< Salinity [PSU].
-  real,    intent(in)  :: pressure !< pressure [Pa].
-  real,    intent(out) :: drho_dT  !< The partial derivative of density with potential
-                                   !! temperature [kg m-3 degC-1].
-  real,    intent(out) :: drho_dS  !< The partial derivative of density with salinity,
-                                   !! in [kg m-3 PSU-1].
-
-  ! Local variables needed to promote the input/output scalars to 1-element arrays
-  real, dimension(1) :: T0    ! A 1-d array with a copy of the temperature [degC]
-  real, dimension(1) :: S0    ! A 1-d array with a copy of the salinity [PSU]
-  real, dimension(1) :: p0    ! A 1-d array with a copy of the pressure [Pa]
-  real, dimension(1) :: drdt0 ! The derivative of density with temperature [kg m-3 degC-1]
-  real, dimension(1) :: drds0 ! The derivative of density with salinity [kg m-3 PSU-1]
-
-  T0(1) = T ; S0(1) = S ; P0(1) = pressure
-  call calculate_density_derivs_array_Jackett(T0, S0, P0, drdt0, drds0, 1, 1)
-  drho_dT = drdt0(1) ; drho_dS = drds0(1)
-
-end subroutine calculate_density_derivs_scalar_Jackett
-
-!> Second derivatives of density with respect to temperature, salinity, and pressure for scalar inputs.
-!!
-!! The scalar version of calculate_density_second_derivs promotes scalar inputs to 1-element array
-!! and then demotes the output back to a scalar
-subroutine calculate_density_second_derivs_scalar_Jackett(T, S, P, drho_ds_ds, drho_ds_dt, drho_dt_dt, &
-                                                         drho_ds_dp, drho_dt_dp)
-  real, intent(in   ) :: T          !< Potential temperature referenced to 0 dbar
-  real, intent(in   ) :: S          !< Salinity [PSU]
-  real, intent(in   ) :: P          !< pressure [Pa]
-  real, intent(  out) :: drho_ds_ds !< Partial derivative of beta with respect
-                                    !! to S [kg m-3 PSU-2]
-  real, intent(  out) :: drho_ds_dt !< Partial derivative of beta with respect
-                                    !! to T [kg m-3 PSU-1 degC-1]
-  real, intent(  out) :: drho_dt_dt !< Partial derivative of alpha with respect
-                                    !! to T [kg m-3 degC-2]
-  real, intent(  out) :: drho_ds_dp !< Partial derivative of beta with respect
-                                    !! to pressure [kg m-3 PSU-1 Pa-1] = [s2 m-2 PSU-1]
-  real, intent(  out) :: drho_dt_dp !< Partial derivative of alpha with respect
-                                    !! to pressure [kg m-3 degC-1 Pa-1] = [s2 m-2 degC-1]
-  ! Local variables
-  real, dimension(1) :: T0    ! A 1-d array with a copy of the temperature [degC]
-  real, dimension(1) :: S0    ! A 1-d array with a copy of the salinity [PSU]
-  real, dimension(1) :: p0    ! A 1-d array with a copy of the pressure [Pa]
-  real, dimension(1) :: drdsds ! The second derivative of density with salinity [kg m-3 PSU-2]
-  real, dimension(1) :: drdsdt ! The second derivative of density with salinity and
-                               ! temperature [kg m-3 PSU-1 degC-1]
-  real, dimension(1) :: drdtdt ! The second derivative of density with temperature [kg m-3 degC-2]
-  real, dimension(1) :: drdsdp ! The second derivative of density with salinity and
-                               ! pressure [kg m-3 PSU-1 Pa-1] = [s2 m-2 PSU-1]
-  real, dimension(1) :: drdtdp ! The second derivative of density with temperature and
-                               ! pressure [kg m-3 degC-1 Pa-1] = [s2 m-2 degC-1]
-
-  T0(1) = T ; S0(1) = S ; P0(1) = P
-  call calculate_density_second_derivs_array_Jackett(T0, S0, P0, drdsds, drdsdt, drdtdt, drdsdp, drdtdp, 1, 1)
-  drho_ds_ds = drdsds(1) ; drho_ds_dt = drdsdt(1) ; drho_dt_dt = drdtdt(1)
-  drho_ds_dp = drdsdp(1) ; drho_dt_dp = drdtdp(1)
-
-end subroutine calculate_density_second_derivs_scalar_Jackett
+end subroutine calculate_compress_elem_Jackett06
 
 !> Return the range of temperatures, salinities and pressures for which the Jackett et al. (2006)
 !! equation of state has been fitted to observations.  Care should be taken when applying this
 !! equation of state outside of its fit range.
-subroutine EoS_fit_range_Jackett06(T_min, T_max, S_min, S_max, p_min, p_max)
+subroutine EoS_fit_range_Jackett06(this, T_min, T_max, S_min, S_max, p_min, p_max)
+  class(Jackett06_EOS), intent(in) :: this !< This EOS
   real, optional, intent(out) :: T_min !< The minimum potential temperature over which this EoS is fitted [degC]
   real, optional, intent(out) :: T_max !< The maximum potential temperature over which this EoS is fitted [degC]
   real, optional, intent(out) :: S_min !< The minimum practical salinity over which this EoS is fitted [PSU]
@@ -562,6 +479,7 @@ subroutine EoS_fit_range_Jackett06(T_min, T_max, S_min, S_max, p_min, p_max)
   if (present(p_max)) p_max = 8.5e7
 
 end subroutine EoS_fit_range_Jackett06
+
 
 !> \namespace mom_eos_Jackett06
 !!

--- a/src/equation_of_state/MOM_EOS_Roquet_SpV.F90
+++ b/src/equation_of_state/MOM_EOS_Roquet_SpV.F90
@@ -3,42 +3,11 @@ module MOM_EOS_Roquet_Spv
 
 ! This file is part of MOM6. See LICENSE.md for the license.
 
-!use gsw_mod_toolbox, only : gsw_sr_from_sp, gsw_ct_from_pt
+use MOM_EOS_base_type, only : EOS_base
 
 implicit none ; private
 
-public calculate_compress_Roquet_SpV, calculate_density_Roquet_SpV, calculate_spec_vol_Roquet_SpV
-public calculate_density_derivs_Roquet_SpV, calculate_specvol_derivs_Roquet_SpV
-public calculate_density_scalar_Roquet_SpV, calculate_density_array_Roquet_SpV
-public calculate_density_second_derivs_Roquet_SpV, EoS_fit_range_Roquet_SpV
-
-!> Compute the in situ density of sea water [kg m-3], or its anomaly with respect to
-!! a reference density, from absolute salinity [g kg-1], conservative temperature [degC],
-!! and pressure [Pa], using the specific volume polynomial fit from Roquet et al. (2015)
-interface calculate_density_Roquet_SpV
-  module procedure calculate_density_scalar_Roquet_SpV, calculate_density_array_Roquet_SpV
-end interface calculate_density_Roquet_SpV
-
-!> Compute the in situ specific volume of sea water (in [m3 kg-1]), or an anomaly with respect
-!! to a reference specific volume, from absolute salinity ([g kg-1]), conservative
-!! temperature (in degrees Celsius [degC]), and pressure [Pa], using the specific volume
-!! polynomial fit from Roquet et al. (2015)
-interface calculate_spec_vol_Roquet_SpV
-  module procedure calculate_spec_vol_scalar_Roquet_SpV, calculate_spec_vol_array_Roquet_SpV
-end interface calculate_spec_vol_Roquet_SpV
-
-!> For a given thermodynamic state, return the derivatives of density with conservative temperature
-!! and absolute salinity, using the specific volume polynomial fit from Roquet et al. (2015)
-interface calculate_density_derivs_Roquet_SpV
-  module procedure calculate_density_derivs_scalar_Roquet_SpV, calculate_density_derivs_array_Roquet_SpV
-end interface calculate_density_derivs_Roquet_SpV
-
-!> Compute the second derivatives of density with various combinations of temperature, salinity
-!! and pressure using the specific volume polynomial fit from Roquet et al. (2015)
-interface calculate_density_second_derivs_Roquet_SpV
-  module procedure calculate_density_second_derivs_scalar_Roquet_SpV
-  module procedure calculate_density_second_derivs_array_Roquet_SpV
-end interface calculate_density_second_derivs_Roquet_SpV
+public Roquet_SpV_EOS
 
 real, parameter :: Pa2kb  = 1.e-8 !< Conversion factor between Pa and kbar [kbar Pa-1]
 !>@{ Parameters in the Roquet specific volume polynomial equation of state
@@ -184,48 +153,46 @@ real, parameter :: BET012 = 0.5*SPV112*r1_S0  ! dSpV_dS fit T * P**2 coef. [m3 k
 real, parameter :: BET003 = 0.5*SPV103*r1_S0  ! dSpV_dS fit P**3 coef.          [m3 kg-1 ppt-1 Pa-3]
 !>@}
 
+!> The EOS_base implementation of the Roquet et al., 2015, equation of state
+type, extends (EOS_base) :: Roquet_SpV_EOS
+
+contains
+  !> Implementation of the in-situ density as an elemental function [kg m-3]
+  procedure :: density_elem => density_elem_Roquet_SpV
+  !> Implementation of the in-situ density anomaly as an elemental function [kg m-3]
+  procedure :: density_anomaly_elem => density_anomaly_elem_Roquet_SpV
+  !> Implementation of the in-situ specific volume as an elemental function [m3 kg-1]
+  procedure :: spec_vol_elem => spec_vol_elem_Roquet_SpV
+  !> Implementation of the in-situ specific volume anomaly as an elemental function [m3 kg-1]
+  procedure :: spec_vol_anomaly_elem => spec_vol_anomaly_elem_Roquet_SpV
+  !> Implementation of the calculation of derivatives of density
+  procedure :: calculate_density_derivs_elem => calculate_density_derivs_elem_Roquet_SpV
+  !> Implementation of the calculation of second derivatives of density
+  procedure :: calculate_density_second_derivs_elem => calculate_density_second_derivs_elem_Roquet_SpV
+  !> Implementation of the calculation of derivatives of specific volume
+  procedure :: calculate_specvol_derivs_elem => calculate_specvol_derivs_elem_Roquet_SpV
+  !> Implementation of the calculation of compressibility
+  procedure :: calculate_compress_elem => calculate_compress_elem_Roquet_SpV
+  !> Implementation of the range query function
+  procedure :: EOS_fit_range => EOS_fit_range_Roquet_SpV
+
+  !> Local implementation of generic calculate_density_array for efficiency
+  procedure :: calculate_density_array => calculate_density_array_Roquet_SpV
+  !> Local implementation of generic calculate_spec_vol_array for efficiency
+  procedure :: calculate_spec_vol_array => calculate_spec_vol_array_Roquet_SpV
+
+end type Roquet_SpV_EOS
+
 contains
 
-!> Computes the Roquet et al. in situ specific volume of sea water for scalar inputs and outputs.
+!> Roquet et al. in situ specific volume of sea water [m3 kg-1]
 !!
-!! Returns the in situ specific volume of sea water (specvol in [m3 kg-1]) from absolute salinity (S [g kg-1]),
-!! conservative temperature (T [degC]) and pressure [Pa].  It uses the specific volume polynomial
-!! fit from Roquet et al. (2015).
-!! If spv_ref is present, specvol is an anomaly from spv_ref.
-subroutine calculate_spec_vol_scalar_Roquet_SpV(T, S, pressure, specvol, spv_ref)
-  real,           intent(in)  :: T        !< Conservative temperature [degC]
-  real,           intent(in)  :: S        !< Absolute salinity [g kg-1]
-  real,           intent(in)  :: pressure !< Pressure [Pa]
-  real,           intent(out) :: specvol  !< In situ specific volume [m3 kg-1]
-  real, optional, intent(in)  :: spv_ref  !< A reference specific volume [m3 kg-1]
-
-  ! Local variables
-  real, dimension(1) :: T0    ! A 1-d array with a copy of the conservative temperature [degC]
-  real, dimension(1) :: S0    ! A 1-d array with a copy of the absolutes salinity [g kg-1]
-  real, dimension(1) :: pres0 ! A 1-d array with a copy of the pressure [Pa]
-  real, dimension(1) :: spv0  ! A 1-d array with a copy of the specific volume [m3 kg-1]
-
-  T0(1) = T ; S0(1) = S ; pres0(1) = pressure
-
-  call calculate_spec_vol_array_Roquet_SpV(T0, S0, pres0, spv0, 1, 1, spv_ref)
-  specvol = spv0(1)
-
-end subroutine calculate_spec_vol_scalar_Roquet_SpV
-
-!> Computes the Roquet et al. in situ specific volume of sea water for 1-d array inputs and outputs.
-!!
-!! Returns the in situ specific volume of sea water (specvol in [m3 kg-1]) from absolute salinity (S [g kg-1]),
-!! conservative temperature (T [degC]) and pressure [Pa].  It uses the specific volume polynomial
-!! fit from Roquet et al. (2015).
-!! If spv_ref is present, specvol is an anomaly from spv_ref.
-subroutine calculate_spec_vol_array_Roquet_SpV(T, S, pressure, specvol, start, npts, spv_ref)
-  real, dimension(:), intent(in)    :: T        !< Conservative temperature [degC]
-  real, dimension(:), intent(in)    :: S        !< Absolute salinity [g kg-1]
-  real, dimension(:), intent(in)    :: pressure !< pressure [Pa]
-  real, dimension(:), intent(inout) :: specvol  !< in situ specific volume [m3 kg-1]
-  integer,            intent(in)    :: start    !< The starting index for calculations
-  integer,            intent(in)    :: npts     !< the number of values to calculate
-  real,     optional, intent(in)    :: spv_ref  !< A reference specific volume [m3 kg-1]
+!! This is an elemental function that can be applied to any combination of scalar and array inputs.
+real elemental function spec_vol_elem_Roquet_SpV(this, T, S, pressure)
+  class(Roquet_SpV_EOS), intent(in) :: this     !< This EOS
+  real,                  intent(in) :: T        !< Conservative temperature [degC]
+  real,                  intent(in) :: S        !< Absolute salinity [g kg-1]
+  real,                  intent(in) :: pressure !< pressure [Pa]
 
   ! Local variables
   real :: zp     ! Pressure [Pa]
@@ -244,118 +211,153 @@ subroutine calculate_spec_vol_array_Roquet_SpV(T, S, pressure, specvol, start, n
   real :: SV_TS3 ! A temperature and salinity dependent specific volume contribution that is
                  ! proportional to pressure**3 [m3 kg-1 Pa-3]
   real :: SV_0S0 ! Salinity dependent specific volume at the surface pressure and zero temperature [m3 kg-1]
-  integer :: j
 
   ! The following algorithm was published by Roquet et al. (2015), intended for use in non-Boussinesq ocean models.
-  do j=start,start+npts-1
-    ! Conversions to the units used here.
-    zt = T(j)
-    zs = SQRT( ABS( S(j) + rdeltaS ) * r1_S0 )  ! square root of normalized salinity plus an offset [nondim]
-    zp = pressure(j)
 
-    ! The next two lines should be used if it is necessary to convert potential temperature and
-    ! practical salinity to conservative temperature and absolute salinity.
-    ! zt = gsw_ct_from_pt(S(j),T(j)) ! Convert potential temp to conservative temp [degC]
-    ! zs = SQRT( ABS( gsw_sr_from_sp(S(j)) + rdeltaS ) * r1_S0 ) ! Convert S from practical to absolute salinity.
+  ! Conversions to the units used here.
+  zt = T
+  zs = SQRT( ABS( S + rdeltaS ) * r1_S0 )  ! square root of normalized salinity plus an offset [nondim]
+  zp = pressure
 
-    SV_TS3 = SPV003 + (zs*SPV103 + zt*SPV013)
-    SV_TS2 = SPV002 + (zs*(SPV102 +  zs*SPV202) &
-                     + zt*(SPV012 + (zs*SPV112 + zt*SPV022)) )
-    SV_TS1 = SPV001 + (zs*(SPV101 +  zs*(SPV201 +  zs*(SPV301 +  zs*SPV401))) &
-                     + zt*(SPV011 + (zs*(SPV111 +  zs*(SPV211 +  zs*SPV311)) &
-                                   + zt*(SPV021 + (zs*(SPV121 +  zs*SPV221) &
-                                                 + zt*(SPV031 + (zs*SPV131 + zt*SPV041)) )) )) )
-    SV_TS0 = zt*(SPV010 &
-               + (zs*(SPV110 +  zs*(SPV210 +  zs*(SPV310 +  zs*(SPV410 +  zs*SPV510)))) &
-                + zt*(SPV020 + (zs*(SPV120 +  zs*(SPV220 +  zs*(SPV320 +  zs*SPV420))) &
-                              + zt*(SPV030 + (zs*(SPV130 +  zs*(SPV230 +  zs*SPV330)) &
-                                            + zt*(SPV040 + (zs*(SPV140 +  zs*SPV240) &
-                                                          + zt*(SPV050 + (zs*SPV150 + zt*SPV060)) )) )) )) ) )
+  ! The next two lines should be used if it is necessary to convert potential temperature and
+  ! practical salinity to conservative temperature and absolute salinity.
+  ! zt = gsw_ct_from_pt(S,T) ! Convert potential temp to conservative temp [degC]
+  ! zs = SQRT( ABS( gsw_sr_from_sp(S) + rdeltaS ) * r1_S0 ) ! Convert S from practical to absolute salinity.
 
-    SV_0S0 = SPV000 + zs*(SPV100 + zs*(SPV200 + zs*(SPV300 + zs*(SPV400 + zs*(SPV500 + zs*SPV600)))))
+  SV_TS3 = SPV003 + (zs*SPV103 + zt*SPV013)
+  SV_TS2 = SPV002 + (zs*(SPV102 +  zs*SPV202) &
+                   + zt*(SPV012 + (zs*SPV112 + zt*SPV022)) )
+  SV_TS1 = SPV001 + (zs*(SPV101 +  zs*(SPV201 +  zs*(SPV301 +  zs*SPV401))) &
+                   + zt*(SPV011 + (zs*(SPV111 +  zs*(SPV211 +  zs*SPV311)) &
+                                 + zt*(SPV021 + (zs*(SPV121 +  zs*SPV221) &
+                                               + zt*(SPV031 + (zs*SPV131 + zt*SPV041)) )) )) )
+  SV_TS0 = zt*(SPV010 &
+             + (zs*(SPV110 +  zs*(SPV210 +  zs*(SPV310 +  zs*(SPV410 +  zs*SPV510)))) &
+              + zt*(SPV020 + (zs*(SPV120 +  zs*(SPV220 +  zs*(SPV320 +  zs*SPV420))) &
+                            + zt*(SPV030 + (zs*(SPV130 +  zs*(SPV230 +  zs*SPV330)) &
+                                          + zt*(SPV040 + (zs*(SPV140 +  zs*SPV240) &
+                                                        + zt*(SPV050 + (zs*SPV150 + zt*SPV060)) )) )) )) ) )
 
-    SV_00p = zp*(V00 + zp*(V01 + zp*(V02 + zp*(V03 + zp*(V04 + zp*V05)))))
+  SV_0S0 = SPV000 + zs*(SPV100 + zs*(SPV200 + zs*(SPV300 + zs*(SPV400 + zs*(SPV500 + zs*SPV600)))))
 
-    if (present(spv_ref)) SV_0S0 = SV_0S0 - spv_ref
+  SV_00p = zp*(V00 + zp*(V01 + zp*(V02 + zp*(V03 + zp*(V04 + zp*V05)))))
 
-    SV_TS  = (SV_TS0 + SV_0S0) + zp*(SV_TS1 + zp*(SV_TS2 +  zp*SV_TS3))
-    specvol(j) = SV_TS + SV_00p  ! In situ specific volume [m3 kg-1]
-  enddo
+  SV_TS  = (SV_TS0 + SV_0S0) + zp*(SV_TS1 + zp*(SV_TS2 +  zp*SV_TS3))
+  spec_vol_elem_Roquet_SpV = SV_TS + SV_00p  ! In situ specific volume [m3 kg-1]
 
-end subroutine calculate_spec_vol_array_Roquet_SpV
+end function spec_vol_elem_Roquet_SpV
 
-
-!> Compute the in situ density of sea water at a point (rho in [kg m-3]) from absolute
-!! salinity (S [g kg-1]), conservative temperature (T [degC]) and pressure [Pa], using the
-!! specific volume polynomial fit from Roquet et al. (2015).
-subroutine calculate_density_scalar_Roquet_SpV(T, S, pressure, rho, rho_ref)
-  real,           intent(in)  :: T        !< Conservative temperature [degC]
-  real,           intent(in)  :: S        !< Absolute salinity [g kg-1]
-  real,           intent(in)  :: pressure !< Pressure [Pa]
-  real,           intent(out) :: rho      !< In situ density [kg m-3]
-  real, optional, intent(in)  :: rho_ref  !< A reference density [kg m-3]
-
-  real, dimension(1) :: T0    ! A 1-d array with a copy of the conservative temperature [degC]
-  real, dimension(1) :: S0    ! A 1-d array with a copy of the absolute salinity [g kg-1]
-  real, dimension(1) :: pres0 ! A 1-d array with a copy of the pressure [Pa]
-  real, dimension(1) :: spv   ! A 1-d array with the specific volume [m3 kg-1]
-
-  T0(1) = T
-  S0(1) = S
-  pres0(1) = pressure
-
-  if (present(rho_ref)) then
-    call calculate_spec_vol_array_Roquet_SpV(T0, S0, pres0, spv, 1, 1, spv_ref=1.0/rho_ref)
-    rho = -rho_ref**2*spv(1) / (rho_ref*spv(1) + 1.0)  ! In situ density [kg m-3]
-  else
-    call calculate_spec_vol_array_Roquet_SpV(T0, S0, pres0, spv, 1, 1)
-    rho = 1.0 / spv(1)
-  endif
-
-end subroutine calculate_density_scalar_Roquet_SpV
-
-!> Compute an array of in situ densities of sea water (rho in [kg m-3]) from absolute
-!! salinity (S [g kg-1]), conservative temperature (T [degC]) and pressure [Pa],
-!! using the specific volume polynomial fit from Roquet et al. (2015).
-subroutine calculate_density_array_Roquet_SpV(T, S, pressure, rho, start, npts, rho_ref)
-  real, dimension(:), intent(in)  :: T        !< Conservative temperature [degC]
-  real, dimension(:), intent(in)  :: S        !< Absolute salinity [g kg-1]
-  real, dimension(:), intent(in)  :: pressure !< Pressure [Pa]
-  real, dimension(:), intent(out) :: rho      !< In situ density [kg m-3]
-  integer,            intent(in)  :: start    !< The starting index for calculations
-  integer,            intent(in)  :: npts     !< The number of values to calculate
-  real,     optional, intent(in)  :: rho_ref  !< A reference density [kg m-3]
+!> Roquet et al. in situ specific volume anomaly of sea water [m3 kg-1]
+!!
+!! This is an elemental function that can be applied to any combination of scalar and array inputs.
+real elemental function spec_vol_anomaly_elem_Roquet_SpV(this, T, S, pressure, spv_ref)
+  class(Roquet_SpV_EOS), intent(in) :: this     !< This EOS
+  real,                  intent(in) :: T        !< Conservative temperature [degC]
+  real,                  intent(in) :: S        !< Absolute salinity [g kg-1]
+  real,                  intent(in) :: pressure !< pressure [Pa]
+  real,                  intent(in) :: spv_ref  !< A reference specific volume [m3 kg-1]
 
   ! Local variables
-  real, dimension(size(T)) :: spv   ! The specific volume [m3 kg-1]
-  integer :: j
+  real :: zp     ! Pressure [Pa]
+  real :: zt     ! Conservative temperature [degC]
+  real :: zs     ! The square root of absolute salinity with an offset normalized
+                 ! by an assumed salinity range [nondim]
+  real :: SV_00p ! A pressure-dependent but temperature and salinity independent contribution to
+                 ! specific volume at the reference temperature and salinity [m3 kg-1]
+  real :: SV_TS  ! Specific volume without a pressure-dependent contribution [m3 kg-1]
+  real :: SV_TS0 ! A contribution to specific volume from temperature and salinity anomalies at
+                 ! the surface pressure [m3 kg-1]
+  real :: SV_TS1 ! A temperature and salinity dependent specific volume contribution that is
+                 ! proportional to pressure [m3 kg-1 Pa-1]
+  real :: SV_TS2 ! A temperature and salinity dependent specific volume contribution that is
+                 ! proportional to pressure**2 [m3 kg-1 Pa-2]
+  real :: SV_TS3 ! A temperature and salinity dependent specific volume contribution that is
+                 ! proportional to pressure**3 [m3 kg-1 Pa-3]
+  real :: SV_0S0 ! Salinity dependent specific volume at the surface pressure and zero temperature [m3 kg-1]
 
-  if (present(rho_ref)) then
-    call calculate_spec_vol_array_Roquet_SpV(T, S, pressure, spv, start, npts, spv_ref=1.0/rho_ref)
-    do j=start,start+npts-1
-      rho(j) = -rho_ref**2*spv(j) / (rho_ref*spv(j) + 1.0)  ! In situ density [kg m-3]
-    enddo
-  else
-    call calculate_spec_vol_array_Roquet_SpV(T, S, pressure, spv, start, npts)
-    do j=start,start+npts-1
-      rho(j) = 1.0 / spv(j)  ! In situ density [kg m-3]
-    enddo
-  endif
+  ! The following algorithm was published by Roquet et al. (2015), intended for use in non-Boussinesq ocean models.
 
-end subroutine calculate_density_array_Roquet_SpV
+  ! Conversions to the units used here.
+  zt = T
+  zs = SQRT( ABS( S + rdeltaS ) * r1_S0 )  ! square root of normalized salinity plus an offset [nondim]
+  zp = pressure
+
+  ! The next two lines should be used if it is necessary to convert potential temperature and
+  ! practical salinity to conservative temperature and absolute salinity.
+  ! zt = gsw_ct_from_pt(S,T) ! Convert potential temp to conservative temp [degC]
+  ! zs = SQRT( ABS( gsw_sr_from_sp(S) + rdeltaS ) * r1_S0 ) ! Convert S from practical to absolute salinity.
+
+  SV_TS3 = SPV003 + (zs*SPV103 + zt*SPV013)
+  SV_TS2 = SPV002 + (zs*(SPV102 +  zs*SPV202) &
+                   + zt*(SPV012 + (zs*SPV112 + zt*SPV022)) )
+  SV_TS1 = SPV001 + (zs*(SPV101 +  zs*(SPV201 +  zs*(SPV301 +  zs*SPV401))) &
+                   + zt*(SPV011 + (zs*(SPV111 +  zs*(SPV211 +  zs*SPV311)) &
+                                 + zt*(SPV021 + (zs*(SPV121 +  zs*SPV221) &
+                                               + zt*(SPV031 + (zs*SPV131 + zt*SPV041)) )) )) )
+  SV_TS0 = zt*(SPV010 &
+             + (zs*(SPV110 +  zs*(SPV210 +  zs*(SPV310 +  zs*(SPV410 +  zs*SPV510)))) &
+              + zt*(SPV020 + (zs*(SPV120 +  zs*(SPV220 +  zs*(SPV320 +  zs*SPV420))) &
+                            + zt*(SPV030 + (zs*(SPV130 +  zs*(SPV230 +  zs*SPV330)) &
+                                          + zt*(SPV040 + (zs*(SPV140 +  zs*SPV240) &
+                                                        + zt*(SPV050 + (zs*SPV150 + zt*SPV060)) )) )) )) ) )
+
+  SV_0S0 = SPV000 + zs*(SPV100 + zs*(SPV200 + zs*(SPV300 + zs*(SPV400 + zs*(SPV500 + zs*SPV600)))))
+
+  SV_00p = zp*(V00 + zp*(V01 + zp*(V02 + zp*(V03 + zp*(V04 + zp*V05)))))
+
+  SV_0S0 = SV_0S0 - spv_ref
+
+  SV_TS  = (SV_TS0 + SV_0S0) + zp*(SV_TS1 + zp*(SV_TS2 +  zp*SV_TS3))
+  spec_vol_anomaly_elem_Roquet_SpV = SV_TS + SV_00p  ! In situ specific volume [m3 kg-1]
+
+end function spec_vol_anomaly_elem_Roquet_SpV
+
+!> Roquet in situ density [kg m-3]
+!!
+!! This is an elemental function that can be applied to any combination of scalar and array inputs.
+real elemental function density_elem_Roquet_SpV(this, T, S, pressure)
+  class(Roquet_SpV_EOS), intent(in) :: this     !< This EOS
+  real,                  intent(in) :: T        !< Conservative temperature [degC]
+  real,                  intent(in) :: S        !< Absolute salinity [g kg-1]
+  real,                  intent(in) :: pressure !< Pressure [Pa]
+
+  ! Local variables
+  real :: spv ! The specific volume [m3 kg-1]
+
+  spv = spec_vol_elem_Roquet_SpV(this, T, S, pressure)
+  density_elem_Roquet_SpV = 1.0 / spv  ! In situ density [kg m-3]
+
+end function density_elem_Roquet_SpV
+
+!> Roquet in situ density anomaly [kg m-3]
+!!
+!! This is an elemental function that can be applied to any combination of scalar and array inputs.
+real elemental function density_anomaly_elem_Roquet_SpV(this, T, S, pressure, rho_ref)
+  class(Roquet_SpV_EOS), intent(in) :: this     !< This EOS
+  real,                  intent(in) :: T        !< Conservative temperature [degC]
+  real,                  intent(in) :: S        !< Absolute salinity [g kg-1]
+  real,                  intent(in) :: pressure !< Pressure [Pa]
+  real,                  intent(in) :: rho_ref  !< A reference density [kg m-3]
+
+  ! Local variables
+  real :: spv ! The specific volume [m3 kg-1]
+
+  spv = spec_vol_anomaly_elem_Roquet_SpV(this, T, S, pressure, spv_ref=1.0/rho_ref)
+  density_anomaly_elem_Roquet_SpV = -rho_ref**2*spv / (rho_ref*spv + 1.0)  ! In situ density [kg m-3]
+
+end function density_anomaly_elem_Roquet_SpV
 
 !> Return the partial derivatives of specific volume with temperature and salinity for 1-d array
 !! inputs and outputs, using the specific volume polynomial fit from Roquet et al. (2015).
-subroutine calculate_specvol_derivs_Roquet_SpV(T, S, pressure, dSV_dT, dSV_dS, start, npts)
-  real,    intent(in),    dimension(:) :: T        !< Conservative temperature [degC]
-  real,    intent(in),    dimension(:) :: S        !< Absolute salinity [g kg-1]
-  real,    intent(in),    dimension(:) :: pressure !< Pressure [Pa]
-  real,    intent(inout), dimension(:) :: dSV_dT   !< The partial derivative of specific volume with
+elemental subroutine calculate_specvol_derivs_elem_Roquet_SpV(this, T, S, pressure, dSV_dT, dSV_dS)
+  class(Roquet_SpV_EOS), intent(in)    :: this     !< This EOS
+  real,                  intent(in)    :: T        !< Conservative temperature [degC]
+  real,                  intent(in)    :: S        !< Absolute salinity [g kg-1]
+  real,                  intent(in)    :: pressure !< Pressure [Pa]
+  real,                  intent(inout) :: dSV_dT   !< The partial derivative of specific volume with
                                                    !! conservative temperature [m3 kg-1 degC-1]
-  real,    intent(inout), dimension(:) :: dSV_dS   !< The partial derivative of specific volume with
+  real,                  intent(inout) :: dSV_dS   !< The partial derivative of specific volume with
                                                    !! absolute salinity [m3 kg-1 ppt-1]
-  integer, intent(in)                  :: start    !< The starting index for calculations
-  integer, intent(in)                  :: npts     !< The number of values to calculate
 
   real :: zp      ! Pressure [Pa]
   real :: zt      ! Conservative temperature [degC]
@@ -377,127 +379,91 @@ subroutine calculate_specvol_derivs_Roquet_SpV(T, S, pressure, dSV_dT, dSV_dS, s
                   ! salinity [m3 kg-1 ppt-1 Pa-2] proportional to pressure**2
   real :: dSVdzs3 ! A contribution to the partial derivative of specific volume with
                   ! salinity [m3 kg-1 ppt-1 Pa-3] proportional to pressure**3
-  integer :: j
 
-  do j=start,start+npts-1
-    ! Conversions to the units used here.
-    zt = T(j)
-    zs = SQRT( ABS( S(j) + rdeltaS ) * r1_S0 )  ! square root of normalized salinity plus an offset [nondim]
-    zp = pressure(j)
+  ! Conversions to the units used here.
+  zt = T
+  zs = SQRT( ABS( S + rdeltaS ) * r1_S0 )  ! square root of normalized salinity plus an offset [nondim]
+  zp = pressure
 
-    ! The next two lines should be used if it is necessary to convert potential temperature and
-    ! practical salinity to conservative temperature and absolute salinity.
-    ! zt = gsw_ct_from_pt(S(j),T(j)) ! Convert potential temp to conservative temp [degC]
-    ! zs = SQRT( ABS( gsw_sr_from_sp(S(j)) + rdeltaS ) * r1_S0 ) ! Convert S from practical to absolute salinity.
+  ! The next two lines should be used if it is necessary to convert potential temperature and
+  ! practical salinity to conservative temperature and absolute salinity.
+  ! zt = gsw_ct_from_pt(S,T) ! Convert potential temp to conservative temp [degC]
+  ! zs = SQRT( ABS( gsw_sr_from_sp(S) + rdeltaS ) * r1_S0 ) ! Convert S from practical to absolute salinity.
 
-    ! Find the partial derivative of specific volume with temperature
-    dSVdzt3 = ALP003
-    dSVdzt2 = ALP002 + (zs*ALP102 + zt*ALP012)
-    dSVdzt1 = ALP001 + (zs*(ALP101 + zs*(ALP201 + zs*ALP301)) &
-                      + zt*(ALP011 + (zs*(ALP111 + zs*ALP211) &
-                                    + zt*(ALP021 + (zs*ALP121 + zt*ALP031)) )) )
-    dSVdzt0 = ALP000 + (zs*(ALP100 +  zs*(ALP200 +  zs*(ALP300 + zs*(ALP400 + zs*ALP500)))) &
-                      + zt*(ALP010 + (zs*(ALP110 +  zs*(ALP210 + zs*(ALP310 + zs*ALP410))) &
-                                    + zt*(ALP020 + (zs*(ALP120 + zs*(ALP220 + zs*ALP320)) &
-                                                  + zt*(ALP030 + (zt*(ALP040 + (zs*ALP140 + zt*ALP050)) &
-                                                                + zs*(ALP130 + zs*ALP230) )) )) )) )
+  ! Find the partial derivative of specific volume with temperature
+  dSVdzt3 = ALP003
+  dSVdzt2 = ALP002 + (zs*ALP102 + zt*ALP012)
+  dSVdzt1 = ALP001 + (zs*(ALP101 + zs*(ALP201 + zs*ALP301)) &
+                    + zt*(ALP011 + (zs*(ALP111 + zs*ALP211) &
+                                  + zt*(ALP021 + (zs*ALP121 + zt*ALP031)) )) )
+  dSVdzt0 = ALP000 + (zs*(ALP100 +  zs*(ALP200 +  zs*(ALP300 + zs*(ALP400 + zs*ALP500)))) &
+                    + zt*(ALP010 + (zs*(ALP110 +  zs*(ALP210 + zs*(ALP310 + zs*ALP410))) &
+                                  + zt*(ALP020 + (zs*(ALP120 + zs*(ALP220 + zs*ALP320)) &
+                                                + zt*(ALP030 + (zt*(ALP040 + (zs*ALP140 + zt*ALP050)) &
+                                                              + zs*(ALP130 + zs*ALP230) )) )) )) )
 
-    dSV_dT(j) = dSVdzt0 + zp*(dSVdzt1 + zp*(dSVdzt2 + zp*dSVdzt3))
+  dSV_dT = dSVdzt0 + zp*(dSVdzt1 + zp*(dSVdzt2 + zp*dSVdzt3))
 
-    ! Find the partial derivative of specific volume with salinity
-    dSVdzs3 = BET003
-    dSVdzs2 = BET002 + (zs*BET102 + zt*BET012)
-    dSVdzs1 = BET001 + (zs*(BET101 + zs*(BET201 + zs*BET301)) &
-                      + zt*(BET011 + (zs*(BET111 + zs*BET211) &
-                                    + zt*(BET021 + (zs*BET121 + zt*BET031)) )) )
-    dSVdzs0 = BET000 + (zs*(BET100 + zs*(BET200 + zs*(BET300 + zs*(BET400 + zs*BET500)))) &
-                      + zt*(BET010 + (zs*(BET110 + zs*(BET210 + zs*(BET310 + zs*BET410))) &
-                                    + zt*(BET020 + (zs*(BET120 + zs*(BET220 + zs*BET320)) &
-                                                  + zt*(BET030 + (zt*(BET040 + (zs*BET140 + zt*BET050)) &
-                                                                + zs*(BET130 + zs*BET230) )) )) )) )
+  ! Find the partial derivative of specific volume with salinity
+  dSVdzs3 = BET003
+  dSVdzs2 = BET002 + (zs*BET102 + zt*BET012)
+  dSVdzs1 = BET001 + (zs*(BET101 + zs*(BET201 + zs*BET301)) &
+                    + zt*(BET011 + (zs*(BET111 + zs*BET211) &
+                                  + zt*(BET021 + (zs*BET121 + zt*BET031)) )) )
+  dSVdzs0 = BET000 + (zs*(BET100 + zs*(BET200 + zs*(BET300 + zs*(BET400 + zs*BET500)))) &
+                    + zt*(BET010 + (zs*(BET110 + zs*(BET210 + zs*(BET310 + zs*BET410))) &
+                                  + zt*(BET020 + (zs*(BET120 + zs*(BET220 + zs*BET320)) &
+                                                + zt*(BET030 + (zt*(BET040 + (zs*BET140 + zt*BET050)) &
+                                                              + zs*(BET130 + zs*BET230) )) )) )) )
 
-    ! The division by zs here is because zs = sqrt(S + S0), so dSV_dS = dzs_dS * dSV_dzs = (0.5 / zs) * dSV_dzs
-    dSV_dS(j) = (dSVdzs0 + zp*(dSVdzs1 + zp*(dSVdzs2 + zp * dSVdzs3))) / zs
-  enddo
+  ! The division by zs here is because zs = sqrt(S + S0), so dSV_dS = dzs_dS * dSV_dzs = (0.5 / zs) * dSV_dzs
+  dSV_dS = (dSVdzs0 + zp*(dSVdzs1 + zp*(dSVdzs2 + zp * dSVdzs3))) / zs
 
-end subroutine calculate_specvol_derivs_Roquet_SpV
-
+end subroutine calculate_specvol_derivs_elem_Roquet_SpV
 
 !> Compute an array of derivatives of densities of sea water with temperature (drho_dT in [kg m-3 degC-1])
 !! and salinity (drho_dS in [kg m-3 ppt-1]) from absolute salinity (S [g kg-1]), conservative temperature
 !! (T [degC]) and pressure [Pa], using the specific volume polynomial fit from Roquet et al. (2015).
-subroutine calculate_density_derivs_array_Roquet_SpV(T, S, pressure, drho_dT, drho_dS, start, npts)
-  real,    intent(in),  dimension(:) :: T        !< Conservative temperature [degC]
-  real,    intent(in),  dimension(:) :: S        !< Absolute salinity [g kg-1]
-  real,    intent(in),  dimension(:) :: pressure !< pressure [Pa]
-  real,    intent(out), dimension(:) :: drho_dT  !< The partial derivative of density with
-                                                 !! conservative temperature [kg m-3 degC-1]
-  real,    intent(out), dimension(:) :: drho_dS  !< The partial derivative of density with
+elemental subroutine calculate_density_derivs_elem_Roquet_SpV(this, T, S, pressure, drho_dT, drho_dS)
+  class(Roquet_SpV_EOS), intent(in)  :: this     !< This EOS
+  real,                  intent(in)  :: T        !< Conservative temperature [degC]
+  real,                  intent(in)  :: S        !< Absolute salinity [g kg-1]
+  real,                  intent(in)  :: pressure !< pressure [Pa]
+  real,                  intent(out) :: drho_dT  !< The partial derivative of density with
+                                                  !! conservative temperature [kg m-3 degC-1]
+  real,                  intent(out) :: drho_dS  !< The partial derivative of density with
                                                  !! absolute salinity [kg m-3 ppt-1]
-  integer, intent(in)                :: start    !< The starting index for calculations
-  integer, intent(in)                :: npts     !< The number of values to calculate
 
   ! Local variables
-  real, dimension(size(T)) :: specvol  ! The specific volume [m3 kg-1]
-  real, dimension(size(T)) :: dSV_dT   ! The partial derivative of specific volume with
+  real :: dSV_dT   ! The partial derivative of specific volume with
                                        ! conservative temperature [m3 kg-1 degC-1]
-  real, dimension(size(T)) :: dSV_dS   ! The partial derivative of specific volume with
+  real :: dSV_dS   ! The partial derivative of specific volume with
                                        ! absolute salinity [m3 kg-1 ppt-1]
+  real :: specvol  ! The specific volume [m3 kg-1]
   real :: rho  ! The in situ density [kg m-3]
-  integer :: j
 
-  call calculate_spec_vol_array_Roquet_SpV(T, S, pressure, specvol, start, npts)
-  call calculate_specvol_derivs_Roquet_SpV(T, S, pressure, dSV_dT, dSV_dS, start, npts)
+  call this%calculate_specvol_derivs_elem(T, S, pressure, dSV_dT, dSV_dS)
 
-  do j=start,start+npts-1
-    rho = 1.0 / specvol(j)
-    drho_dT(j) = -dSv_dT(j) * rho**2
-    drho_dS(j) = -dSv_dS(j) * rho**2
-  enddo
+  specvol = this%spec_vol_elem(T, S, pressure)
+  rho = 1.0 / specvol
+  drho_dT = -dSv_dT * rho**2
+  drho_dS = -dSv_dS * rho**2
 
-end subroutine calculate_density_derivs_array_Roquet_SpV
-
-!> Wrapper to calculate_density_derivs_array_Roquet_SpV for scalar inputs
-subroutine calculate_density_derivs_scalar_Roquet_SpV(T, S, pressure, drho_dt, drho_ds)
-  real,    intent(in)  :: T        !< Conservative temperature [degC]
-  real,    intent(in)  :: S        !< Absolute salinity [g kg-1]
-  real,    intent(in)  :: pressure !< Pressure [Pa]
-  real,    intent(out) :: drho_dT  !< The partial derivative of density with
-                                   !! conservative temperature [kg m-3 degC-1]
-  real,    intent(out) :: drho_dS  !< The partial derivative of density with
-                                   !! absolute salinity [kg m-3 ppt-1]
-  ! Local variables
-  real, dimension(1) :: T0    ! A 1-d array with a copy of the conservative temperature [degC]
-  real, dimension(1) :: S0    ! A 1-d array with a copy of the absolute salinity [g kg-1]
-  real, dimension(1) :: pres0 ! A 1-d array with a copy of the pressure [Pa]
-  real, dimension(1) :: drdt0 ! A 1-d array with a copy of the derivative of density
-                              ! with conservative temperature [kg m-3 degC-1]
-  real, dimension(1) :: drds0 ! A 1-d array with a copy of the derivative of density
-                              ! with absolute salinity [kg m-3 ppt-1]
-
-  T0(1) = T
-  S0(1) = S
-  pres0(1) = pressure
-
-  call calculate_density_derivs_array_Roquet_SpV(T0, S0, pres0, drdt0, drds0, 1, 1)
-  drho_dt = drdt0(1)
-  drho_ds = drds0(1)
-end subroutine calculate_density_derivs_scalar_Roquet_SpV
+end subroutine calculate_density_derivs_elem_Roquet_SpV
 
 !> Compute the in situ density of sea water (rho in [kg m-3]) and the compressibility
 !! (drho/dp = C_sound^-2, stored as drho_dp [s2 m-2]) from absolute salinity (sal [g kg-1]),
 !! conservative temperature (T [degC]), and pressure [Pa], using the specific volume
 !! polynomial fit from Roquet et al. (2015).
-subroutine calculate_compress_Roquet_SpV(T, S, pressure, rho, drho_dp, start, npts)
-  real,    intent(in),  dimension(:) :: T        !< Conservative temperature [degC]
-  real,    intent(in),  dimension(:) :: S        !< Absolute salinity [g kg-1]
-  real,    intent(in),  dimension(:) :: pressure !< pressure [Pa]
-  real,    intent(out), dimension(:) :: rho      !< In situ density [kg m-3]
-  real,    intent(out), dimension(:) :: drho_dp  !< The partial derivative of density with pressure
+elemental subroutine calculate_compress_elem_Roquet_SpV(this, T, S, pressure, rho, drho_dp)
+  class(Roquet_SpV_EOS), intent(in)  :: this     !< This EOS
+  real,                  intent(in)  :: T        !< Conservative temperature [degC]
+  real,                  intent(in)  :: S        !< Absolute salinity [g kg-1]
+  real,                  intent(in)  :: pressure !< pressure [Pa]
+  real,                  intent(out) :: rho      !< In situ density [kg m-3]
+  real,                  intent(out) :: drho_dp  !< The partial derivative of density with pressure
                                                  !! (also the inverse of the square of sound speed)
                                                  !! [s2 m-2]
-  integer, intent(in)                :: start    !< The starting index for calculations
-  integer, intent(in)                :: npts     !< The number of values to calculate
 
   ! Local variables
   real :: zp     ! Pressure [Pa]
@@ -521,73 +487,67 @@ subroutine calculate_compress_Roquet_SpV(T, S, pressure, rho, drho_dp, start, np
                  ! proportional to pressure**3 [m3 kg-1 Pa-3]
   real :: SV_0S0 ! Salinity dependent specific volume at the surface pressure and zero temperature [m3 kg-1]
   real :: dSpecVol_dp ! The partial derivative of specific volume with pressure [m3 kg-1 Pa-1]
-  integer :: j
 
   ! The following algorithm was published by Roquet et al. (2015), intended for use
   ! with NEMO, but it is not necessarily the algorithm used in NEMO ocean model.
-  do j=start,start+npts-1
-    ! Conversions to the units used here.
-    zt = T(j)
-    zs = SQRT( ABS( S(j) + rdeltaS ) * r1_S0 )  ! square root of normalized salinity plus an offset [nondim]
-    zp = pressure(j)
 
-    ! The next two lines should be used if it is necessary to convert potential temperature and
-    ! practical salinity to conservative temperature and absolute salinity.
-    ! zt = gsw_ct_from_pt(S(j),T(j)) ! Convert potential temp to conservative temp [degC]
-    ! zs = SQRT( ABS( gsw_sr_from_sp(S(j)) + rdeltaS ) * r1_S0 ) ! Convert S from practical to absolute salinity.
+  ! Conversions to the units used here.
+  zt = T
+  zs = SQRT( ABS( S + rdeltaS ) * r1_S0 )  ! square root of normalized salinity plus an offset [nondim]
+  zp = pressure
 
-    SV_TS3 = SPV003 + (zs*SPV103 + zt*SPV013)
-    SV_TS2 = SPV002 + (zs*(SPV102 +  zs*SPV202) &
-                     + zt*(SPV012 + (zs*SPV112 + zt*SPV022)) )
-    SV_TS1 = SPV001 + (zs*(SPV101 +  zs*(SPV201 +  zs*(SPV301 +  zs*SPV401))) &
-                     + zt*(SPV011 + (zs*(SPV111 +  zs*(SPV211 +  zs*SPV311)) &
-                                   + zt*(SPV021 + (zs*(SPV121 +  zs*SPV221) &
-                                                 + zt*(SPV031 + (zs*SPV131 + zt*SPV041)) )) )) )
+  ! The next two lines should be used if it is necessary to convert potential temperature and
+  ! practical salinity to conservative temperature and absolute salinity.
+  ! zt = gsw_ct_from_pt(S,T) ! Convert potential temp to conservative temp [degC]
+  ! zs = SQRT( ABS( gsw_sr_from_sp(S) + rdeltaS ) * r1_S0 ) ! Convert S from practical to absolute salinity.
 
-    SV_TS0 = zt*(SPV010 &
-               + (zs*(SPV110 +  zs*(SPV210 +  zs*(SPV310 +  zs*(SPV410 +  zs*SPV510)))) &
-                + zt*(SPV020 + (zs*(SPV120 +  zs*(SPV220 +  zs*(SPV320 +  zs*SPV420))) &
-                              + zt*(SPV030 + (zs*(SPV130 +  zs*(SPV230 +  zs*SPV330)) &
-                                            + zt*(SPV040 + (zs*(SPV140 +  zs*SPV240) &
-                                                          + zt*(SPV050 + (zs*SPV150 + zt*SPV060)) )) )) )) ) )
+  SV_TS3 = SPV003 + (zs*SPV103 + zt*SPV013)
+  SV_TS2 = SPV002 + (zs*(SPV102 +  zs*SPV202) &
+                   + zt*(SPV012 + (zs*SPV112 + zt*SPV022)) )
+  SV_TS1 = SPV001 + (zs*(SPV101 +  zs*(SPV201 +  zs*(SPV301 +  zs*SPV401))) &
+                   + zt*(SPV011 + (zs*(SPV111 +  zs*(SPV211 +  zs*SPV311)) &
+                                 + zt*(SPV021 + (zs*(SPV121 +  zs*SPV221) &
+                                               + zt*(SPV031 + (zs*SPV131 + zt*SPV041)) )) )) )
 
-    SV_0S0 = SPV000 + zs*(SPV100 + zs*(SPV200 + zs*(SPV300 + zs*(SPV400 + zs*(SPV500 + zs*SPV600)))))
+  SV_TS0 = zt*(SPV010 &
+             + (zs*(SPV110 +  zs*(SPV210 +  zs*(SPV310 +  zs*(SPV410 +  zs*SPV510)))) &
+              + zt*(SPV020 + (zs*(SPV120 +  zs*(SPV220 +  zs*(SPV320 +  zs*SPV420))) &
+                            + zt*(SPV030 + (zs*(SPV130 +  zs*(SPV230 +  zs*SPV330)) &
+                                          + zt*(SPV040 + (zs*(SPV140 +  zs*SPV240) &
+                                                        + zt*(SPV050 + (zs*SPV150 + zt*SPV060)) )) )) )) ) )
 
-    SV_00p = zp*(V00 + zp*(V01 + zp*(V02 + zp*(V03 + zp*(V04 + zp*V05)))))
+  SV_0S0 = SPV000 + zs*(SPV100 + zs*(SPV200 + zs*(SPV300 + zs*(SPV400 + zs*(SPV500 + zs*SPV600)))))
 
-    SV_TS  = (SV_TS0 + SV_0S0) + zp*(SV_TS1 + zp*(SV_TS2 +  zp*SV_TS3))
-    ! specvol = SV_TS + SV_00p ! In situ specific volume [m3 kg-1]
-    rho(j) = 1.0 / (SV_TS + SV_00p) ! In situ density [kg m-3]
+  SV_00p = zp*(V00 + zp*(V01 + zp*(V02 + zp*(V03 + zp*(V04 + zp*V05)))))
 
-    dSV_00p_dp = V00 + zp*(2.*V01 + zp*(3.*V02 + zp*(4.*V03 + zp*(5.*V04 + zp*(6.*V05)))))
-    dSV_TS_dp  = SV_TS1 + zp*(2.*SV_TS2 + zp*(3.*SV_TS3))
-    dSpecVol_dp = dSV_TS_dp + dSV_00p_dp  !  [m3 kg-1 Pa-1]
-    drho_dp(j) = -dSpecVol_dp * rho(j)**2 ! Compressibility [s2 m-2]
+  SV_TS  = (SV_TS0 + SV_0S0) + zp*(SV_TS1 + zp*(SV_TS2 +  zp*SV_TS3))
+  ! specvol = SV_TS + SV_00p ! In situ specific volume [m3 kg-1]
+  rho = 1.0 / (SV_TS + SV_00p) ! In situ density [kg m-3]
 
-  enddo
-end subroutine calculate_compress_Roquet_SpV
+  dSV_00p_dp = V00 + zp*(2.*V01 + zp*(3.*V02 + zp*(4.*V03 + zp*(5.*V04 + zp*(6.*V05)))))
+  dSV_TS_dp  = SV_TS1 + zp*(2.*SV_TS2 + zp*(3.*SV_TS3))
+  dSpecVol_dp = dSV_TS_dp + dSV_00p_dp  !  [m3 kg-1 Pa-1]
+  drho_dp = -dSpecVol_dp * rho**2 ! Compressibility [s2 m-2]
 
+end subroutine calculate_compress_elem_Roquet_SpV
 
 !> Second derivatives of specific volume with respect to temperature, salinity, and pressure for a
 !! 1-d array inputs and outputs using the specific volume polynomial fit from Roquet et al. (2015).
-subroutine calc_spec_vol_second_derivs_array_Roquet_SpV(T, S, P, dSV_ds_ds, dSV_ds_dt, dSV_dt_dt, &
-                                                        dSV_ds_dp, dSV_dt_dp, start, npts)
-  real, dimension(:), intent(in   ) :: T !< Conservative temperature [degC]
-  real, dimension(:), intent(in   ) :: S !< Absolute salinity [g kg-1]
-  real, dimension(:), intent(in   ) :: P !< Pressure [Pa]
-  real, dimension(:), intent(inout) :: dSV_ds_ds  !< Second derivative of specific volume with respect
-                                                  !! to salinity [m3 kg-1 ppt-2]
-  real, dimension(:), intent(inout) :: dSV_ds_dt  !< Second derivative of specific volume with respect
-                                                  !! to salinity and temperature [m3 kg-1 ppt-1 degC-1]
-  real, dimension(:), intent(inout) :: dSV_dt_dt  !< Second derivative of specific volume with respect
-                                                  !! to temperature [m3 kg-1 degC-2]
-  real, dimension(:), intent(inout) :: dSV_ds_dp  !< Second derivative of specific volume with respect to pressure
-                                                  !! and salinity [m3 kg-1 ppt-1 Pa-1]
-  real, dimension(:), intent(inout) :: dSV_dt_dp  !< Second derivative of specific volume with respect to pressure
-                                                  !! and temperature [m3 kg-1 degC-1 Pa-1]
-  integer,            intent(in   ) :: start      !< The starting index for calculations
-  integer,            intent(in   ) :: npts       !< The number of values to calculate
-
+elemental subroutine calc_spec_vol_second_derivs_elem_Roquet_SpV(T, S, P, &
+                           dSV_ds_ds, dSV_ds_dt, dSV_dt_dt, dSV_ds_dp, dSV_dt_dp)
+  real, intent(in)    :: T          !< Conservative temperature [degC]
+  real, intent(in)    :: S          !< Absolute salinity [g kg-1]
+  real, intent(in)    :: P          !< Pressure [Pa]
+  real, intent(inout) :: dSV_ds_ds  !< Second derivative of specific volume with respect
+                                    !! to salinity [m3 kg-1 ppt-2]
+  real, intent(inout) :: dSV_ds_dt  !< Second derivative of specific volume with respect
+                                    !! to salinity and temperature [m3 kg-1 ppt-1 degC-1]
+  real, intent(inout) :: dSV_dt_dt  !< Second derivative of specific volume with respect
+                                    !! to temperature [m3 kg-1 degC-2]
+  real, intent(inout) :: dSV_ds_dp  !< Second derivative of specific volume with respect to pressure
+                                    !! and salinity [m3 kg-1 ppt-1 Pa-1]
+  real, intent(inout) :: dSV_dt_dp  !< Second derivative of specific volume with respect to pressure
+                                    !! and temperature [m3 kg-1 degC-1 Pa-1]
   ! Local variables
   real :: zp      ! Pressure [Pa]
   real :: zt      ! Conservative temperature [degC]
@@ -598,186 +558,135 @@ subroutine calc_spec_vol_second_derivs_array_Roquet_SpV(T, S, P, dSV_ds_ds, dSV_
   real :: d2SV_p1 ! A contribution to one of the second derivatives that is proportional to pressure [various]
   real :: d2SV_p2 ! A contribution to one of the second derivatives that is proportional to pressure**2 [various]
   real :: d2SV_p3 ! A contribution to one of the second derivatives that is proportional to pressure**3 [various]
-  integer :: j
 
-  do j = start,start+npts-1
-    ! Conversions to the units used here.
-    zt = T(j)
-    zs = SQRT( ABS( S(j) + rdeltaS ) * r1_S0 )  ! square root of normalized salinity plus an offset [nondim]
-    zp = P(j)
+  ! Conversions to the units used here.
+  zt = T
+  zs = SQRT( ABS( S + rdeltaS ) * r1_S0 )  ! square root of normalized salinity plus an offset [nondim]
+  zp = P
 
-    ! The next two lines should be used if it is necessary to convert potential temperature and
-    ! practical salinity to conservative temperature and absolute salinity.
-    ! zt = gsw_ct_from_pt(S(j),T(j)) ! Convert potential temp to conservative temp [degC]
-    ! zs = SQRT( ABS( gsw_sr_from_sp(S(j)) + rdeltaS ) * r1_S0 )  ! Convert S from practical to absolute salinity.
+  ! The next two lines should be used if it is necessary to convert potential temperature and
+  ! practical salinity to conservative temperature and absolute salinity.
+  ! zt = gsw_ct_from_pt(S,T) ! Convert potential temp to conservative temp [degC]
+  ! zs = SQRT( ABS( gsw_sr_from_sp(S) + rdeltaS ) * r1_S0 )  ! Convert S from practical to absolute salinity.
 
-    I_s = 1.0 / zs
+  I_s = 1.0 / zs
 
-    ! Find dSV_ds_ds
-    d2SV_p3 = -SPV103*I_s**2
-    d2SV_p2 = -(SPV102 + zt*SPV112)*I_s**2
-    d2SV_p1 = (3.*SPV301 + (zt*(3.*SPV311) + zs*(8.*SPV401))) &
-              - ( SPV101 + zt*(SPV111 + zt*(SPV121 + zt*SPV131)) )*I_s**2
-    d2SV_p0 = (3.*SPV300 + (zs*(8.*SPV400 + zs*(15.*SPV500 + zs*(24.*SPV600))) &
-                          + zt*(3.*SPV310 + (zs*(8.*SPV410 + zs*(15.*SPV510)) &
-                                           + zt*(3.*SPV320 + (zs*(8.*SPV420) + zt*(3.*SPV330))) )) )) &
-              - (SPV100 + zt*(SPV110 + zt*(SPV120 + zt*(SPV130 + zt*(SPV140 + zt*SPV150)))) )*I_s**2
-    dSV_dS_dS(j) = (0.5*r1_S0)**2 * ((d2SV_p0 + zp*(d2SV_p1 + zp*(d2SV_p2 + zp*d2SV_p3))) * I_s)
+  ! Find dSV_ds_ds
+  d2SV_p3 = -SPV103*I_s**2
+  d2SV_p2 = -(SPV102 + zt*SPV112)*I_s**2
+  d2SV_p1 = (3.*SPV301 + (zt*(3.*SPV311) + zs*(8.*SPV401))) &
+            - ( SPV101 + zt*(SPV111 + zt*(SPV121 + zt*SPV131)) )*I_s**2
+  d2SV_p0 = (3.*SPV300 + (zs*(8.*SPV400 + zs*(15.*SPV500 + zs*(24.*SPV600))) &
+                        + zt*(3.*SPV310 + (zs*(8.*SPV410 + zs*(15.*SPV510)) &
+                                         + zt*(3.*SPV320 + (zs*(8.*SPV420) + zt*(3.*SPV330))) )) )) &
+            - (SPV100 + zt*(SPV110 + zt*(SPV120 + zt*(SPV130 + zt*(SPV140 + zt*SPV150)))) )*I_s**2
+  dSV_dS_dS = (0.5*r1_S0)**2 * ((d2SV_p0 + zp*(d2SV_p1 + zp*(d2SV_p2 + zp*d2SV_p3))) * I_s)
 
-    ! Find dSV_ds_dt
-    d2SV_p2 = SPV112
-    d2SV_p1 = SPV111 + (zs*(2.*SPV211 +  zs*(3.*SPV311)) &
-                      + zt*(2.*SPV121 + (zs*(4.*SPV221) + zt*(3.*SPV131))) )
-    d2SV_p0 = SPV110 + (zs*(2.*SPV210 +  zs*(3.*SPV310 +  zs*(4.*SPV410 +  zs*(5.*SPV510)))) &
-                      + zt*(2.*SPV120 + (zs*(4.*SPV220 +  zs*(6.*SPV320 +  zs*(8.*SPV420))) &
-                                       + zt*(3.*SPV130 + (zs*(6.*SPV230 +  zs*(9.*SPV330)) &
-                                                        + zt*(4.*SPV140 + (zs*(8.*SPV240) &
-                                                                         + zt*(5.*SPV150))) )) )) )
-    dSV_ds_dt(j) = (0.5*r1_S0) * ((d2SV_p0 + zp*(d2SV_p1 + zp*d2SV_p2)) * I_s)
+  ! Find dSV_ds_dt
+  d2SV_p2 = SPV112
+  d2SV_p1 = SPV111 + (zs*(2.*SPV211 +  zs*(3.*SPV311)) &
+                    + zt*(2.*SPV121 + (zs*(4.*SPV221) + zt*(3.*SPV131))) )
+  d2SV_p0 = SPV110 + (zs*(2.*SPV210 +  zs*(3.*SPV310 +  zs*(4.*SPV410 +  zs*(5.*SPV510)))) &
+                    + zt*(2.*SPV120 + (zs*(4.*SPV220 +  zs*(6.*SPV320 +  zs*(8.*SPV420))) &
+                                     + zt*(3.*SPV130 + (zs*(6.*SPV230 +  zs*(9.*SPV330)) &
+                                                      + zt*(4.*SPV140 + (zs*(8.*SPV240) &
+                                                                       + zt*(5.*SPV150))) )) )) )
+  dSV_ds_dt = (0.5*r1_S0) * ((d2SV_p0 + zp*(d2SV_p1 + zp*d2SV_p2)) * I_s)
 
-    ! Find dSV_dt_dt
-    d2SV_p2 = 2.*SPV022
-    d2SV_p1 = 2.*SPV021 + (zs*(2.*SPV121 +  zs*(2.*SPV221)) &
-                         + zt*(6.*SPV031 + (zs*(6.*SPV131) + zt*(12.*SPV041))) )
-    d2SV_p0 = 2.*SPV020 + (zs*(2.*SPV120 +  zs*( 2.*SPV220 +  zs*( 2.*SPV320 + zs * (2.*SPV420)))) &
-                         + zt*(6.*SPV030 + (zs*( 6.*SPV130 +  zs*( 6.*SPV230 + zs * (6.*SPV330))) &
-                                          + zt*(12.*SPV040 + (zs*(12.*SPV140 + zs *(12.*SPV240)) &
-                                                            + zt*(20.*SPV050 + (zs*(20.*SPV150) &
-                                                                              + zt*(30.*SPV060) )) )) )) )
-    dSV_dt_dt(j) = d2SV_p0 + zp*(d2SV_p1 + zp*d2SV_p2)
+  ! Find dSV_dt_dt
+  d2SV_p2 = 2.*SPV022
+  d2SV_p1 = 2.*SPV021 + (zs*(2.*SPV121 +  zs*(2.*SPV221)) &
+                       + zt*(6.*SPV031 + (zs*(6.*SPV131) + zt*(12.*SPV041))) )
+  d2SV_p0 = 2.*SPV020 + (zs*(2.*SPV120 +  zs*( 2.*SPV220 +  zs*( 2.*SPV320 + zs * (2.*SPV420)))) &
+                       + zt*(6.*SPV030 + (zs*( 6.*SPV130 +  zs*( 6.*SPV230 + zs * (6.*SPV330))) &
+                                        + zt*(12.*SPV040 + (zs*(12.*SPV140 + zs *(12.*SPV240)) &
+                                                          + zt*(20.*SPV050 + (zs*(20.*SPV150) &
+                                                                            + zt*(30.*SPV060) )) )) )) )
+  dSV_dt_dt = d2SV_p0 + zp*(d2SV_p1 + zp*d2SV_p2)
 
-    ! Find dSV_ds_dp
-    d2SV_p2 = 3.*SPV103
-    d2SV_p1 = 2.*SPV102 + (zs*(4.*SPV202) + zt*(2.*SPV112))
-    d2SV_p0 = SPV101 + (zs*(2.*SPV201 + zs*(3.*SPV301 +  zs*(4.*SPV401))) &
-                      + zt*(SPV111 +   (zs*(2.*SPV211 +  zs*(3.*SPV311)) &
-                                      + zt*(   SPV121 + (zs*(2.*SPV221) + zt*SPV131)) )) )
-    dSV_ds_dp(j) =  ((d2SV_p0 + zp*(d2SV_p1 + zp*d2SV_p2)) * I_s) * (0.5*r1_S0)
+  ! Find dSV_ds_dp
+  d2SV_p2 = 3.*SPV103
+  d2SV_p1 = 2.*SPV102 + (zs*(4.*SPV202) + zt*(2.*SPV112))
+  d2SV_p0 = SPV101 + (zs*(2.*SPV201 + zs*(3.*SPV301 +  zs*(4.*SPV401))) &
+                    + zt*(SPV111 +   (zs*(2.*SPV211 +  zs*(3.*SPV311)) &
+                                    + zt*(   SPV121 + (zs*(2.*SPV221) + zt*SPV131)) )) )
+  dSV_ds_dp =  ((d2SV_p0 + zp*(d2SV_p1 + zp*d2SV_p2)) * I_s) * (0.5*r1_S0)
 
-    ! Find dSV_dt_dp
-    d2SV_p2 = 3.*SPV013
-    d2SV_p1 = 2.*SPV012 + (zs*(2.*SPV112) + zt*(4.*SPV022))
-    d2SV_p0 = SPV011 + (zs*(SPV111     + zs*(   SPV211 +  zs*    SPV311)) &
-                      + zt*(2.*SPV021 + (zs*(2.*SPV121 +  zs*(2.*SPV221)) &
-                                       + zt*(3.*SPV031 + (zs*(3.*SPV131) + zt*(4.*SPV041))) )) )
-    dSV_dt_dp(j) =  d2SV_p0 + zp*(d2SV_p1 + zp*d2SV_p2)
-  enddo
+  ! Find dSV_dt_dp
+  d2SV_p2 = 3.*SPV013
+  d2SV_p1 = 2.*SPV012 + (zs*(2.*SPV112) + zt*(4.*SPV022))
+  d2SV_p0 = SPV011 + (zs*(SPV111     + zs*(   SPV211 +  zs*    SPV311)) &
+                    + zt*(2.*SPV021 + (zs*(2.*SPV121 +  zs*(2.*SPV221)) &
+                                     + zt*(3.*SPV031 + (zs*(3.*SPV131) + zt*(4.*SPV041))) )) )
+  dSV_dt_dp =  d2SV_p0 + zp*(d2SV_p1 + zp*d2SV_p2)
 
-end subroutine calc_spec_vol_second_derivs_array_Roquet_SpV
-
+end subroutine calc_spec_vol_second_derivs_elem_Roquet_SpV
 
 !> Second derivatives of density with respect to temperature, salinity, and pressure for a
 !! 1-d array inputs and outputs using the specific volume polynomial fit from Roquet et al. (2015).
-subroutine calculate_density_second_derivs_array_Roquet_SpV(T, S, P, drho_ds_ds, drho_ds_dt, drho_dt_dt, &
-                                                            drho_ds_dp, drho_dt_dp, start, npts)
-  real, dimension(:), intent(in   ) :: T !< Conservative temperature [degC]
-  real, dimension(:), intent(in   ) :: S !< Absolute salinity [g kg-1]
-  real, dimension(:), intent(in   ) :: P !< Pressure [Pa]
-  real, dimension(:), intent(inout) :: drho_ds_ds !< Second derivative of density with respect
-                                                  !! to salinity [kg m-3 ppt-2]
-  real, dimension(:), intent(inout) :: drho_ds_dt !< Second derivative of density with respect
-                                                  !! to salinity and temperature [kg m-3 ppt-1 degC-1]
-  real, dimension(:), intent(inout) :: drho_dt_dt !< Second derivative of density with respect
-                                                  !! to temperature [kg m-3 degC-2]
-  real, dimension(:), intent(inout) :: drho_ds_dp !< Second derivative of density with respect to pressure
-                                                  !! and salinity [kg m-3 ppt-1 Pa-1] = [s2 m-2 ppt-1]
-  real, dimension(:), intent(inout) :: drho_dt_dp !< Second derivative of density with respect to pressure
-                                                  !! and temperature [kg m-3 degC-1 Pa-1] = [s2 m-2 degC-1]
-  integer,            intent(in   ) :: start      !< The starting index for calculations
-  integer,            intent(in   ) :: npts       !< The number of values to calculate
+elemental subroutine calculate_density_second_derivs_elem_Roquet_SpV(this, T, S, pressure, &
+                               drho_ds_ds, drho_ds_dt, drho_dt_dt, drho_ds_dp, drho_dt_dp)
+  class(Roquet_SpV_EOS), intent(in)    :: this       !< This EOS
+  real,                  intent(in)    :: T          !< Conservative temperature [degC]
+  real,                  intent(in)    :: S          !< Absolute salinity [g kg-1]
+  real,                  intent(in)    :: pressure   !< Pressure [Pa]
+  real,                  intent(inout) :: drho_ds_ds !< Second derivative of density with respect
+                                                     !! to salinity [kg m-3 ppt-2]
+  real,                  intent(inout) :: drho_ds_dt !< Second derivative of density with respect
+                                                     !! to salinity and temperature [kg m-3 ppt-1 degC-1]
+  real,                  intent(inout) :: drho_dt_dt !< Second derivative of density with respect
+                                                     !! to temperature [kg m-3 degC-2]
+  real,                  intent(inout) :: drho_ds_dp !< Second derivative of density with respect to pressure
+                                                     !! and salinity [kg m-3 ppt-1 Pa-1] = [s2 m-2 ppt-1]
+  real,                  intent(inout) :: drho_dt_dp !< Second derivative of density with respect to pressure
+                                                     !! and temperature [kg m-3 degC-1 Pa-1] = [s2 m-2 degC-1]
 
   ! Local variables
-  real, dimension(size(T)) :: rho       ! The in situ density [kg m-3]
-  real, dimension(size(T)) :: drho_dp   ! The partial derivative of density with pressure
-                                        ! (also the inverse of the square of sound speed)  [s2 m-2]
-  real, dimension(size(T)) :: dSV_dT    ! The partial derivative of specific volume with
-                                        ! conservative temperature [m3 kg-1 degC-1]
-  real, dimension(size(T)) :: dSV_dS    ! The partial derivative of specific volume with
-                                        ! absolute salinity [m3 kg-1 ppt-1]
-  real, dimension(size(T)) :: dSV_ds_ds ! Second derivative of specific volume with respect
-                                        ! to salinity [m3 kg-1 ppt-2]
-  real, dimension(size(T)) :: dSV_ds_dt ! Second derivative of specific volume with respect
-                                        ! to salinity and temperature [m3 kg-1 ppt-1 degC-1]
-  real, dimension(size(T)) :: dSV_dt_dt ! Second derivative of specific volume with respect
-                                        ! to temperature [m3 kg-1 degC-2]
-  real, dimension(size(T)) :: dSV_ds_dp ! Second derivative of specific volume with respect to pressure
-                                        ! and salinity [m3 kg-1 ppt-1 Pa-1]
-  real, dimension(size(T)) :: dSV_dt_dp ! Second derivative of specific volume with respect to pressure
-                                        ! and temperature [m3 kg-1 degC-1 Pa-1]
-  integer :: j
+  real :: rho       ! The in situ density [kg m-3]
+  real :: drho_dp   ! The partial derivative of density with pressure
+                    ! (also the inverse of the square of sound speed)  [s2 m-2]
+  real :: dSV_dT    ! The partial derivative of specific volume with
+                    ! conservative temperature [m3 kg-1 degC-1]
+  real :: dSV_dS    ! The partial derivative of specific volume with
+                    ! absolute salinity [m3 kg-1 ppt-1]
+  real :: dSV_ds_ds ! Second derivative of specific volume with respect
+                    ! to salinity [m3 kg-1 ppt-2]
+  real :: dSV_ds_dt ! Second derivative of specific volume with respect
+                    ! to salinity and temperature [m3 kg-1 ppt-1 degC-1]
+  real :: dSV_dt_dt ! Second derivative of specific volume with respect
+                    ! to temperature [m3 kg-1 degC-2]
+  real :: dSV_ds_dp ! Second derivative of specific volume with respect to pressure
+                    ! and salinity [m3 kg-1 ppt-1 Pa-1]
+  real :: dSV_dt_dp ! Second derivative of specific volume with respect to pressure
+                    ! and temperature [m3 kg-1 degC-1 Pa-1]
 
-  call calc_spec_vol_second_derivs_array_Roquet_SpV(T, S, P, dSV_ds_ds, dSV_ds_dt, dSV_dt_dt, &
-                                                    dSV_ds_dp, dSV_dt_dp, start, npts)
-  call calculate_specvol_derivs_Roquet_SpV(T, S, P, dSV_dT, dSV_dS, start, npts)
-  call calculate_compress_Roquet_SpV(T, S, P, rho, drho_dp, start, npts)
+  call calc_spec_vol_second_derivs_elem_Roquet_SpV(T, S, pressure, &
+                 dSV_ds_ds, dSV_ds_dt, dSV_dt_dt, dSV_ds_dp, dSV_dt_dp)
+  call this%calculate_specvol_derivs_elem(T, S, pressure, dSV_dT, dSV_dS)
+  call this%calculate_compress_elem(T, S, pressure, rho, drho_dp)
 
-  do j = start,start+npts-1
-    ! Find drho_ds_ds
-    drho_dS_dS(j) = rho(j)**2 * (2.0*rho(j)*dSV_dS(j)**2 - dSV_dS_dS(j))
+  ! Find drho_ds_ds
+  drho_dS_dS = rho**2 * (2.0*rho*dSV_dS**2 - dSV_dS_dS)
 
-    ! Find drho_ds_dt
-    drho_ds_dt(j) = rho(j)**2 * (2.0*rho(j)*(dSV_dT(j)*dSV_dS(j)) - dSV_dS_dT(j))
+  ! Find drho_ds_dt
+  drho_ds_dt = rho**2 * (2.0*rho*(dSV_dT*dSV_dS) - dSV_dS_dT)
 
-    ! Find drho_dt_dt
-    drho_dT_dT(j) = rho(j)**2 * (2.0*rho(j)*dSV_dT(j)**2 - dSV_dT_dT(j))
+  ! Find drho_dt_dt
+  drho_dT_dT = rho**2 * (2.0*rho*dSV_dT**2 - dSV_dT_dT)
 
-    ! Find drho_ds_dp
-    drho_ds_dp(j) =  -rho(j) * (2.0*dSV_dS(j) * drho_dp(j) + rho(j) * dSV_dS_dp(j))
+  ! Find drho_ds_dp
+  drho_ds_dp =  -rho * (2.0*dSV_dS * drho_dp + rho * dSV_dS_dp)
 
-    ! Find drho_dt_dp
-    drho_dt_dp(j) =  -rho(j) * (2.0*dSV_dT(j) * drho_dp(j) + rho(j) * dSV_dT_dp(j))
-  enddo
+  ! Find drho_dt_dp
+  drho_dt_dp =  -rho * (2.0*dSV_dT * drho_dp + rho * dSV_dT_dp)
 
-end subroutine calculate_density_second_derivs_array_Roquet_SpV
-
-!> Second derivatives of density with respect to temperature, salinity, and pressure for scalar inputs.
-!!
-!! The scalar version of calculate_density_second_derivs promotes scalar inputs to 1-element array
-!! and then demotes the output back to a scalar
-subroutine calculate_density_second_derivs_scalar_Roquet_SpV(T, S, P, drho_ds_ds, drho_ds_dt, drho_dt_dt, &
-                                                             drho_ds_dp, drho_dt_dp)
-  real, intent(in   ) :: T          !< Conservative temperature [degC]
-  real, intent(in   ) :: S          !< Absolute salinity [g kg-1]
-  real, intent(in   ) :: P          !< pressure [Pa]
-  real, intent(  out) :: drho_ds_ds !< Second derivative of density with respect
-                                    !! to salinity [kg m-3 ppt-2]
-  real, intent(  out) :: drho_ds_dt !< Second derivative of density with respect
-                                    !! to salinity and temperature [kg m-3 ppt-1 degC-1]
-  real, intent(  out) :: drho_dt_dt !< Second derivative of density with respect
-                                    !! to temperature [kg m-3 degC-2]
-  real, intent(  out) :: drho_ds_dp !< Second derivative of density with respect to pressure
-                                    !! and salinity [kg m-3 ppt-1 Pa-1] = [s2 m-2 ppt-1]
-  real, intent(  out) :: drho_dt_dp !< Second derivative of density with respect to pressure
-                                    !! and temperature [kg m-3 degC-1 Pa-1] = [s2 m-2 degC-1]
-  ! Local variables
-  real, dimension(1) :: T0     ! A 1-d array with a copy of the temperature [degC]
-  real, dimension(1) :: S0     ! A 1-d array with a copy of the salinity [g kg-1]
-  real, dimension(1) :: p0     ! A 1-d array with a copy of the pressure [Pa]
-  real, dimension(1) :: drdsds ! The second derivative of density with salinity [kg m-3 ppt-2]
-  real, dimension(1) :: drdsdt ! The second derivative of density with salinity and
-                               ! temperature [kg m-3 ppt-1 degC-1]
-  real, dimension(1) :: drdtdt ! The second derivative of density with temperature [kg m-3 degC-2]
-  real, dimension(1) :: drdsdp ! The second derivative of density with salinity and
-                               ! pressure [kg m-3 ppt-1 Pa-1] = [s2 m-2 ppt-1]
-  real, dimension(1) :: drdtdp ! The second derivative of density with temperature and
-                               ! pressure [kg m-3 degC-1 Pa-1] = [s2 m-2 degC-1]
-
-  T0(1) = T
-  S0(1) = S
-  P0(1) = P
-  call calculate_density_second_derivs_array_Roquet_SpV(T0, S0, P0, drdsds, drdsdt, drdtdt, drdsdp, drdtdp, 1, 1)
-  drho_ds_ds = drdsds(1)
-  drho_ds_dt = drdsdt(1)
-  drho_dt_dt = drdtdt(1)
-  drho_ds_dp = drdsdp(1)
-  drho_dt_dp = drdtdp(1)
-
-end subroutine calculate_density_second_derivs_scalar_Roquet_SpV
+end subroutine calculate_density_second_derivs_elem_Roquet_SpV
 
 !> Return the range of temperatures, salinities and pressures for which the Roquet et al. (2015)
 !! expression for specific volume has been fitted to observations.  Care should be taken when
 !! applying this equation of state outside of its fit range.
-subroutine EoS_fit_range_Roquet_SpV(T_min, T_max, S_min, S_max, p_min, p_max)
+subroutine EoS_fit_range_Roquet_SpV(this, T_min, T_max, S_min, S_max, p_min, p_max)
+  class(Roquet_SpV_EOS), intent(in)    :: this       !< This EOS
   real, optional, intent(out) :: T_min !< The minimum conservative temperature over which this EoS is fitted [degC]
   real, optional, intent(out) :: T_max !< The maximum conservative temperature over which this EoS is fitted [degC]
   real, optional, intent(out) :: S_min !< The minimum absolute salinity over which this EoS is fitted [g kg-1]
@@ -793,6 +702,58 @@ subroutine EoS_fit_range_Roquet_SpV(T_min, T_max, S_min, S_max, p_min, p_max)
   if (present(p_max)) p_max = 1.0e8
 
 end subroutine EoS_fit_range_Roquet_SpV
+
+!> Calculate the in-situ density for 1D arraya inputs and outputs.
+subroutine calculate_density_array_Roquet_SpV(this, T, S, pressure, rho, start, npts, rho_ref)
+  class(Roquet_SpV_EOS),  intent(in) :: this  !< This EOS
+  real, dimension(:), intent(in)  :: T        !< Potential temperature relative to the surface [degC]
+  real, dimension(:), intent(in)  :: S        !< Salinity [PSU]
+  real, dimension(:), intent(in)  :: pressure !< Pressure [Pa]
+  real, dimension(:), intent(out) :: rho      !< In situ density [kg m-3]
+  integer,            intent(in)  :: start    !< The starting index for calculations
+  integer,            intent(in)  :: npts     !< The number of values to calculate
+  real,     optional, intent(in)  :: rho_ref  !< A reference density [kg m-3]
+
+  ! Local variables
+  integer :: j
+
+  if (present(rho_ref)) then
+    do j = start, start+npts-1
+      rho(j) = density_anomaly_elem_Roquet_SpV(this, T(j), S(j), pressure(j), rho_ref)
+    enddo
+  else
+    do j = start, start+npts-1
+      rho(j) = density_elem_Roquet_SpV(this, T(j), S(j), pressure(j))
+    enddo
+  endif
+
+end subroutine calculate_density_array_Roquet_SpV
+
+!> Calculate the in-situ specific volume for 1D array inputs and outputs.
+subroutine calculate_spec_vol_array_Roquet_SpV(this, T, S, pressure, specvol, start, npts, spv_ref)
+  class(Roquet_SpV_EOS),  intent(in) :: this  !< This EOS
+  real, dimension(:), intent(in)  :: T        !< Potential temperature relative to the surface [degC]
+  real, dimension(:), intent(in)  :: S        !< Salinity [PSU]
+  real, dimension(:), intent(in)  :: pressure !< Pressure [Pa]
+  real, dimension(:), intent(out) :: specvol  !< In situ specific volume [m3 kg-1]
+  integer,            intent(in)  :: start    !< The starting index for calculations
+  integer,            intent(in)  :: npts     !< The number of values to calculate
+  real,     optional, intent(in)  :: spv_ref  !< A reference specific volume [m3 kg-1]
+
+  ! Local variables
+  integer :: j
+
+  if (present(spv_ref)) then
+    do j = start, start+npts-1
+      specvol(j) = spec_vol_anomaly_elem_Roquet_SpV(this, T(j), S(j), pressure(j), spv_ref)
+    enddo
+  else
+    do j = start, start+npts-1
+      specvol(j) = spec_vol_elem_Roquet_SpV(this, T(j), S(j), pressure(j) )
+    enddo
+  endif
+
+end subroutine calculate_spec_vol_array_Roquet_SpV
 
 !> \namespace mom_eos_Roquet_SpV
 !!

--- a/src/equation_of_state/MOM_EOS_TEOS10.F90
+++ b/src/equation_of_state/MOM_EOS_TEOS10.F90
@@ -3,216 +3,132 @@ module MOM_EOS_TEOS10
 
 ! This file is part of MOM6. See LICENSE.md for the license.
 
-!***********************************************************************
-!*  The subroutines in this file implement the equation of state for   *
-!*  sea water using the TEOS10 functions                               *
-!***********************************************************************
-
 use gsw_mod_toolbox, only : gsw_sp_from_sr, gsw_pt_from_ct
 use gsw_mod_toolbox, only : gsw_rho, gsw_specvol
 use gsw_mod_toolbox, only : gsw_rho_first_derivatives, gsw_specvol_first_derivatives
 use gsw_mod_toolbox, only : gsw_rho_second_derivatives
-!use gsw_mod_toolbox, only : gsw_sr_from_sp, gsw_ct_from_pt
+use MOM_EOS_base_type, only : EOS_base
 
 implicit none ; private
 
-public calculate_compress_teos10, calculate_density_teos10, calculate_spec_vol_teos10
-public calculate_density_derivs_teos10, calculate_specvol_derivs_teos10
-public calculate_density_second_derivs_teos10, EoS_fit_range_teos10
 public gsw_sp_from_sr, gsw_pt_from_ct
-
-!> Compute the in situ density of sea water ([kg m-3]), or its anomaly with respect to
-!! a reference density, from absolute salinity (g/kg), conservative temperature (in deg C),
-!! and pressure [Pa], using the TEOS10 expressions.
-interface calculate_density_teos10
-  module procedure calculate_density_scalar_teos10, calculate_density_array_teos10
-end interface calculate_density_teos10
-
-!> Compute the in situ specific volume of sea water (in [m3 kg-1]), or an anomaly with respect
-!! to a reference specific volume, from absolute salinity (in g/kg), conservative temperature
-!! (in deg C), and pressure [Pa], using the TEOS10 expressions.
-interface calculate_spec_vol_teos10
-  module procedure calculate_spec_vol_scalar_teos10, calculate_spec_vol_array_teos10
-end interface calculate_spec_vol_teos10
-
-!> For a given thermodynamic state, return the derivatives of density with conservative temperature
-!! and absolute salinity, using the TEOS10 expressions.
-interface calculate_density_derivs_teos10
-  module procedure calculate_density_derivs_scalar_teos10, calculate_density_derivs_array_teos10
-end interface calculate_density_derivs_teos10
-
-!> For a given thermodynamic state, return the second derivatives of density with various combinations
-!! of conservative temperature, absolute salinity, and pressure, using the TEOS10 expressions.
-interface calculate_density_second_derivs_teos10
-  module procedure calculate_density_second_derivs_scalar_teos10, calculate_density_second_derivs_array_teos10
-end interface calculate_density_second_derivs_teos10
+public TEOS10_EOS
 
 real, parameter :: Pa2db  = 1.e-4  !< The conversion factor from Pa to dbar [dbar Pa-1]
 
+!> The EOS_base implementation of the TEOS10 equation of state
+type, extends (EOS_base) :: TEOS10_EOS
+
+contains
+  !> Implementation of the in-situ density as an elemental function [kg m-3]
+  procedure :: density_elem => density_elem_TEOS10
+  !> Implementation of the in-situ density anomaly as an elemental function [kg m-3]
+  procedure :: density_anomaly_elem => density_anomaly_elem_TEOS10
+  !> Implementation of the in-situ specific volume as an elemental function [m3 kg-1]
+  procedure :: spec_vol_elem => spec_vol_elem_TEOS10
+  !> Implementation of the in-situ specific volume anomaly as an elemental function [m3 kg-1]
+  procedure :: spec_vol_anomaly_elem => spec_vol_anomaly_elem_TEOS10
+  !> Implementation of the calculation of derivatives of density
+  procedure :: calculate_density_derivs_elem => calculate_density_derivs_elem_TEOS10
+  !> Implementation of the calculation of second derivatives of density
+  procedure :: calculate_density_second_derivs_elem => calculate_density_second_derivs_elem_TEOS10
+  !> Implementation of the calculation of derivatives of specific volume
+  procedure :: calculate_specvol_derivs_elem => calculate_specvol_derivs_elem_TEOS10
+  !> Implementation of the calculation of compressibility
+  procedure :: calculate_compress_elem => calculate_compress_elem_TEOS10
+  !> Implementation of the range query function
+  procedure :: EOS_fit_range => EOS_fit_range_TEOS10
+
+end type TEOS10_EOS
+
 contains
 
-!> This subroutine computes the in situ density of sea water (rho in [kg m-3])
-!! from absolute salinity (S [g kg-1]), conservative temperature (T [degC]),
-!! and pressure [Pa].  It uses the expression from the TEOS10 website.
-subroutine calculate_density_scalar_teos10(T, S, pressure, rho, rho_ref)
-  real,           intent(in)  :: T        !< Conservative temperature [degC].
-  real,           intent(in)  :: S        !< Absolute salinity [g kg-1].
-  real,           intent(in)  :: pressure !< pressure [Pa].
-  real,           intent(out) :: rho      !< In situ density [kg m-3].
-  real, optional, intent(in)  :: rho_ref  !< A reference density [kg m-3].
+!> GSW in situ density [kg m-3]
+real elemental function density_elem_TEOS10(this, T, S, pressure)
+  class(TEOS10_EOS), intent(in) :: this     !< This EOS
+  real,              intent(in) :: T        !< Conservative temperature [degC].
+  real,              intent(in) :: S        !< Absolute salinity [g kg-1].
+  real,              intent(in) :: pressure !< pressure [Pa].
 
-  ! Local variables
-  real, dimension(1) :: T0    ! A 1-d array with a copy of the conservative temperature [degC]
-  real, dimension(1) :: S0    ! A 1-d array with a copy of the absolute salinity [g kg-1]
-  real, dimension(1) :: pressure0 ! A 1-d array with a copy of the pressure [Pa]
-  real, dimension(1) :: rho0  ! A 1-d array with a copy of the density [kg m-3]
+  !!! #### This code originally had this "masking" line. The answer to the question below is "no" -AJA
+! if (S < -1.0e-10) then ! Can we assume safely that this is a missing value?
+!   density_elem_TEOS10 = 1000.0
+! else
+!   density_elem_TEOS10 = gsw_rho(S, T, pressure * Pa2db)
+! endif
 
-  T0(1) = T
-  S0(1) = S
-  pressure0(1) = pressure
+  density_elem_TEOS10 = gsw_rho(S, T, pressure * Pa2db)
 
-  call calculate_density_array_teos10(T0, S0, pressure0, rho0, 1, 1, rho_ref)
-  rho = rho0(1)
+end function density_elem_TEOS10
 
-end subroutine calculate_density_scalar_teos10
+!> GSW in situ density anomaly [kg m-3]
+real elemental function density_anomaly_elem_TEOS10(this, T, S, pressure, rho_ref)
+  class(TEOS10_EOS), intent(in) :: this     !< This EOS
+  real,              intent(in) :: T        !< Conservative temperature [degC].
+  real,              intent(in) :: S        !< Absolute salinity [g kg-1].
+  real,              intent(in) :: pressure !< pressure [Pa].
+  real,              intent(in) :: rho_ref  !< A reference density [kg m-3].
 
-!> This subroutine computes the in situ density of sea water (rho in [kg m-3])
-!! from absolute salinity (S [g kg-1]), conservative temperature (T [degC]),
-!! and pressure [Pa].  It uses the expression from the
-!! TEOS10 website.
-subroutine calculate_density_array_teos10(T, S, pressure, rho, start, npts, rho_ref)
-  real, dimension(:), intent(in)  :: T        !< Conservative temperature [degC].
-  real, dimension(:), intent(in)  :: S        !< Absolute salinity [g kg-1]
-  real, dimension(:), intent(in)  :: pressure !< pressure [Pa].
-  real, dimension(:), intent(out) :: rho      !< in situ density [kg m-3].
-  integer,            intent(in)  :: start    !< the starting point in the arrays.
-  integer,            intent(in)  :: npts     !< the number of values to calculate.
-  real,     optional, intent(in)  :: rho_ref  !< A reference density [kg m-3].
+  !!! #### This code originally had this "masking" line. The answer to the question below is "no" -AJA
+! if (S < -1.0e-10) then ! Can we assume safely that this is a missing value?
+!   density_elem_TEOS10 = 1000.0
+! else
+!   density_elem_TEOS10 = gsw_rho(S, T, pressure * Pa2db)
+! endif
 
-  ! Local variables
-  real :: zs  ! Absolute salinity [g kg-1]
-  real :: zt  ! Conservative temperature [degC]
-  real :: zp  ! Pressure converted to decibars [dbar]
-  integer :: j
+  density_anomaly_elem_TEOS10 = gsw_rho(S, T, pressure * Pa2db)
+  density_anomaly_elem_TEOS10 = density_anomaly_elem_TEOS10 - rho_ref
 
-  do j=start,start+npts-1
-    !Conversions
-    zs = S(j) !gsw_sr_from_sp(S(j))       !Convert practical salinity to absolute salinity
-    zt = T(j) !gsw_ct_from_pt(S(j),T(j))  !Convert potential temp to conservative temp
-    zp = pressure(j)* Pa2db         !Convert pressure from Pascal to decibar
+end function density_anomaly_elem_TEOS10
 
-    if (S(j) < -1.0e-10) then !Can we assume safely that this is a missing value?
-      rho(j) = 1000.0
-    else
-      rho(j) = gsw_rho(zs,zt,zp)
-    endif
-    if (present(rho_ref)) rho(j) = rho(j) - rho_ref
-  enddo
-end subroutine calculate_density_array_teos10
+!> GSW in situ specific volume [m3 kg-1]
+real elemental function spec_vol_elem_TEOS10(this, T, S, pressure)
+  class(TEOS10_EOS), intent(in) :: this     !< This EOS
+  real,              intent(in) :: T        !< Conservative temperature [degC].
+  real,              intent(in) :: S        !< Absolute salinity [g kg-1].
+  real,              intent(in) :: pressure !< pressure [Pa].
 
-!> This subroutine computes the in situ specific volume of sea water (specvol in
-!! [m3 kg-1]) from absolute salinity (S [g kg-1]), conservative temperature (T [degC])
-!! and pressure [Pa], using the TEOS10 equation of state.
-!! If spv_ref is present, specvol is an anomaly from spv_ref.
-subroutine calculate_spec_vol_scalar_teos10(T, S, pressure, specvol, spv_ref)
-  real,           intent(in)  :: T        !< Conservative temperature [degC].
-  real,           intent(in)  :: S        !< Absolute salinity [g kg-1]
-  real,           intent(in)  :: pressure !< pressure [Pa].
-  real,           intent(out) :: specvol  !< in situ specific volume [m3 kg-1].
-  real, optional, intent(in)  :: spv_ref  !< A reference specific volume [m3 kg-1].
+  !!! #### This code originally had this "masking" line. The answer to the question below is "no" -AJA
+! if (S < -1.0e-10) then ! Can we assume safely that this is a missing value?
+!   spec_vol_elem_TEOS10 = 0.001
+! else
+!   spec_vol_elem_TEOS10 = gsw_rho(S, T, pressure * Pa2db)
+! endif
 
-  ! Local variables
-  real, dimension(1) :: T0    ! A 1-d array with a copy of the conservative temperature [degC]
-  real, dimension(1) :: S0    ! A 1-d array with a copy of the absolute salinity [g kg-1]
-  real, dimension(1) :: pressure0 ! A 1-d array with a copy of the pressure [Pa]
-  real, dimension(1) :: spv0  ! A 1-d array with a copy of the specific volume [m3 kg-1]
+  spec_vol_elem_TEOS10 = gsw_specvol(S, T, pressure * Pa2db)
 
-  T0(1) = T ; S0(1) = S ; pressure0(1) = pressure
+end function spec_vol_elem_TEOS10
 
-  call calculate_spec_vol_array_teos10(T0, S0, pressure0, spv0, 1, 1, spv_ref)
-  specvol = spv0(1)
-end subroutine calculate_spec_vol_scalar_teos10
+!> GSW in situ specific volume anomaly [m3 kg-1]
+real elemental function spec_vol_anomaly_elem_TEOS10(this, T, S, pressure, spv_ref)
+  class(TEOS10_EOS), intent(in) :: this     !< This EOS
+  real,              intent(in) :: T        !< Conservative temperature [degC].
+  real,              intent(in) :: S        !< Absolute salinity [g kg-1].
+  real,              intent(in) :: pressure !< pressure [Pa].
+  real,              intent(in) :: spv_ref  !< A reference specific volume [m3 kg-1].
 
+  !!! #### This code originally had this "masking" line. The answer to the question below is "no" -AJA
+! if (S < -1.0e-10) then ! Can we assume safely that this is a missing value?
+!   spec_vol_elem_TEOS10 = 0.001
+! else
+!   spec_vol_elem_TEOS10 = gsw_rho(S, T, pressure * Pa2db)
+! endif
 
-!> This subroutine computes the in situ specific volume of sea water (specvol in
-!! [m3 kg-1]) from absolute salinity (S [g kg-1]), conservative temperature (T [degC])
-!! and pressure [Pa], using the TEOS10 equation of state.
-!! If spv_ref is present, specvol is an anomaly from spv_ref.
-subroutine calculate_spec_vol_array_teos10(T, S, pressure, specvol, start, npts, spv_ref)
-  real, dimension(:), intent(in)  :: T        !< Conservative temperature [degC].
-  real, dimension(:), intent(in)  :: S        !< salinity [g kg-1].
-  real, dimension(:), intent(in)  :: pressure !< pressure [Pa].
-  real, dimension(:), intent(out) :: specvol  !< in situ specific volume [m3 kg-1].
-  integer,            intent(in)  :: start    !< the starting point in the arrays.
-  integer,            intent(in)  :: npts     !< the number of values to calculate.
-  real,     optional, intent(in)  :: spv_ref  !< A reference specific volume [m3 kg-1].
+  spec_vol_anomaly_elem_TEOS10 = gsw_specvol(S, T, pressure * Pa2db) - spv_ref
 
-  ! Local variables
-  real :: zs  ! Absolute salinity [g kg-1]
-  real :: zt  ! Conservative temperature [degC]
-  real :: zp  ! Pressure converted to decibars [dbar]
-  integer :: j
-
-  do j=start,start+npts-1
-    !Conversions
-    zs = S(j) !gsw_sr_from_sp(S(j))       !Convert practical salinity to absolute salinity
-    zt = T(j) !gsw_ct_from_pt(S(j),T(j))  !Convert potential temp to conservative temp
-    zp = pressure(j)* Pa2db         !Convert pressure from Pascal to decibar
-
-    if (S(j) < -1.0e-10) then
-      specvol(j) = 0.001 !Can we assume safely that this is a missing value?
-    else
-      specvol(j) = gsw_specvol(zs,zt,zp)
-    endif
-    if (present(spv_ref)) specvol(j) = specvol(j) - spv_ref
-  enddo
-
-end subroutine calculate_spec_vol_array_teos10
+end function spec_vol_anomaly_elem_TEOS10
 
 !> For a given thermodynamic state, calculate the derivatives of density with conservative
 !! temperature and absolute salinity, using the TEOS10 expressions.
-subroutine calculate_density_derivs_array_teos10(T, S, pressure, drho_dT, drho_dS, start, npts)
-  real,    intent(in),  dimension(:) :: T        !< Conservative temperature [degC].
-  real,    intent(in),  dimension(:) :: S        !< Absolute salinity [g kg-1].
-  real,    intent(in),  dimension(:) :: pressure !< pressure [Pa].
-  real,    intent(out), dimension(:) :: drho_dT  !< The partial derivative of density with conservative
-                                                 !! temperature [kg m-3 degC-1].
-  real,    intent(out), dimension(:) :: drho_dS  !< The partial derivative of density with absolute salinity,
-                                                 !! [kg m-3 (g/kg)-1].
-  integer, intent(in)                :: start    !< The starting point in the arrays.
-  integer, intent(in)                :: npts     !< The number of values to calculate.
-
-  ! Local variables
-  real :: zs  ! Absolute salinity [g kg-1]
-  real :: zt  ! Conservative temperature [degC]
-  real :: zp  ! Pressure converted to decibars [dbar]
-  integer :: j
-
-  do j=start,start+npts-1
-    !Conversions
-    zs = S(j) !gsw_sr_from_sp(S(j))       !Convert practical salinity to absolute salinity
-    zt = T(j) !gsw_ct_from_pt(S(j),T(j))  !Convert potential temp to conservative temp
-    zp = pressure(j)* Pa2db         !Convert pressure from Pascal to decibar
-    if (S(j) < -1.0e-10) then   !Can we assume safely that this is a missing value?
-      drho_dT(j) = 0.0 ; drho_dS(j) = 0.0
-    else
-      call gsw_rho_first_derivatives(zs, zt, zp, drho_dsa=drho_dS(j), drho_dct=drho_dT(j))
-    endif
-  enddo
-
-end subroutine calculate_density_derivs_array_teos10
-
-!> For a given thermodynamic state, calculate the derivatives of density with conservative
-!! temperature and absolute salinity, using the TEOS10 expressions.
-subroutine calculate_density_derivs_scalar_teos10(T, S, pressure, drho_dT, drho_dS)
-  real,    intent(in)  :: T        !< Conservative temperature [degC]
-  real,    intent(in)  :: S        !< Absolute Salinity [g kg-1]
-  real,    intent(in)  :: pressure !< pressure [Pa].
-  real,    intent(out) :: drho_dT  !< The partial derivative of density with conservative
-                                   !! temperature [kg m-3 degC-1].
-  real,    intent(out) :: drho_dS  !< The partial derivative of density with absolute salinity,
-                                   !! [kg m-3 (g/kg)-1].
-
+elemental subroutine calculate_density_derivs_elem_TEOS10(this, T, S, pressure, drho_dT, drho_dS)
+  class(TEOS10_EOS), intent(in)  :: this     !< This EOS
+  real,              intent(in)  :: T        !< Potential temperature relative to the surface [degC]
+  real,              intent(in)  :: S        !< Salinity [PSU]
+  real,              intent(in)  :: pressure !< Pressure [Pa]
+  real,              intent(out) :: drho_dT  !< The partial derivative of density with potential
+                                             !! temperature [kg m-3 degC-1]
+  real,              intent(out) :: drho_dS  !< The partial derivative of density with salinity,
+                                             !! in [kg m-3 PSU-1]
   ! Local variables
   real :: zs  ! Absolute salinity [g kg-1]
   real :: zt  ! Conservative temperature [degC]
@@ -222,60 +138,63 @@ subroutine calculate_density_derivs_scalar_teos10(T, S, pressure, drho_dT, drho_
   zs = S !gsw_sr_from_sp(S)       !Convert practical salinity to absolute salinity
   zt = T !gsw_ct_from_pt(S,T)  !Convert potential temp to conservative temp
   zp = pressure* Pa2db         !Convert pressure from Pascal to decibar
-  if (S < -1.0e-10) return !Can we assume safely that this is a missing value?
-  call gsw_rho_first_derivatives(zs, zt, zp, drho_dsa=drho_dS, drho_dct=drho_dT)
-end subroutine calculate_density_derivs_scalar_teos10
+  !!! #### This code originally had this "masking" line. The answer to the question below is "no" -AJA
+  !if (S < -1.0e-10) then   !Can we assume safely that this is a missing value?
+  !  drho_dT = 0.0 ; drho_dS = 0.0
+  !else
+    call gsw_rho_first_derivatives(zs, zt, zp, drho_dsa=drho_dS, drho_dct=drho_dT)
+  !endif
+
+end subroutine calculate_density_derivs_elem_TEOS10
+
+!> Calculate the 5 second derivatives of the equation of state for scalar inputs
+elemental subroutine calculate_density_second_derivs_elem_TEOS10(this, T, S, pressure, &
+                       drho_dS_dS, drho_dS_dT, drho_dT_dT, drho_dS_dP, drho_dT_dP)
+  class(TEOS10_EOS), intent(in)    :: this !< This EOS
+  real,              intent(in)    :: T !< Potential temperature referenced to 0 dbar [degC]
+  real,              intent(in)    :: S !< Salinity [PSU]
+  real,              intent(in)    :: pressure !< Pressure [Pa]
+  real,              intent(inout) :: drho_ds_ds !< Partial derivative of beta with respect
+                                                 !! to S [kg m-3 PSU-2]
+  real,              intent(inout) :: drho_ds_dt !< Partial derivative of beta with respect
+                                                 !! to T [kg m-3 PSU-1 degC-1]
+  real,              intent(inout) :: drho_dt_dt !< Partial derivative of alpha with respect
+                                                 !! to T [kg m-3 degC-2]
+  real,              intent(inout) :: drho_ds_dp !< Partial derivative of beta with respect
+                                                 !! to pressure [kg m-3 PSU-1 Pa-1] = [s2 m-2 PSU-1]
+  real,              intent(inout) :: drho_dt_dp !< Partial derivative of alpha with respect
+                                                 !! to pressure [kg m-3 degC-1 Pa-1] = [s2 m-2 degC-1]
+  ! Local variables
+  real :: zs  ! Absolute salinity [g kg-1]
+  real :: zt  ! Conservative temperature [degC]
+  real :: zp  ! Pressure converted to decibars [dbar]
+
+  !Conversions
+  zs = S !gsw_sr_from_sp(S)       !Convert practical salinity to absolute salinity
+  zt = T !gsw_ct_from_pt(S,T)  !Convert potential temp to conservative temp
+  zp = pressure* Pa2db         !Convert pressure from Pascal to decibar
+  !!! #### This code originally had this "masking" line. The answer to the question below is "no" -AJA
+  !if (S < -1.0e-10) then   !Can we assume safely that this is a missing value?
+  !  drho_dS_dS = 0.0 ; drho_dS_dT = 0.0 ; drho_dT_dT = 0.0
+  !  drho_dS_dP = 0.0 ; drho_dT_dP = 0.0
+  !else
+    call gsw_rho_second_derivatives(zs, zt, zp, rho_sa_sa=drho_dS_dS, rho_sa_ct=drho_dS_dT, &
+                                    rho_ct_ct=drho_dT_dT, rho_sa_p=drho_dS_dP, rho_ct_p=drho_dT_dP)
+  !endif
+
+end subroutine calculate_density_second_derivs_elem_TEOS10
 
 !> For a given thermodynamic state, calculate the derivatives of specific volume with conservative
 !! temperature and absolute salinity, using the TEOS10 expressions.
-subroutine calculate_specvol_derivs_teos10(T, S, pressure, dSV_dT, dSV_dS, start, npts)
-  real,    intent(in),  dimension(:) :: T        !< Conservative temperature [degC].
-  real,    intent(in),  dimension(:) :: S        !< Absolute salinity [g kg-1].
-  real,    intent(in),  dimension(:) :: pressure !< pressure [Pa].
-  real,    intent(out), dimension(:) :: dSV_dT   !< The partial derivative of specific volume with
-                                                 !! conservative temperature [m3 kg-1 degC-1].
-  real,    intent(out), dimension(:) :: dSV_dS   !< The partial derivative of specific volume with
-                                                 !! absolute salinity [m3 kg-1 (g/kg)-1].
-  integer, intent(in)                :: start    !< The starting point in the arrays.
-  integer, intent(in)                :: npts     !< The number of values to calculate.
-
-  ! Local variables
-  real :: zs  ! Absolute salinity [g kg-1]
-  real :: zt  ! Conservative temperature [degC]
-  real :: zp  ! Pressure converted to decibars [dbar]
-  integer :: j
-
-  do j=start,start+npts-1
-    !Conversions
-    zs = S(j) !gsw_sr_from_sp(S(j))       !Convert practical salinity to absolute salinity
-    zt = T(j) !gsw_ct_from_pt(S(j),T(j))  !Convert potential temp to conservative temp
-    zp = pressure(j)* Pa2db         !Convert pressure from Pascal to decibar
-    if (S(j) < -1.0e-10) then   !Can we assume safely that this is a missing value?
-      dSV_dT(j) = 0.0 ; dSV_dS(j) = 0.0
-    else
-      call gsw_specvol_first_derivatives(zs,zt,zp, v_sa=dSV_dS(j), v_ct=dSV_dT(j))
-    endif
-  enddo
-
-end subroutine calculate_specvol_derivs_teos10
-
-!> Calculate the 5 second derivatives of the equation of state for scalar inputs
-subroutine calculate_density_second_derivs_scalar_teos10(T, S, pressure, drho_dS_dS, drho_dS_dT, &
-                                                         drho_dT_dT, drho_dS_dP, drho_dT_dP)
-  real, intent(in)     :: T          !< Conservative temperature [degC]
-  real, intent(in)     :: S          !< Absolute Salinity [g kg-1]
-  real, intent(in)     :: pressure   !< pressure [Pa].
-  real, intent(out)    :: drho_dS_dS !< Partial derivative of beta with respect
-                                     !! to S [kg m-3 (g/kg)-2]
-  real, intent(out)    :: drho_dS_dT !< Partial derivative of beta with respect
-                                     !! to T [kg m-3 (g/kg)-1 degC-1]
-  real, intent(out)    :: drho_dT_dT !< Partial derivative of alpha with respect
-                                     !! to T [kg m-3 degC-2]
-  real, intent(out)    :: drho_dS_dP !< Partial derivative of beta with respect
-                                     !! to pressure [kg m-3 (g/kg)-1 Pa-1] = [s2 m-2 (g/kg)-1]
-  real, intent(out)    :: drho_dT_dP !< Partial derivative of alpha with respect
-                                     !! to pressure [kg m-3 degC-1 Pa-1] = [s2 m-2 degC-1]
-
+elemental subroutine calculate_specvol_derivs_elem_TEOS10(this, T, S, pressure, dSV_dT, dSV_dS)
+  class(TEOS10_EOS),  intent(in)    :: this     !< This EOS
+  real,               intent(in)    :: T        !< Potential temperature [degC]
+  real,               intent(in)    :: S        !< Salinity [PSU]
+  real,               intent(in)    :: pressure !< Pressure [Pa]
+  real,               intent(inout) :: dSV_dT   !< The partial derivative of specific volume with
+                                                !! potential temperature [m3 kg-1 degC-1]
+  real,               intent(inout) :: dSV_dS   !< The partial derivative of specific volume with
+                                                !! salinity [m3 kg-1 PSU-1]
   ! Local variables
   real :: zs  ! Absolute salinity [g kg-1]
   real :: zt  ! Conservative temperature [degC]
@@ -285,94 +204,54 @@ subroutine calculate_density_second_derivs_scalar_teos10(T, S, pressure, drho_dS
   zs = S !gsw_sr_from_sp(S)       !Convert practical salinity to absolute salinity
   zt = T !gsw_ct_from_pt(S,T)  !Convert potential temp to conservative temp
   zp = pressure* Pa2db         !Convert pressure from Pascal to decibar
-  if (S < -1.0e-10) return !Can we assume safely that this is a missing value?
-  call gsw_rho_second_derivatives(zs, zt, zp, rho_sa_sa=drho_dS_dS, rho_sa_ct=drho_dS_dT, &
-                                     rho_ct_ct=drho_dT_dT, rho_sa_p=drho_dS_dP, rho_ct_p=drho_dT_dP)
+  !!! #### This code originally had this "masking" line. The answer to the question below is "no" -AJA
+  !if (S < -1.0e-10) then   !Can we assume safely that this is a missing value?
+  !  dSV_dT = 0.0 ; dSV_dS = 0.0
+  !else
+    call gsw_specvol_first_derivatives(zs,zt,zp, v_sa=dSV_dS, v_ct=dSV_dT)
+  !endif
 
-end subroutine calculate_density_second_derivs_scalar_teos10
-
-!> Calculate the 5 second derivatives of the equation of state for scalar inputs
-subroutine calculate_density_second_derivs_array_teos10(T, S, pressure, drho_dS_dS, drho_dS_dT, &
-                                                        drho_dT_dT, drho_dS_dP, drho_dT_dP, start, npts)
-  real, dimension(:), intent(in)     :: T          !< Conservative temperature [degC]
-  real, dimension(:), intent(in)     :: S          !< Absolute Salinity [g kg-1]
-  real, dimension(:), intent(in)     :: pressure   !< pressure [Pa].
-  real, dimension(:), intent(out)    :: drho_dS_dS !< Partial derivative of beta with respect
-                                                   !! to S [kg m-3 (g/kg)-2]
-  real, dimension(:), intent(out)    :: drho_dS_dT !< Partial derivative of beta with respect
-                                                   !! to T [kg m-3 (g/kg)-1 degC-1]
-  real, dimension(:), intent(out)    :: drho_dT_dT !< Partial derivative of alpha with respect
-                                                   !! to T [kg m-3 degC-2]
-  real, dimension(:), intent(out)    :: drho_dS_dP !< Partial derivative of beta with respect
-                                                   !! to pressure [kg m-3 (g/kg)-1 Pa-1] = [s2 m-2 (g/kg)-1]
-  real, dimension(:), intent(out)    :: drho_dT_dP !< Partial derivative of alpha with respect
-                                                   !! to pressure [kg m-3 degC-1 Pa-1] = [s2 m-2 degC-1]
-  integer, intent(in)  :: start    !< The starting point in the arrays.
-  integer, intent(in)  :: npts     !< The number of values to calculate.
-
-  ! Local variables
-  real :: zs  ! Absolute salinity [g kg-1]
-  real :: zt  ! Conservative temperature [degC]
-  real :: zp  ! Pressure converted to decibars [dbar]
-  integer :: j
-
-  do j=start,start+npts-1
-    !Conversions
-    zs = S(j) !gsw_sr_from_sp(S)       !Convert practical salinity to absolute salinity
-    zt = T(j) !gsw_ct_from_pt(S,T)  !Convert potential temp to conservative temp
-    zp = pressure(j)* Pa2db         !Convert pressure from Pascal to decibar
-    if (S(j) < -1.0e-10) then   !Can we assume safely that this is a missing value?
-      drho_dS_dS(j) = 0.0 ; drho_dS_dT(j) = 0.0 ; drho_dT_dT(j) = 0.0
-      drho_dS_dP(j) = 0.0 ; drho_dT_dP(j) = 0.0
-    else
-      call gsw_rho_second_derivatives(zs, zt, zp, rho_sa_sa=drho_dS_dS(j), rho_sa_ct=drho_dS_dT(j), &
-                                      rho_ct_ct=drho_dT_dT(j), rho_sa_p=drho_dS_dP(j), rho_ct_p=drho_dT_dP(j))
-    endif
-  enddo
-
-end subroutine calculate_density_second_derivs_array_teos10
+end subroutine calculate_specvol_derivs_elem_TEOS10
 
 !> This subroutine computes the in situ density of sea water (rho in
 !! [kg m-3]) and the compressibility (drho/dp = C_sound^-2)
 !! (drho_dp [s2 m-2]) from absolute salinity (sal [g kg-1]),
 !! conservative temperature (T [degC]), and pressure [Pa].  It uses the
 !! subroutines from TEOS10 website
-subroutine calculate_compress_teos10(T, S, pressure, rho, drho_dp, start, npts)
-  real,    intent(in),  dimension(:) :: T        !< Conservative temperature [degC].
-  real,    intent(in),  dimension(:) :: S        !< Absolute salinity [g kg-1].
-  real,    intent(in),  dimension(:) :: pressure !< Pressure [Pa].
-  real,    intent(out), dimension(:) :: rho      !< In situ density [kg m-3].
-  real,    intent(out), dimension(:) :: drho_dp  !< The partial derivative of density with pressure
-                                                 !! (also the inverse of the square of sound speed)
-                                                 !! [s2 m-2].
-  integer, intent(in)                :: start    !< The starting point in the arrays.
-  integer, intent(in)                :: npts     !< The number of values to calculate.
+elemental subroutine calculate_compress_elem_TEOS10(this, T, S, pressure, rho, drho_dp)
+  class(TEOS10_EOS),  intent(in)  :: this     !< This EOS
+  real,               intent(in)  :: T        !< Potential temperature relative to the surface [degC]
+  real,               intent(in)  :: S        !< Salinity [PSU]
+  real,               intent(in)  :: pressure !< Pressure [Pa]
+  real,               intent(out) :: rho      !< In situ density [kg m-3]
+  real,               intent(out) :: drho_dp  !< The partial derivative of density with pressure
+                                              !! (also the inverse of the square of sound speed)
+                                              !! [s2 m-2]
 
   ! Local variables
   real :: zs  ! Absolute salinity [g kg-1]
   real :: zt  ! Conservative temperature [degC]
   real :: zp  ! Pressure converted to decibars [dbar]
-  integer :: j
 
-  do j=start,start+npts-1
-    !Conversions
-    zs = S(j) !gsw_sr_from_sp(S(j))       !Convert practical salinity to absolute salinity
-    zt = T(j) !gsw_ct_from_pt(S(j),T(j))  !Convert potential temp to conservative temp
-    zp = pressure(j)* Pa2db         !Convert pressure from Pascal to decibar
-    if (S(j) < -1.0e-10) then   !Can we assume safely that this is a missing value?
-      rho(j) = 1000.0 ; drho_dp(j) = 0.0
-    else
-      rho(j) = gsw_rho(zs,zt,zp)
-      call gsw_rho_first_derivatives(zs,zt,zp, drho_dp=drho_dp(j))
-    endif
-  enddo
-end subroutine calculate_compress_teos10
+  !Conversions
+  zs = S !gsw_sr_from_sp(S)       !Convert practical salinity to absolute salinity
+  zt = T !gsw_ct_from_pt(S,T)  !Convert potential temp to conservative temp
+  zp = pressure* Pa2db         !Convert pressure from Pascal to decibar
+  !!! #### This code originally had this "masking" line. The answer to the question below is "no" -AJA
+  !if (S < -1.0e-10) then   !Can we assume safely that this is a missing value?
+  !  rho = 1000.0 ; drho_dp = 0.0
+  !else
+    rho = gsw_rho(zs,zt,zp)
+    call gsw_rho_first_derivatives(zs,zt,zp, drho_dp=drho_dp)
+  !endif
 
+end subroutine calculate_compress_elem_TEOS10
 
 !> Return the range of temperatures, salinities and pressures for which the TEOS-10
 !! equation of state has been fitted to observations.  Care should be taken when
 !! applying this equation of state outside of its fit range.
-subroutine EoS_fit_range_teos10(T_min, T_max, S_min, S_max, p_min, p_max)
+subroutine EoS_fit_range_teos10(this, T_min, T_max, S_min, S_max, p_min, p_max)
+  class(TEOS10_EOS),  intent(in)  :: this     !< This EOS
   real, optional, intent(out) :: T_min !< The minimum conservative temperature over which this EoS is fitted [degC]
   real, optional, intent(out) :: T_max !< The maximum conservative temperature over which this EoS is fitted [degC]
   real, optional, intent(out) :: S_min !< The minimum absolute salinity over which this EoS is fitted [g kg-1]
@@ -388,5 +267,12 @@ subroutine EoS_fit_range_teos10(T_min, T_max, S_min, S_max, p_min, p_max)
   if (present(p_max)) p_max = 1.0e8
 
 end subroutine EoS_fit_range_teos10
+
+!> \namespace mom_eos_teos10
+!!
+!! \section section_EOS_TEOS10 TEOS10 equation of state
+!!
+!! The TEOS10 equation of state is implemented via the GSW toolbox. We recommend using the
+!! Roquet et al. forms of this equation of state.
 
 end module MOM_EOS_TEOS10

--- a/src/equation_of_state/MOM_EOS_UNESCO.F90
+++ b/src/equation_of_state/MOM_EOS_UNESCO.F90
@@ -3,33 +3,11 @@ module MOM_EOS_UNESCO
 
 ! This file is part of MOM6. See LICENSE.md for the license.
 
+use MOM_EOS_base_type, only : EOS_base
+
 implicit none ; private
 
-public calculate_compress_UNESCO, calculate_density_UNESCO, calculate_spec_vol_UNESCO
-public calculate_density_derivs_UNESCO, calculate_specvol_derivs_UNESCO
-public calculate_density_scalar_UNESCO, calculate_density_array_UNESCO
-public calculate_density_second_derivs_UNESCO, EoS_fit_range_UNESCO
-
-!> Compute the in situ density of sea water (in [kg m-3]), or its anomaly with respect to
-!! a reference density, from salinity [PSU], potential temperature [degC] and pressure [Pa],
-!! using the UNESCO (1981) equation of state, as refit by Jackett and McDougall (1995).
-interface calculate_density_UNESCO
-  module procedure calculate_density_scalar_UNESCO, calculate_density_array_UNESCO
-end interface calculate_density_UNESCO
-
-!> Compute the in situ specific volume of sea water (in [m3 kg-1]), or an anomaly with respect
-!! to a reference specific volume, from salinity [PSU], potential temperature [degC], and
-!! pressure [Pa], using the UNESCO (1981) equation of state, as refit by Jackett and McDougall (1995).
-interface calculate_spec_vol_UNESCO
-  module procedure calculate_spec_vol_scalar_UNESCO, calculate_spec_vol_array_UNESCO
-end interface calculate_spec_vol_UNESCO
-
-!> Compute the second derivatives of density with various combinations of temperature, salinity and
-!! pressure, using the UNESCO (1981) equation of state, as refit by Jackett and McDougall (1995).
-interface calculate_density_second_derivs_UNESCO
-  module procedure calculate_density_second_derivs_scalar_UNESCO, calculate_density_second_derivs_array_UNESCO
-end interface calculate_density_second_derivs_UNESCO
-
+public UNESCO_EOS
 
 !>@{ Parameters in the UNESCO equation of state, as published in appendix A3 of Gill, 1982.
 ! The following constants are used to calculate rho0, the density of seawater at 1 atmosphere pressure.
@@ -84,46 +62,41 @@ real, parameter :: S112 = 6.128773e-8  ! A coefficient in the secant bulk modulu
 real, parameter :: S122 = 6.207323e-10 ! A coefficient in the secant bulk modulus fit [bar-1 degC-2 PSU-1]
 !>@}
 
+!> The EOS_base implementation of the UNESCO equation of state
+type, extends (EOS_base) :: UNESCO_EOS
+
+contains
+  !> Implementation of the in-situ density as an elemental function [kg m-3]
+  procedure :: density_elem => density_elem_UNESCO
+  !> Implementation of the in-situ density anomaly as an elemental function [kg m-3]
+  procedure :: density_anomaly_elem => density_anomaly_elem_UNESCO
+  !> Implementation of the in-situ specific volume as an elemental function [m3 kg-1]
+  procedure :: spec_vol_elem => spec_vol_elem_UNESCO
+  !> Implementation of the in-situ specific volume anomaly as an elemental function [m3 kg-1]
+  procedure :: spec_vol_anomaly_elem => spec_vol_anomaly_elem_UNESCO
+  !> Implementation of the calculation of derivatives of density
+  procedure :: calculate_density_derivs_elem => calculate_density_derivs_elem_UNESCO
+  !> Implementation of the calculation of second derivatives of density
+  procedure :: calculate_density_second_derivs_elem => calculate_density_second_derivs_elem_UNESCO
+  !> Implementation of the calculation of derivatives of specific volume
+  procedure :: calculate_specvol_derivs_elem => calculate_specvol_derivs_elem_UNESCO
+  !> Implementation of the calculation of compressibility
+  procedure :: calculate_compress_elem => calculate_compress_elem_UNESCO
+  !> Implementation of the range query function
+  procedure :: EOS_fit_range => EOS_fit_range_UNESCO
+
+end type UNESCO_EOS
+
 contains
 
-!> This subroutine computes the in situ density of sea water (rho in [kg m-3])
-!! from salinity (S [PSU]), potential temperature (T [degC]), and pressure [Pa],
-!! using the UNESCO (1981) equation of state, as refit by Jackett and McDougall (1995).
-!! If rho_ref is present, rho is an anomaly from rho_ref.
-subroutine calculate_density_scalar_UNESCO(T, S, pressure, rho, rho_ref)
-  real,           intent(in)  :: T        !< Potential temperature relative to the surface [degC]
-  real,           intent(in)  :: S        !< Salinity [PSU]
-  real,           intent(in)  :: pressure !< Pressure [Pa]
-  real,           intent(out) :: rho      !< In situ density [kg m-3]
-  real, optional, intent(in)  :: rho_ref  !< A reference density [kg m-3]
-
-  ! Local variables
-  real, dimension(1) :: T0    ! A 1-d array with a copy of the potential temperature [degC]
-  real, dimension(1) :: S0    ! A 1-d array with a copy of the salinity [PSU]
-  real, dimension(1) :: pressure0 ! A 1-d array with a copy of the pressure [Pa]
-  real, dimension(1) :: rho0  ! A 1-d array with a copy of the in situ density [kg m-3]
-
-  T0(1) = T
-  S0(1) = S
-  pressure0(1) = pressure
-
-  call calculate_density_array_UNESCO(T0, S0, pressure0, rho0, 1, 1, rho_ref)
-  rho = rho0(1)
-
-end subroutine calculate_density_scalar_UNESCO
-
-!> This subroutine computes the in situ density of sea water (rho in [kg m-3])
-!! from salinity (S [PSU]), potential temperature (T [degC]) and pressure [Pa],
-!! using the UNESCO (1981) equation of state, as refit by Jackett and McDougall (1995).
-!! If rho_ref is present, rho is an anomaly from rho_ref.
-subroutine calculate_density_array_UNESCO(T, S, pressure, rho, start, npts, rho_ref)
-  real, dimension(:), intent(in)  :: T        !< Potential temperature relative to the surface [degC]
-  real, dimension(:), intent(in)  :: S        !< Salinity [PSU]
-  real, dimension(:), intent(in)  :: pressure !< Pressure [Pa]
-  real, dimension(:), intent(out) :: rho      !< In situ density [kg m-3]
-  integer,            intent(in)  :: start    !< The starting index for calculations
-  integer,            intent(in)  :: npts     !< The number of values to calculate
-  real,     optional, intent(in)  :: rho_ref  !< A reference density [kg m-3]
+!> In situ density as fit by Jackett and McDougall, 1995 [kg m-3]
+!!
+!! This is an elemental function that can be applied to any combination of scalar and array inputs.
+real elemental function density_elem_UNESCO(this, T, S, pressure)
+  class(UNESCO_EOS), intent(in) :: this     !< This EOS
+  real,              intent(in) :: T        !< Potential temperature relative to the surface [degC]
+  real,              intent(in) :: S        !< Salinity [PSU]
+  real,              intent(in) :: pressure !< Pressure [Pa]
 
   ! Local variables
   real :: t1   ! A copy of the temperature at a point [degC]
@@ -133,70 +106,74 @@ subroutine calculate_density_array_UNESCO(T, S, pressure, rho, start, npts, rho_
   real :: rho0 ! Density at 1 bar pressure [kg m-3]
   real :: sig0 ! The anomaly of rho0 from R00 [kg m-3]
   real :: ks   ! The secant bulk modulus [bar]
-  integer :: j
 
-  do j=start,start+npts-1
-    p1 = pressure(j)*1.0e-5 ; t1 = T(j)
-    s1 = max(S(j), 0.0) ; s12 = sqrt(s1)
+  p1 = pressure*1.0e-5 ; t1 = T
+  s1 = max(S, 0.0) ; s12 = sqrt(s1)
 
-!  Compute rho(s,theta,p=0) - (same as rho(s,t_insitu,p=0) ).
+  ! Compute rho(s,theta,p=0) - (same as rho(s,t_insitu,p=0) ).
+  sig0 = ( t1*(R01 + t1*(R02 + t1*(R03 + t1*(R04 + t1*R05)))) + &
+           s1*((R10 + t1*(R11 + t1*(R12 + t1*(R13 + t1*R14)))) + &
+               (s12*(R60 + t1*(R61 + t1*R62)) + s1*R20)) )
+  rho0 = R00 + sig0
 
-    sig0 = ( t1*(R01 + t1*(R02 + t1*(R03 + t1*(R04 + t1*R05)))) + &
-             s1*((R10 + t1*(R11 + t1*(R12 + t1*(R13 + t1*R14)))) + &
-                 (s12*(R60 + t1*(R61 + t1*R62)) + s1*R20)) )
-    rho0 = R00 + sig0
+  ! Compute rho(s,theta,p), first calculating the secant bulk modulus.
+  ks = (S000 + ( t1*(S010 + t1*(S020 + t1*(S030 + t1*S040))) + &
+                 s1*((S100 + t1*(S110 + t1*(S120 + t1*S130))) + s12*(S600 + t1*(S610 + t1*S620))) )) + &
+       p1*( (S001 + ( t1*(S011 + t1*(S021 + t1*S031)) + &
+                      s1*((S101 + t1*(S111 + t1*S121)) + s12*S601) )) + &
+            p1*(S002 + ( t1*(S012 + t1*S022) + s1*(S102 + t1*(S112 + t1*S122)) )) )
 
-!  Compute rho(s,theta,p), first calculating the secant bulk modulus.
+  density_elem_UNESCO = rho0*ks / (ks - p1)
 
-    ks = (S000 + ( t1*(S010 + t1*(S020 + t1*(S030 + t1*S040))) + &
-                   s1*((S100 + t1*(S110 + t1*(S120 + t1*S130))) + s12*(S600 + t1*(S610 + t1*S620))) )) + &
-         p1*( (S001 + ( t1*(S011 + t1*(S021 + t1*S031)) + &
-                        s1*((S101 + t1*(S111 + t1*S121)) + s12*S601) )) + &
-              p1*(S002 + ( t1*(S012 + t1*S022) + s1*(S102 + t1*(S112 + t1*S122)) )) )
+end function density_elem_UNESCO
 
-    if (present(rho_ref)) then
-      rho(j) = ((R00 - rho_ref)*ks + (sig0*ks + p1*rho_ref)) / (ks - p1)
-    else
-      rho(j) = rho0*ks / (ks - p1)
-    endif
-  enddo
-end subroutine calculate_density_array_UNESCO
-
-!> This subroutine computes the in situ specific volume of sea water (specvol in [m3 kg-1])
-!! from salinity (S [PSU]), potential temperature (T [degC]) and pressure [Pa],
-!! using the UNESCO (1981) equation of state, as refit by Jackett and McDougall (1995).
-!! If spv_ref is present, specvol is an anomaly from spv_ref.
-subroutine calculate_spec_vol_scalar_UNESCO(T, S, pressure, specvol, spv_ref)
-  real,           intent(in)  :: T        !< Potential temperature relative to the surface [degC]
-  real,           intent(in)  :: S        !< Salinity [PSU]
-  real,           intent(in)  :: pressure !< Pressure [Pa]
-  real,           intent(out) :: specvol  !< In situ specific volume [m3 kg-1]
-  real, optional, intent(in)  :: spv_ref  !< A reference specific volume [m3 kg-1]
+!> In situ density anomaly as fit by Jackett and McDougall, 1995 [kg m-3]
+!!
+!! This is an elemental function that can be applied to any combination of scalar and array inputs.
+real elemental function density_anomaly_elem_UNESCO(this, T, S, pressure, rho_ref)
+  class(UNESCO_EOS), intent(in) :: this     !< This EOS
+  real,              intent(in) :: T        !< Potential temperature relative to the surface [degC]
+  real,              intent(in) :: S        !< Salinity [PSU]
+  real,              intent(in) :: pressure !< Pressure [Pa]
+  real,              intent(in) :: rho_ref  !< A reference density [kg m-3]
 
   ! Local variables
-  real, dimension(1) :: T0    ! A 1-d array with a copy of the potential temperature [degC]
-  real, dimension(1) :: S0    ! A 1-d array with a copy of the salinity [PSU]
-  real, dimension(1) :: pressure0 ! A 1-d array with a copy of the pressure [Pa]
-  real, dimension(1) :: spv0  ! A 1-d array with a copy of the specific volume [m3 kg-1]
+  real :: t1   ! A copy of the temperature at a point [degC]
+  real :: s1   ! A copy of the salinity at a point [PSU]
+  real :: p1   ! Pressure converted to bars [bar]
+  real :: s12  ! The square root of salinity [PSU1/2]
+  real :: rho0 ! Density at 1 bar pressure [kg m-3]
+  real :: sig0 ! The anomaly of rho0 from R00 [kg m-3]
+  real :: ks   ! The secant bulk modulus [bar]
 
-  T0(1) = T ; S0(1) = S ; pressure0(1) = pressure
+  p1 = pressure*1.0e-5 ; t1 = T
+  s1 = max(S, 0.0) ; s12 = sqrt(s1)
 
-  call calculate_spec_vol_array_UNESCO(T0, S0, pressure0, spv0, 1, 1, spv_ref)
-  specvol = spv0(1)
-end subroutine calculate_spec_vol_scalar_UNESCO
+  ! Compute rho(s,theta,p=0) - (same as rho(s,t_insitu,p=0) ).
+  sig0 = ( t1*(R01 + t1*(R02 + t1*(R03 + t1*(R04 + t1*R05)))) + &
+           s1*((R10 + t1*(R11 + t1*(R12 + t1*(R13 + t1*R14)))) + &
+               (s12*(R60 + t1*(R61 + t1*R62)) + s1*R20)) )
+  rho0 = R00 + sig0
 
-!> This subroutine computes the in situ specific volume of sea water (specvol in [m3 kg-1])
-!! from salinity (S [PSU]), potential temperature (T [degC]) and pressure [Pa],
-!! using the UNESCO (1981) equation of state, as refit by Jackett and McDougall (1995).
-!! If spv_ref is present, specvol is an anomaly from spv_ref.
-subroutine calculate_spec_vol_array_UNESCO(T, S, pressure, specvol, start, npts, spv_ref)
-  real, dimension(:), intent(in)  :: T        !< Potential temperature relative to the surface [degC]
-  real, dimension(:), intent(in)  :: S        !< Salinity [PSU]
-  real, dimension(:), intent(in)  :: pressure !< Pressure [Pa]
-  real, dimension(:), intent(out) :: specvol  !< In situ specific volume [m3 kg-1]
-  integer,            intent(in)  :: start    !< The starting index for calculations
-  integer,            intent(in)  :: npts     !< The number of values to calculate
-  real,     optional, intent(in)  :: spv_ref  !< A reference specific volume [m3 kg-1]
+  ! Compute rho(s,theta,p), first calculating the secant bulk modulus.
+  ks = (S000 + ( t1*(S010 + t1*(S020 + t1*(S030 + t1*S040))) + &
+                 s1*((S100 + t1*(S110 + t1*(S120 + t1*S130))) + s12*(S600 + t1*(S610 + t1*S620))) )) + &
+       p1*( (S001 + ( t1*(S011 + t1*(S021 + t1*S031)) + &
+                      s1*((S101 + t1*(S111 + t1*S121)) + s12*S601) )) + &
+            p1*(S002 + ( t1*(S012 + t1*S022) + s1*(S102 + t1*(S112 + t1*S122)) )) )
+
+  density_anomaly_elem_UNESCO = ((R00 - rho_ref)*ks + (sig0*ks + p1*rho_ref)) / (ks - p1)
+
+end function density_anomaly_elem_UNESCO
+
+!> In situ specific volume as fit by Jackett and McDougall, 1995 [m3 kg-1]
+!!
+!! This is an elemental function that can be applied to any combination of scalar and array inputs.
+real elemental function spec_vol_elem_UNESCO(this, T, S, pressure)
+  class(UNESCO_EOS), intent(in) :: this    !< This EOS
+  real,           intent(in) :: T        !< Potential temperature relative to the surface [degC]
+  real,           intent(in) :: S        !< Salinity [PSU]
+  real,           intent(in) :: pressure !< Pressure [Pa]
 
   ! Local variables
   real :: t1   ! A copy of the temperature at a point [degC]
@@ -205,49 +182,74 @@ subroutine calculate_spec_vol_array_UNESCO(T, S, pressure, specvol, start, npts,
   real :: s12  ! The square root of salinity [PSU1/2]l553
   real :: rho0 ! Density at 1 bar pressure [kg m-3]
   real :: ks   ! The secant bulk modulus [bar]
-  integer :: j
 
-  do j=start,start+npts-1
+  p1 = pressure*1.0e-5 ; t1 = T
+  s1 = max(S, 0.0) ; s12 = sqrt(s1)
 
-    p1 = pressure(j)*1.0e-5 ; t1 = T(j)
-    s1 = max(S(j), 0.0) ; s12 = sqrt(s1)
+  ! Compute rho(s,theta,p=0), which is the same as rho(s,t_insitu,p=0).
+  rho0 = R00 + ( t1*(R01 + t1*(R02 + t1*(R03 + t1*(R04 + t1*R05)))) + &
+                 s1*((R10 + t1*(R11 + t1*(R12 + t1*(R13 + t1*R14)))) + &
+                     (s12*(R60 + t1*(R61 + t1*R62)) + s1*R20)) )
 
-    ! Compute rho(s,theta,p=0), which is the same as rho(s,t_insitu,p=0).
+  ! Compute rho(s,theta,p), first calculating the secant bulk modulus.
+  ks = (S000 + ( t1*(S010 + t1*(S020 + t1*(S030 + t1*S040))) + &
+                 s1*((S100 + t1*(S110 + t1*(S120 + t1*S130))) + s12*(S600 + t1*(S610 + t1*S620))) )) + &
+       p1*( (S001 + ( t1*(S011 + t1*(S021 + t1*S031)) + &
+                      s1*((S101 + t1*(S111 + t1*S121)) + s12*S601) )) + &
+            p1*(S002 + ( t1*(S012 + t1*S022) + s1*(S102 + t1*(S112 + t1*S122)) )) )
 
-    rho0 = R00 + ( t1*(R01 + t1*(R02 + t1*(R03 + t1*(R04 + t1*R05)))) + &
-                   s1*((R10 + t1*(R11 + t1*(R12 + t1*(R13 + t1*R14)))) + &
-                       (s12*(R60 + t1*(R61 + t1*R62)) + s1*R20)) )
+  spec_vol_elem_UNESCO = (ks - p1) / (rho0*ks)
 
-    ! Compute rho(s,theta,p), first calculating the secant bulk modulus.
+end function spec_vol_elem_UNESCO
 
-    ks = (S000 + ( t1*(S010 + t1*(S020 + t1*(S030 + t1*S040))) + &
-                   s1*((S100 + t1*(S110 + t1*(S120 + t1*S130))) + s12*(S600 + t1*(S610 + t1*S620))) )) + &
-         p1*( (S001 + ( t1*(S011 + t1*(S021 + t1*S031)) + &
-                        s1*((S101 + t1*(S111 + t1*S121)) + s12*S601) )) + &
-              p1*(S002 + ( t1*(S012 + t1*S022) + s1*(S102 + t1*(S112 + t1*S122)) )) )
+!> In situ specific volume anomaly as fit by Jackett and McDougall, 1995 [m3 kg-1]
+!!
+!! This is an elemental function that can be applied to any combination of scalar and array inputs.
+real elemental function spec_vol_anomaly_elem_UNESCO(this, T, S, pressure, spv_ref)
+  class(UNESCO_EOS), intent(in) :: this    !< This EOS
+  real,           intent(in) :: T        !< Potential temperature relative to the surface [degC]
+  real,           intent(in) :: S        !< Salinity [PSU]
+  real,           intent(in) :: pressure !< Pressure [Pa]
+  real,           intent(in) :: spv_ref  !< A reference specific volume [m3 kg-1]
 
-    if (present(spv_ref)) then
-      specvol(j) = (ks*(1.0 - (rho0*spv_ref)) - p1) / (rho0*ks)
-    else
-      specvol(j) = (ks - p1) / (rho0*ks)
-    endif
-  enddo
-end subroutine calculate_spec_vol_array_UNESCO
+  ! Local variables
+  real :: t1   ! A copy of the temperature at a point [degC]
+  real :: s1   ! A copy of the salinity at a point [PSU]
+  real :: p1   ! Pressure converted to bars [bar]
+  real :: s12  ! The square root of salinity [PSU1/2]
+  real :: rho0 ! Density at 1 bar pressure [kg m-3]
+  real :: ks   ! The secant bulk modulus [bar]
 
+  p1 = pressure*1.0e-5 ; t1 = T
+  s1 = max(S, 0.0) ; s12 = sqrt(s1)
+
+  ! Compute rho(s,theta,p=0), which is the same as rho(s,t_insitu,p=0).
+  rho0 = R00 + ( t1*(R01 + t1*(R02 + t1*(R03 + t1*(R04 + t1*R05)))) + &
+                 s1*((R10 + t1*(R11 + t1*(R12 + t1*(R13 + t1*R14)))) + &
+                     (s12*(R60 + t1*(R61 + t1*R62)) + s1*R20)) )
+
+  ! Compute rho(s,theta,p), first calculating the secant bulk modulus.
+  ks = (S000 + ( t1*(S010 + t1*(S020 + t1*(S030 + t1*S040))) + &
+                 s1*((S100 + t1*(S110 + t1*(S120 + t1*S130))) + s12*(S600 + t1*(S610 + t1*S620))) )) + &
+       p1*( (S001 + ( t1*(S011 + t1*(S021 + t1*S031)) + &
+                      s1*((S101 + t1*(S111 + t1*S121)) + s12*S601) )) + &
+            p1*(S002 + ( t1*(S012 + t1*S022) + s1*(S102 + t1*(S112 + t1*S122)) )) )
+
+  spec_vol_anomaly_elem_UNESCO = (ks*(1.0 - (rho0*spv_ref)) - p1) / (rho0*ks)
+
+end function spec_vol_anomaly_elem_UNESCO
 
 !> Calculate the partial derivatives of density with potential temperature and salinity
 !! using the UNESCO (1981) equation of state, as refit by Jackett and McDougall (1995).
-subroutine calculate_density_derivs_UNESCO(T, S, pressure, drho_dT, drho_dS, start, npts)
-  real,    intent(in),  dimension(:) :: T        !< Potential temperature relative to the surface [degC]
-  real,    intent(in),  dimension(:) :: S        !< Salinity [PSU]
-  real,    intent(in),  dimension(:) :: pressure !< Pressure [Pa]
-  real,    intent(out), dimension(:) :: drho_dT  !< The partial derivative of density with potential
-                                                 !! temperature [kg m-3 degC-1]
-  real,    intent(out), dimension(:) :: drho_dS  !< The partial derivative of density with salinity,
-                                                 !! in [kg m-3 PSU-1]
-  integer, intent(in)                :: start    !< The starting index for calculations
-  integer, intent(in)                :: npts     !< The number of values to calculate
-
+elemental subroutine calculate_density_derivs_elem_UNESCO(this, T, S, pressure, drho_dT, drho_dS)
+  class(UNESCO_EOS), intent(in)  :: this     !< This EOS
+  real,              intent(in)  :: T        !< Potential temperature relative to the surface [degC]
+  real,              intent(in)  :: S        !< Salinity [PSU]
+  real,              intent(in)  :: pressure !< Pressure [Pa]
+  real,              intent(out) :: drho_dT  !< The partial derivative of density with potential
+                                             !! temperature [kg m-3 degC-1]
+  real,              intent(out) :: drho_dS  !< The partial derivative of density with salinity,
+                                             !! in [kg m-3 PSU-1]
   ! Local variables
   real :: t1       ! A copy of the temperature at a point [degC]
   real :: s1       ! A copy of the salinity at a point [PSU]
@@ -260,182 +262,58 @@ subroutine calculate_density_derivs_UNESCO(T, S, pressure, drho_dT, drho_dS, sta
   real :: dks_dT   ! Derivative of ks with T [bar degC-1]
   real :: dks_dS   ! Derivative of ks with S [bar psu-1]
   real :: I_denom  ! 1.0 / (ks - p1) [bar-1]
-  integer :: j
 
-  do j=start,start+npts-1
-    p1 = pressure(j)*1.0e-5 ; t1 = T(j)
-    s1 = max(S(j), 0.0) ; s12 = sqrt(s1)
+  p1 = pressure*1.0e-5 ; t1 = T
+  s1 = max(S, 0.0) ; s12 = sqrt(s1)
 
-    ! Compute rho(s,theta,p=0) and its derivatives with temperature and salinity
-    rho0 = R00 + ( t1*(R01 + t1*(R02 + t1*(R03 + t1*(R04 + t1*R05)))) + &
-                   s1*((R10 + t1*(R11 + t1*(R12 + t1*(R13 + t1*R14)))) + &
-                       (s12*(R60 + t1*(R61 + t1*R62)) + s1*R20)) )
-    drho0_dT = R01 + ( t1*(2.0*R02 + t1*(3.0*R03 + t1*(4.0*R04 + t1*(5.0*R05)))) + &
-                       s1*(R11 + (t1*(2.0*R12 + t1*(3.0*R13 + t1*(4.0*R14))) + &
-                                  s12*(R61 + t1*(2.0*R62)) )) )
-    drho0_dS = R10 + ( t1*(R11 + t1*(R12 + t1*(R13 + t1*R14))) + &
-                       (1.5*(s12*(R60 + t1*(R61 + t1*R62))) + s1*(2.0*R20)) )
+  ! Compute rho(s,theta,p=0) and its derivatives with temperature and salinity
+  rho0 = R00 + ( t1*(R01 + t1*(R02 + t1*(R03 + t1*(R04 + t1*R05)))) + &
+                 s1*((R10 + t1*(R11 + t1*(R12 + t1*(R13 + t1*R14)))) + &
+                     (s12*(R60 + t1*(R61 + t1*R62)) + s1*R20)) )
+  drho0_dT = R01 + ( t1*(2.0*R02 + t1*(3.0*R03 + t1*(4.0*R04 + t1*(5.0*R05)))) + &
+                     s1*(R11 + (t1*(2.0*R12 + t1*(3.0*R13 + t1*(4.0*R14))) + &
+                                s12*(R61 + t1*(2.0*R62)) )) )
+  drho0_dS = R10 + ( t1*(R11 + t1*(R12 + t1*(R13 + t1*R14))) + &
+                     (1.5*(s12*(R60 + t1*(R61 + t1*R62))) + s1*(2.0*R20)) )
 
-    ! Compute the secant bulk modulus and its derivatives with temperature and salinity
-    ks = ( S000 + (t1*(S010 + t1*(S020 + t1*(S030 + t1*S040))) + &
-                   s1*((S100 + t1*(S110 + t1*(S120 + t1*S130))) + s12*(S600 + t1*(S610 + t1*S620)))) ) + &
-         p1*( (S001 + ( t1*(S011 + t1*(S021 + t1*S031)) + &
-                        s1*((S101 + t1*(S111 + t1*S121)) + s12*S601) )) + &
-              p1*(S002 + ( t1*(S012 + t1*S022) + s1*(S102 + t1*(S112 + t1*S122)) )) )
-    dks_dT = ( S010 + (t1*(2.0*S020 + t1*(3.0*S030 + t1*(4.0*S040))) + &
-                       s1*((S110 + t1*(2.0*S120 + t1*(3.0*S130))) + s12*(S610 + t1*(2.0*S620)))) ) + &
-             p1*(((S011 + t1*(2.0*S021 + t1*(3.0*S031))) + s1*(S111 + t1*(2.0*S121)) ) + &
-                 p1*(S012 + t1*(2.0*S022) + s1*(S112 + t1*(2.0*S122))) )
-    dks_dS = ( S100 + (t1*(S110 + t1*(S120 + t1*S130)) + 1.5*(s12*(S600 + t1*(S610 + t1*S620)))) ) + &
-             p1*((S101 + t1*(S111 + t1*S121) + s12*(1.5*S601)) + &
-                 p1*(S102 + t1*(S112 + t1*S122)) )
+  ! Compute the secant bulk modulus and its derivatives with temperature and salinity
+  ks = ( S000 + (t1*(S010 + t1*(S020 + t1*(S030 + t1*S040))) + &
+                 s1*((S100 + t1*(S110 + t1*(S120 + t1*S130))) + s12*(S600 + t1*(S610 + t1*S620)))) ) + &
+       p1*( (S001 + ( t1*(S011 + t1*(S021 + t1*S031)) + &
+                      s1*((S101 + t1*(S111 + t1*S121)) + s12*S601) )) + &
+            p1*(S002 + ( t1*(S012 + t1*S022) + s1*(S102 + t1*(S112 + t1*S122)) )) )
+  dks_dT = ( S010 + (t1*(2.0*S020 + t1*(3.0*S030 + t1*(4.0*S040))) + &
+                     s1*((S110 + t1*(2.0*S120 + t1*(3.0*S130))) + s12*(S610 + t1*(2.0*S620)))) ) + &
+           p1*(((S011 + t1*(2.0*S021 + t1*(3.0*S031))) + s1*(S111 + t1*(2.0*S121)) ) + &
+               p1*(S012 + t1*(2.0*S022) + s1*(S112 + t1*(2.0*S122))) )
+  dks_dS = ( S100 + (t1*(S110 + t1*(S120 + t1*S130)) + 1.5*(s12*(S600 + t1*(S610 + t1*S620)))) ) + &
+           p1*((S101 + t1*(S111 + t1*S121) + s12*(1.5*S601)) + &
+               p1*(S102 + t1*(S112 + t1*S122)) )
 
-    I_denom = 1.0 / (ks - p1)
-    drho_dT(j) = (ks*drho0_dT - dks_dT*((rho0*p1)*I_denom)) * I_denom
-    drho_dS(j) = (ks*drho0_dS - dks_dS*((rho0*p1)*I_denom)) * I_denom
-  enddo
+  I_denom = 1.0 / (ks - p1)
+  drho_dT = (ks*drho0_dT - dks_dT*((rho0*p1)*I_denom)) * I_denom
+  drho_dS = (ks*drho0_dS - dks_dS*((rho0*p1)*I_denom)) * I_denom
 
-end subroutine calculate_density_derivs_UNESCO
+end subroutine calculate_density_derivs_elem_UNESCO
 
-!> Return the partial derivatives of specific volume with temperature and salinity
-!! using the UNESCO (1981) equation of state, as refit by Jackett and McDougall (1995).
-subroutine calculate_specvol_derivs_UNESCO(T, S, pressure, dSV_dT, dSV_dS, start, npts)
-  real,    intent(in),    dimension(:) :: T        !< Potential temperature relative to the surface [degC].
-  real,    intent(in),    dimension(:) :: S        !< Salinity [PSU].
-  real,    intent(in),    dimension(:) :: pressure !< Pressure [Pa].
-  real,    intent(inout), dimension(:) :: dSV_dT   !< The partial derivative of specific volume with
-                                                   !! potential temperature [m3 kg-1 degC-1].
-  real,    intent(inout), dimension(:) :: dSV_dS   !< The partial derivative of specific volume with
-                                                   !! salinity [m3 kg-1 PSU-1].
-  integer, intent(in)                  :: start    !< The starting point in the arrays.
-  integer, intent(in)                  :: npts     !< The number of values to calculate.
-
-  ! Local variables
-  real :: t1       ! A copy of the temperature at a point [degC]
-  real :: s1       ! A copy of the salinity at a point [PSU]
-  real :: p1       ! Pressure converted to bars [bar]
-  real :: s12      ! The square root of salinity [PSU1/2]
-  real :: rho0     ! Density at 1 bar pressure [kg m-3]
-  real :: ks       ! The secant bulk modulus [bar]
-  real :: drho0_dT ! Derivative of rho0 with T [kg m-3 degC-1]
-  real :: drho0_dS ! Derivative of rho0 with S [kg m-3 PSU-1]
-  real :: dks_dT   ! Derivative of ks with T [bar degC-1]
-  real :: dks_dS   ! Derivative of ks with S [bar psu-1]
-  real :: I_denom2 ! 1.0 / (rho0*ks)**2 [m6 kg-2 bar-2]
-  integer :: j
-
-  do j=start,start+npts-1
-    p1 = pressure(j)*1.0e-5 ; t1 = T(j)
-    s1 = max(S(j), 0.0) ; s12 = sqrt(s1)
-
-    ! Compute rho(s,theta,p=0) and its derivatives with temperature and salinity
-    rho0 = R00 + ( t1*(R01 + t1*(R02 + t1*(R03 + t1*(R04 + t1*R05)))) + &
-                   s1*((R10 + t1*(R11 + t1*(R12 + t1*(R13 + t1*R14)))) + &
-                       (s12*(R60 + t1*(R61 + t1*R62)) + s1*R20)) )
-    drho0_dT = R01 + ( t1*(2.0*R02 + t1*(3.0*R03 + t1*(4.0*R04 + t1*(5.0*R05)))) + &
-                       s1*(R11 + (t1*(2.0*R12 + t1*(3.0*R13 + t1*(4.0*R14))) + &
-                                  s12*(R61 + t1*(2.0*R62)) )) )
-    drho0_dS = R10 + ( t1*(R11 + t1*(R12 + t1*(R13 + t1*R14))) + &
-                       (1.5*(s12*(R60 + t1*(R61 + t1*R62))) + s1*(2.0*R20)) )
-
-    ! Compute the secant bulk modulus and its derivatives with temperature and salinity
-    ks = ( S000 + (t1*(S010 + t1*(S020 + t1*(S030 + t1*S040))) + &
-                   s1*((S100 + t1*(S110 + t1*(S120 + t1*S130))) + s12*(S600 + t1*(S610 + t1*S620)))) ) + &
-         p1*( (S001 + ( t1*(S011 + t1*(S021 + t1*S031)) + &
-                        s1*((S101 + t1*(S111 + t1*S121)) + s12*S601) )) + &
-              p1*(S002 + ( t1*(S012 + t1*S022) + s1*(S102 + t1*(S112 + t1*S122)) )) )
-    dks_dT = ( S010 + (t1*(2.0*S020 + t1*(3.0*S030 + t1*(4.0*S040))) + &
-                       s1*((S110 + t1*(2.0*S120 + t1*(3.0*S130))) + s12*(S610 + t1*(2.0*S620)))) ) + &
-             p1*(((S011 + t1*(2.0*S021 + t1*(3.0*S031))) + s1*(S111 + t1*(2.0*S121)) ) + &
-                 p1*(S012 + t1*(2.0*S022) + s1*(S112 + t1*(2.0*S122))) )
-    dks_dS = ( S100 + (t1*(S110 + t1*(S120 + t1*S130)) + 1.5*(s12*(S600 + t1*(S610 + t1*S620)))) ) + &
-             p1*((S101 + t1*(S111 + t1*S121) + s12*(1.5*S601)) + &
-                 p1*(S102 + t1*(S112 + t1*S122)) )
-
-    ! specvol(j) = (ks - p1) / (rho0*ks) = 1/rho0 - p1/(rho0*ks)
-    I_denom2 = 1.0 / (rho0*ks)**2
-    dSV_dT(j) = ((p1*rho0)*dks_dT + ((p1 - ks)*ks)*drho0_dT) * I_denom2
-    dSV_dS(j) = ((p1*rho0)*dks_dS + ((p1 - ks)*ks)*drho0_dS) * I_denom2
-  enddo
-
-end subroutine calculate_specvol_derivs_UNESCO
-
-!> Compute the in situ density of sea water (rho) and the compressibility (drho/dp == C_sound^-2)
-!! at the given salinity, potential temperature and pressure using the UNESCO (1981)
-!! equation of state, as refit by Jackett and McDougall (1995).
-subroutine calculate_compress_UNESCO(T, S, pressure, rho, drho_dp, start, npts)
-  real,    intent(in),  dimension(:) :: T        !< Potential temperature relative to the surface
-                                                 !! [degC]
-  real,    intent(in),  dimension(:) :: S        !< Salinity [PSU]
-  real,    intent(in),  dimension(:) :: pressure !< Pressure [Pa]
-  real,    intent(out), dimension(:) :: rho      !< In situ density [kg m-3]
-  real,    intent(out), dimension(:) :: drho_dp  !< The partial derivative of density with pressure
-                                                 !! (also the inverse of the square of sound speed)
-                                                 !! [s2 m-2]
-  integer, intent(in)                :: start    !< The starting index for calculations
-  integer, intent(in)                :: npts     !< The number of values to calculate
-
-  ! Local variables
-  real :: t1      ! A copy of the temperature at a point [degC]
-  real :: s1      ! A copy of the salinity at a point [PSU]
-  real :: p1      ! Pressure converted to bars [bar]
-  real :: s12     ! The square root of salinity [PSU1/2]
-  real :: rho0    ! Density at 1 bar pressure [kg m-3]
-  real :: ks      ! The secant bulk modulus [bar]
-  real :: ks_0    ! The secant bulk modulus at zero pressure [bar]
-  real :: ks_1    ! The linear pressure dependence of the secant bulk modulus at zero pressure [nondim]
-  real :: ks_2    ! The quadratic pressure dependence of the secant bulk modulus at zero pressure [bar-1]
-  real :: dks_dp  ! The derivative of the secant bulk modulus with pressure [nondim]
-  real :: I_denom  ! 1.0 / (ks - p1) [bar-1]
-  integer :: j
-
-  do j=start,start+npts-1
-    p1 = pressure(j)*1.0e-5 ; t1 = T(j)
-    s1 = max(S(j), 0.0) ; s12 = sqrt(s1)
-
-    ! Compute rho(s,theta,p=0), which is the same as rho(s,t_insitu,p=0).
-
-    rho0 = R00 + ( t1*(R01 + t1*(R02 + t1*(R03 + t1*(R04 + t1*R05)))) + &
-                   s1*((R10 + t1*(R11 + t1*(R12 + t1*(R13 + t1*R14)))) + &
-                       (s12*(R60 + t1*(R61 + t1*R62)) + s1*R20)) )
-
-    ! Calculate the secant bulk modulus and its derivative with pressure.
-    ks_0 = S000 + ( t1*( S010 + t1*(S020 + t1*(S030 + t1*S040))) + &
-                    s1*((S100 + t1*(S110 + t1*(S120 + t1*S130))) + s12*(S600 + t1*(S610 + t1*S620))) )
-    ks_1 = S001 + ( t1*( S011 + t1*(S021 + t1*S031)) + &
-                    s1*((S101 + t1*(S111 + t1*S121)) + s12*S601) )
-    ks_2 = S002 + ( t1*( S012 + t1*S022) + s1*(S102 + t1*(S112 + t1*S122)) )
-
-    ks = ks_0 + p1*(ks_1 + p1*ks_2)
-    dks_dp = ks_1 + 2.0*p1*ks_2
-    I_denom = 1.0 / (ks - p1)
-
-    ! Compute the in situ density, rho(s,theta,p), and its derivative with pressure.
-    rho(j) = rho0*ks * I_denom
-    ! The factor of 1.0e-5 is because pressure here is in bars, not Pa.
-    drho_dp(j) = 1.0e-5 * ((rho0 * (ks - p1*dks_dp)) * I_denom**2)
-  enddo
-end subroutine calculate_compress_UNESCO
-
-!> Calculate second derivatives of density with respect to temperature, salinity, and pressure
-!! using the UNESCO (1981) equation of state, as refit by Jackett and McDougall (1995).
-subroutine calculate_density_second_derivs_array_UNESCO(T, S, P, drho_ds_ds, drho_ds_dt, drho_dt_dt, &
-                                                         drho_ds_dp, drho_dt_dp, start, npts)
-  real, dimension(:), intent(in   ) :: T !< Potential temperature referenced to 0 dbar [degC]
-  real, dimension(:), intent(in   ) :: S !< Salinity [PSU]
-  real, dimension(:), intent(in   ) :: P !< Pressure [Pa]
-  real, dimension(:), intent(inout) :: drho_ds_ds !< Partial derivative of beta with respect
-                                                  !! to S [kg m-3 PSU-2]
-  real, dimension(:), intent(inout) :: drho_ds_dt !< Partial derivative of beta with respect
-                                                  !! to T [kg m-3 PSU-1 degC-1]
-  real, dimension(:), intent(inout) :: drho_dt_dt !< Partial derivative of alpha with respect
-                                                  !! to T [kg m-3 degC-2]
-  real, dimension(:), intent(inout) :: drho_ds_dp !< Partial derivative of beta with respect
-                                                  !! to pressure [kg m-3 PSU-1 Pa-1] = [s2 m-2 PSU-1]
-  real, dimension(:), intent(inout) :: drho_dt_dp !< Partial derivative of alpha with respect
-                                                  !! to pressure [kg m-3 degC-1 Pa-1] = [s2 m-2 degC-1]
-  integer,            intent(in   ) :: start !< Starting index in T,S,P
-  integer,            intent(in   ) :: npts  !< Number of points to loop over
+!> Calculate second derivatives of density with respect to temperature, salinity, and pressure,
+!! using the UNESCO (1981) equation of state, as refit by Jackett and McDougall (1995)
+elemental subroutine calculate_density_second_derivs_elem_UNESCO(this, T, S, pressure, &
+                            drho_ds_ds, drho_ds_dt, drho_dt_dt, drho_ds_dp, drho_dt_dp)
+  class(UNESCO_EOS), intent(in)    :: this !< This EOS
+  real,              intent(in)    :: T !< Potential temperature referenced to 0 dbar [degC]
+  real,              intent(in)    :: S !< Salinity [PSU]
+  real,              intent(in)    :: pressure !< Pressure [Pa]
+  real,              intent(inout) :: drho_ds_ds !< Partial derivative of beta with respect
+                                                 !! to S [kg m-3 PSU-2]
+  real,              intent(inout) :: drho_ds_dt !< Partial derivative of beta with respect
+                                                 !! to T [kg m-3 PSU-1 degC-1]
+  real,              intent(inout) :: drho_dt_dt !< Partial derivative of alpha with respect
+                                                 !! to T [kg m-3 degC-2]
+  real,              intent(inout) :: drho_ds_dp !< Partial derivative of beta with respect
+                                                 !! to pressure [kg m-3 PSU-1 Pa-1] = [s2 m-2 PSU-1]
+  real,              intent(inout) :: drho_dt_dp !< Partial derivative of alpha with respect
+                                                 !! to pressure [kg m-3 degC-1 Pa-1] = [s2 m-2 degC-1]
 
   ! Local variables
   real :: t1          ! A copy of the temperature at a point [degC]
@@ -462,134 +340,198 @@ subroutine calculate_density_second_derivs_array_UNESCO(T, S, P, drho_ds_ds, drh
   real :: d2ks_dSdp   ! Second derivative of the secant bulk modulus with salinity and pressure [psu-1]
   real :: d2ks_dTdp   ! Second derivative of the secant bulk modulus with temperature and pressure [degC-1]
   real :: I_denom     ! The inverse of the denominator of the expression for density [bar-1]
-  integer :: j
 
-  do j=start,start+npts-1
+  p1 = pressure*1.0e-5 ; t1 = T
+  s1 = max(S, 0.0) ; s12 = sqrt(s1)
+  ! The UNESCO equation of state is a fit to density, but it chooses a form that exhibits a
+  ! singularity in the second derivatives with salinity for fresh water.  To avoid this, the
+  ! square root of salinity can be treated with a floor such that the contribution from the
+  ! S**1.5 terms to both the surface density and the secant bulk modulus are lost to roundoff.
+  ! This salinity is given by (~1e-16*S000/S600)**(2/3) ~= 3e-8 PSU, or S12 ~= 1.7e-4
+  I_s12 = 1.0 / (max(s12, 1.0e-4))
 
-    p1 = P(j)*1.0e-5 ; t1 = T(j)
-    s1 = max(S(j), 0.0) ; s12 = sqrt(s1)
-    ! The UNESCO equation of state is a fit to density, but it chooses a form that exhibits a
-    ! singularity in the second derivatives with salinity for fresh water.  To avoid this, the
-    ! square root of salinity can be treated with a floor such that the contribution from the
-    ! S**1.5 terms to both the surface density and the secant bulk modulus are lost to roundoff.
-    ! This salinity is given by (~1e-16*S000/S600)**(2/3) ~= 3e-8 PSU, or S12 ~= 1.7e-4
-    I_s12 = 1.0 / (max(s12, 1.0e-4))
+  ! Calculate the density at sea level pressure and its derivatives
+  rho0 = R00 + ( t1*(R01 + t1*(R02 + t1*(R03 + t1*(R04 + t1*R05)))) + &
+                 s1*((R10 + t1*(R11 + t1*(R12 + t1*(R13 + t1*R14)))) + &
+                     (s12*(R60 + t1*(R61 + t1*R62)) + s1*R20)) )
+  drho0_dT = R01 + ( t1*(2.0*R02 + t1*(3.0*R03 + t1*(4.0*R04 + t1*(5.0*R05)))) + &
+                     s1*(R11 + ( t1*(2.0*R12 + t1*(3.0*R13 + t1*(4.0*R14))) + &
+                                 s12*(R61 + t1*(2.0*R62)) ) ) )
+  drho0_dS = R10 + ( t1*(R11 + t1*(R12 + t1*(R13 + t1*R14))) + &
+                     (1.5*(s12*(R60 + t1*(R61 + t1*R62))) + s1*(2.0*R20)) )
+  d2rho0_dS2 = 0.75*(R60 + t1*(R61 + t1*R62))*I_s12 + 2.0*R20
+  d2rho0_dSdT = R11 + ( t1*(2.0*R12 + t1*(3.0*R13 + t1*(4.0*R14))) + s12*(1.5*R61 + t1*(3.0*R62)) )
+  d2rho0_dT2 = 2.0*R02 + ( t1*(6.0*R03 + t1*(12.0*R04 + t1*(20.0*R05))) + &
+                           s1*((2.0*R12 + t1*(6.0*R13 + t1*(12.0*R14))) + s12*(2.0*R62)) )
 
-    ! Calculate the density at sea level pressure and its derivatives
-    rho0 = R00 + ( t1*(R01 + t1*(R02 + t1*(R03 + t1*(R04 + t1*R05)))) + &
-                   s1*((R10 + t1*(R11 + t1*(R12 + t1*(R13 + t1*R14)))) + &
-                       (s12*(R60 + t1*(R61 + t1*R62)) + s1*R20)) )
-    drho0_dT = R01 + ( t1*(2.0*R02 + t1*(3.0*R03 + t1*(4.0*R04 + t1*(5.0*R05)))) + &
-                       s1*(R11 + ( t1*(2.0*R12 + t1*(3.0*R13 + t1*(4.0*R14))) + &
-                                   s12*(R61 + t1*(2.0*R62)) ) ) )
-    drho0_dS = R10 + ( t1*(R11 + t1*(R12 + t1*(R13 + t1*R14))) + &
-                       (1.5*(s12*(R60 + t1*(R61 + t1*R62))) + s1*(2.0*R20)) )
-    d2rho0_dS2 = 0.75*(R60 + t1*(R61 + t1*R62))*I_s12 + 2.0*R20
-    d2rho0_dSdT = R11 + ( t1*(2.0*R12 + t1*(3.0*R13 + t1*(4.0*R14))) + s12*(1.5*R61 + t1*(3.0*R62)) )
-    d2rho0_dT2 = 2.0*R02 + ( t1*(6.0*R03 + t1*(12.0*R04 + t1*(20.0*R05))) + &
-                             s1*((2.0*R12 + t1*(6.0*R13 + t1*(12.0*R14))) + s12*(2.0*R62)) )
+  !  Calculate the secant bulk modulus and its derivatives
+  ks_0 = S000 + ( t1*( S010 + t1*(S020 + t1*(S030 + t1*S040))) + &
+                  s1*((S100 + t1*(S110 + t1*(S120 + t1*S130))) + s12*(S600 + t1*(S610 + t1*S620))) )
+  ks_1 = S001 + ( t1*( S011 + t1*(S021 + t1*S031)) + &
+                  s1*((S101 + t1*(S111 + t1*S121)) + s12*S601) )
+  ks_2 = S002 + ( t1*( S012 + t1*S022) + s1*(S102 + t1*(S112 + t1*S122)) )
 
-    !  Calculate the secant bulk modulus and its derivatives
-    ks_0 = S000 + ( t1*( S010 + t1*(S020 + t1*(S030 + t1*S040))) + &
-                    s1*((S100 + t1*(S110 + t1*(S120 + t1*S130))) + s12*(S600 + t1*(S610 + t1*S620))) )
-    ks_1 = S001 + ( t1*( S011 + t1*(S021 + t1*S031)) + &
-                    s1*((S101 + t1*(S111 + t1*S121)) + s12*S601) )
-    ks_2 = S002 + ( t1*( S012 + t1*S022) + s1*(S102 + t1*(S112 + t1*S122)) )
+  ks = ks_0 + p1*(ks_1 + p1*ks_2)
+  dks_dp = ks_1 + 2.0*p1*ks_2
+  dks_dT = (S010 + ( t1*(2.0*S020 + t1*(3.0*S030 + t1*(4.0*S040))) + &
+                     s1*((S110 + t1*(2.0*S120 + t1*(3.0*S130))) + s12*(S610 + t1*(2.0*S620))) )) + &
+           p1*((S011 + t1*(2.0*S021 + t1*(3.0*S031)) + s1*(S111 + t1*(2.0*S121))) + &
+               p1*(S012 + t1*(2.0*S022) + s1*(S112 + t1*(2.0*S122))))
+  dks_dS = (S100 + ( t1*(S110 + t1*(S120 + t1*S130)) + 1.5*(s12*(S600 + t1*(S610 + t1*S620))) )) + &
+           p1*((S101 + t1*(S111 + t1*S121) + s12*(1.5*S601)) + &
+               p1*(S102 + t1*(S112 + t1*S122)))
+  d2ks_dS2 = 0.75*((S600 + t1*(S610 + t1*S620)) + p1*S601)*I_s12
+  d2ks_dSdT = (S110 + ( t1*(2.0*S120 + t1*(3.0*S130)) + s12*(1.5*S610 + t1*(3.0*S620)) )) + &
+              p1*((S111 + t1*(2.0*S121)) +  p1*(S112 + t1*(2.0*S122)))
+  d2ks_dT2 = 2.0*(S020 + ( t1*(3.0*S030 + t1*(6.0*S040)) + s1*((S120 + t1*(3.0*S130)) + s12*S620) )) + &
+             2.0*p1*((S021 + (t1*(3.0*S031) + s1*S121)) + p1*(S022 + s1*S122))
 
-    ks = ks_0 + p1*(ks_1 + p1*ks_2)
-    dks_dp = ks_1 + 2.0*p1*ks_2
-    dks_dT = (S010 + ( t1*(2.0*S020 + t1*(3.0*S030 + t1*(4.0*S040))) + &
-                       s1*((S110 + t1*(2.0*S120 + t1*(3.0*S130))) + s12*(S610 + t1*(2.0*S620))) )) + &
-             p1*((S011 + t1*(2.0*S021 + t1*(3.0*S031)) + s1*(S111 + t1*(2.0*S121))) + &
-                 p1*(S012 + t1*(2.0*S022) + s1*(S112 + t1*(2.0*S122))))
-    dks_dS = (S100 + ( t1*(S110 + t1*(S120 + t1*S130)) + 1.5*(s12*(S600 + t1*(S610 + t1*S620))) )) + &
-             p1*((S101 + t1*(S111 + t1*S121) + s12*(1.5*S601)) + &
-                 p1*(S102 + t1*(S112 + t1*S122)))
-    d2ks_dS2 = 0.75*((S600 + t1*(S610 + t1*S620)) + p1*S601)*I_s12
-    d2ks_dSdT = (S110 + ( t1*(2.0*S120 + t1*(3.0*S130)) + s12*(1.5*S610 + t1*(3.0*S620)) )) + &
-                p1*((S111 + t1*(2.0*S121)) +  p1*(S112 + t1*(2.0*S122)))
-    d2ks_dT2 = 2.0*(S020 + ( t1*(3.0*S030 + t1*(6.0*S040)) + s1*((S120 + t1*(3.0*S130)) + s12*S620) )) + &
-               2.0*p1*((S021 + (t1*(3.0*S031) + s1*S121)) + p1*(S022 + s1*S122))
+  d2ks_dSdp = (S101 + (t1*(S111 + t1*S121) + s12*(1.5*S601))) + &
+              2.0*p1*(S102 + t1*(S112 + t1*S122))
+  d2ks_dTdp = (S011 + (t1*(2.0*S021 + t1*(3.0*S031)) + s1*(S111 + t1*(2.0*S121)))) + &
+              2.0*p1*(S012 + t1*(2.0*S022) + s1*(S112 + t1*(2.0*S122)))
+  I_denom = 1.0 / (ks - p1)
 
-    d2ks_dSdp = (S101 + (t1*(S111 + t1*S121) + s12*(1.5*S601))) + &
-                2.0*p1*(S102 + t1*(S112 + t1*S122))
-    d2ks_dTdp = (S011 + (t1*(2.0*S021 + t1*(3.0*S031)) + s1*(S111 + t1*(2.0*S121)))) + &
-                2.0*p1*(S012 + t1*(2.0*S022) + s1*(S112 + t1*(2.0*S122)))
-    I_denom = 1.0 / (ks - p1)
+  ! Expressions for density and its first derivatives are copied here for reference:
+  !   rho = rho0*ks * I_denom
+  !   drho_dT = I_denom*(ks*drho0_dT - p1*rho0*I_denom*dks_dT)
+  !   drho_dS = I_denom*(ks*drho0_dS - p1*rho0*I_denom*dks_dS)
+  !   drho_dp = 1.0e-5 * (rho0 * I_denom**2) * (ks - dks_dp*p1)
 
-    ! Expressions for density and its first derivatives are copied here for reference:
-    !   rho = rho0*ks * I_denom
-    !   drho_dT = I_denom*(ks*drho0_dT - p1*rho0*I_denom*dks_dT)
-    !   drho_dS = I_denom*(ks*drho0_dS - p1*rho0*I_denom*dks_dS)
-    !   drho_dp = 1.0e-5 * (rho0 * I_denom**2) * (ks - dks_dp*p1)
+  ! Finally calculate the second derivatives
+  drho_dS_dS = I_denom * ( ks*d2rho0_dS2 - (p1*I_denom) * &
+                    (2.0*drho0_dS*dks_dS + rho0*(d2ks_dS2 - 2.0*dks_dS**2*I_denom)) )
+  drho_dS_dT = I_denom * (ks * d2rho0_dSdT - (p1*I_denom) * &
+                      ((drho0_dT*dks_dS + drho0_dS*dks_dT) + &
+                       rho0*(d2ks_dSdT - 2.0*(dks_dS*dks_dT)*I_denom)) )
+  drho_dT_dT = I_denom * ( ks*d2rho0_dT2 - (p1*I_denom) * &
+                    (2.0*drho0_dT*dks_dT + rho0*(d2ks_dT2 - 2.0*dks_dT**2*I_denom)) )
 
-    ! Finally calculate the second derivatives
-    drho_dS_dS(j) = I_denom * ( ks*d2rho0_dS2 - (p1*I_denom) * &
-                      (2.0*drho0_dS*dks_dS + rho0*(d2ks_dS2 - 2.0*dks_dS**2*I_denom)) )
-    drho_dS_dT(j) = I_denom * (ks * d2rho0_dSdT - (p1*I_denom) * &
-                        ((drho0_dT*dks_dS + drho0_dS*dks_dT) + &
-                         rho0*(d2ks_dSdT - 2.0*(dks_dS*dks_dT)*I_denom)) )
-    drho_dT_dT(j) = I_denom * ( ks*d2rho0_dT2 - (p1*I_denom) * &
-                      (2.0*drho0_dT*dks_dT + rho0*(d2ks_dT2 - 2.0*dks_dT**2*I_denom)) )
+  ! The factor of 1.0e-5 is because pressure here is in bars, not Pa.
+  drho_dS_dp = (1.0e-5 * I_denom**2) * ( (ks*drho0_dS - rho0*dks_dS) - &
+                    p1*( (dks_dp*drho0_dS + rho0*d2ks_dSdp) - &
+                         2.0*(rho0*dks_dS) * ((dks_dp - 1.0)*I_denom) ) )
+  drho_dT_dp = (1.0e-5 * I_denom**2) * ( (ks*drho0_dT - rho0*dks_dT) - &
+                    p1*( (dks_dp*drho0_dT + rho0*d2ks_dTdp) - &
+                         2.0*(rho0*dks_dT) * ((dks_dp - 1.0)*I_denom) ) )
 
-    ! The factor of 1.0e-5 is because pressure here is in bars, not Pa.
-    drho_dS_dp(j) = (1.0e-5 * I_denom**2) * ( (ks*drho0_dS - rho0*dks_dS) - &
-                      p1*( (dks_dp*drho0_dS + rho0*d2ks_dSdp) - &
-                           2.0*(rho0*dks_dS) * ((dks_dp - 1.0)*I_denom) ) )
-    drho_dT_dp(j) = (1.0e-5 * I_denom**2) * ( (ks*drho0_dT - rho0*dks_dT) - &
-                      p1*( (dks_dp*drho0_dT + rho0*d2ks_dTdp) - &
-                           2.0*(rho0*dks_dT) * ((dks_dp - 1.0)*I_denom) ) )
-  enddo
+end subroutine calculate_density_second_derivs_elem_UNESCO
 
-end subroutine calculate_density_second_derivs_array_UNESCO
-
-!> Second derivatives of density with respect to temperature, salinity and pressure for scalar inputs
+!> Calculate the partial derivatives of specific volume with temperature and salinity
 !! using the UNESCO (1981) equation of state, as refit by Jackett and McDougall (1995).
-!! Inputs are promoted to 1-element arrays and outputs are demoted to scalars.
-subroutine calculate_density_second_derivs_scalar_UNESCO(T, S, P, drho_ds_ds, drho_ds_dt, drho_dt_dt, &
-                                                         drho_ds_dp, drho_dt_dp)
-  real, intent(in   ) :: T          !< Potential temperature referenced to 0 dbar
-  real, intent(in   ) :: S          !< Salinity [PSU]
-  real, intent(in   ) :: P          !< Pressure [Pa]
-  real, intent(  out) :: drho_ds_ds !< Partial derivative of beta with respect
-                                    !! to S [kg m-3 PSU-2]
-  real, intent(  out) :: drho_ds_dt !< Partial derivative of beta with respect
-                                    !! to T [kg m-3 PSU-1 degC-1]
-  real, intent(  out) :: drho_dt_dt !< Partial derivative of alpha with respect
-                                    !! to T [kg m-3 degC-2]
-  real, intent(  out) :: drho_ds_dp !< Partial derivative of beta with respect
-                                    !! to pressure [kg m-3 PSU-1 Pa-1] = [s2 m-2 PSU-1]
-  real, intent(  out) :: drho_dt_dp !< Partial derivative of alpha with respect
-                                    !! to pressure [kg m-3 degC-1 Pa-1] = [s2 m-2 degC-1]
+elemental subroutine calculate_specvol_derivs_elem_UNESCO(this, T, S, pressure, dSV_dT, dSV_dS)
+  class(UNESCO_EOS), intent(in)    :: this     !< This EOS
+  real,              intent(in)    :: T        !< Potential temperature [degC]
+  real,              intent(in)    :: S        !< Salinity [PSU]
+  real,              intent(in)    :: pressure !< Pressure [Pa]
+  real,              intent(inout) :: dSV_dT   !< The partial derivative of specific volume with
+                                               !! potential temperature [m3 kg-1 degC-1]
+  real,              intent(inout) :: dSV_dS   !< The partial derivative of specific volume with
+                                               !! salinity [m3 kg-1 PSU-1]
   ! Local variables
-  real, dimension(1) :: T0      ! A 1-d array with a copy of the temperature [degC]
-  real, dimension(1) :: S0      ! A 1-d array with a copy of the salinity [PSU]
-  real, dimension(1) :: p0      ! A 1-d array with a copy of the pressure [Pa]
-  real, dimension(1) :: drdsds  ! The second derivative of density with salinity [kg m-3 PSU-2]
-  real, dimension(1) :: drdsdt  ! The second derivative of density with salinity and
-                                ! temperature [kg m-3 PSU-1 degC-1]
-  real, dimension(1) :: drdtdt  ! The second derivative of density with temperature [kg m-3 degC-2]
-  real, dimension(1) :: drdsdp  ! The second derivative of density with salinity and
-                                ! pressure [kg m-3 PSU-1 Pa-1] = [s2 m-2 PSU-1]
-  real, dimension(1) :: drdtdp  ! The second derivative of density with temperature and
-                                ! pressure [kg m-3 degC-1 Pa-1] = [s2 m-2 degC-1]
+  real :: t1       ! A copy of the temperature at a point [degC]
+  real :: s1       ! A copy of the salinity at a point [PSU]
+  real :: p1       ! Pressure converted to bars [bar]
+  real :: s12      ! The square root of salinity [PSU1/2]
+  real :: rho0     ! Density at 1 bar pressure [kg m-3]
+  real :: ks       ! The secant bulk modulus [bar]
+  real :: drho0_dT ! Derivative of rho0 with T [kg m-3 degC-1]
+  real :: drho0_dS ! Derivative of rho0 with S [kg m-3 PSU-1]
+  real :: dks_dT   ! Derivative of ks with T [bar degC-1]
+  real :: dks_dS   ! Derivative of ks with S [bar psu-1]
+  real :: I_denom2 ! 1.0 / (rho0*ks)**2 [m6 kg-2 bar-2]
 
-  T0(1) = T
-  S0(1) = S
-  P0(1) = P
-  call calculate_density_second_derivs_array_UNESCO(T0, S0, P0, drdsds, drdsdt, drdtdt, drdsdp, drdtdp, 1, 1)
-  drho_ds_ds = drdsds(1)
-  drho_ds_dt = drdsdt(1)
-  drho_dt_dt = drdtdt(1)
-  drho_ds_dp = drdsdp(1)
-  drho_dt_dp = drdtdp(1)
+  p1 = pressure*1.0e-5 ; t1 = T
+  s1 = max(S, 0.0) ; s12 = sqrt(s1)
 
-end subroutine calculate_density_second_derivs_scalar_UNESCO
+  ! Compute rho(s,theta,p=0) and its derivatives with temperature and salinity
+  rho0 = R00 + ( t1*(R01 + t1*(R02 + t1*(R03 + t1*(R04 + t1*R05)))) + &
+                 s1*((R10 + t1*(R11 + t1*(R12 + t1*(R13 + t1*R14)))) + &
+                     (s12*(R60 + t1*(R61 + t1*R62)) + s1*R20)) )
+  drho0_dT = R01 + ( t1*(2.0*R02 + t1*(3.0*R03 + t1*(4.0*R04 + t1*(5.0*R05)))) + &
+                     s1*(R11 + (t1*(2.0*R12 + t1*(3.0*R13 + t1*(4.0*R14))) + &
+                                s12*(R61 + t1*(2.0*R62)) )) )
+  drho0_dS = R10 + ( t1*(R11 + t1*(R12 + t1*(R13 + t1*R14))) + &
+                     (1.5*(s12*(R60 + t1*(R61 + t1*R62))) + s1*(2.0*R20)) )
+
+  ! Compute the secant bulk modulus and its derivatives with temperature and salinity
+  ks = ( S000 + (t1*(S010 + t1*(S020 + t1*(S030 + t1*S040))) + &
+                 s1*((S100 + t1*(S110 + t1*(S120 + t1*S130))) + s12*(S600 + t1*(S610 + t1*S620)))) ) + &
+       p1*( (S001 + ( t1*(S011 + t1*(S021 + t1*S031)) + &
+                      s1*((S101 + t1*(S111 + t1*S121)) + s12*S601) )) + &
+            p1*(S002 + ( t1*(S012 + t1*S022) + s1*(S102 + t1*(S112 + t1*S122)) )) )
+  dks_dT = ( S010 + (t1*(2.0*S020 + t1*(3.0*S030 + t1*(4.0*S040))) + &
+                     s1*((S110 + t1*(2.0*S120 + t1*(3.0*S130))) + s12*(S610 + t1*(2.0*S620)))) ) + &
+           p1*(((S011 + t1*(2.0*S021 + t1*(3.0*S031))) + s1*(S111 + t1*(2.0*S121)) ) + &
+               p1*(S012 + t1*(2.0*S022) + s1*(S112 + t1*(2.0*S122))) )
+  dks_dS = ( S100 + (t1*(S110 + t1*(S120 + t1*S130)) + 1.5*(s12*(S600 + t1*(S610 + t1*S620)))) ) + &
+           p1*((S101 + t1*(S111 + t1*S121) + s12*(1.5*S601)) + &
+               p1*(S102 + t1*(S112 + t1*S122)) )
+
+  ! specvol = (ks - p1) / (rho0*ks) = 1/rho0 - p1/(rho0*ks)
+  I_denom2 = 1.0 / (rho0*ks)**2
+  dSV_dT = ((p1*rho0)*dks_dT + ((p1 - ks)*ks)*drho0_dT) * I_denom2
+  dSV_dS = ((p1*rho0)*dks_dS + ((p1 - ks)*ks)*drho0_dS) * I_denom2
+
+end subroutine calculate_specvol_derivs_elem_UNESCO
+
+!> Compute the in situ density of sea water (rho) and the compressibility (drho/dp == C_sound^-2)
+!! at the given salinity, potential temperature and pressure using the UNESCO (1981)
+!! equation of state, as refit by Jackett and McDougall (1995).
+elemental subroutine calculate_compress_elem_UNESCO(this, T, S, pressure, rho, drho_dp)
+  class(UNESCO_EOS), intent(in)  :: this     !< This EOS
+  real,              intent(in)  :: T        !< Potential temperature relative to the surface [degC]
+  real,              intent(in)  :: S        !< Salinity [PSU]
+  real,              intent(in)  :: pressure !< Pressure [Pa]
+  real,              intent(out) :: rho      !< In situ density [kg m-3]
+  real,              intent(out) :: drho_dp  !< The partial derivative of density with pressure
+                                             !! (also the inverse of the square of sound speed)
+                                             !! [s2 m-2]
+  ! Local variables
+  real :: t1      ! A copy of the temperature at a point [degC]
+  real :: s1      ! A copy of the salinity at a point [PSU]
+  real :: p1      ! Pressure converted to bars [bar]
+  real :: s12     ! The square root of salinity [PSU1/2]
+  real :: rho0    ! Density at 1 bar pressure [kg m-3]
+  real :: ks      ! The secant bulk modulus [bar]
+  real :: ks_0    ! The secant bulk modulus at zero pressure [bar]
+  real :: ks_1    ! The linear pressure dependence of the secant bulk modulus at zero pressure [nondim]
+  real :: ks_2    ! The quadratic pressure dependence of the secant bulk modulus at zero pressure [bar-1]
+  real :: dks_dp  ! The derivative of the secant bulk modulus with pressure [nondim]
+  real :: I_denom  ! 1.0 / (ks - p1) [bar-1]
+
+  p1 = pressure*1.0e-5 ; t1 = T
+  s1 = max(S, 0.0) ; s12 = sqrt(s1)
+
+  ! Compute rho(s,theta,p=0), which is the same as rho(s,t_insitu,p=0).
+
+  rho0 = R00 + ( t1*(R01 + t1*(R02 + t1*(R03 + t1*(R04 + t1*R05)))) + &
+                 s1*((R10 + t1*(R11 + t1*(R12 + t1*(R13 + t1*R14)))) + &
+                     (s12*(R60 + t1*(R61 + t1*R62)) + s1*R20)) )
+
+  ! Calculate the secant bulk modulus and its derivative with pressure.
+  ks_0 = S000 + ( t1*( S010 + t1*(S020 + t1*(S030 + t1*S040))) + &
+                  s1*((S100 + t1*(S110 + t1*(S120 + t1*S130))) + s12*(S600 + t1*(S610 + t1*S620))) )
+  ks_1 = S001 + ( t1*( S011 + t1*(S021 + t1*S031)) + &
+                  s1*((S101 + t1*(S111 + t1*S121)) + s12*S601) )
+  ks_2 = S002 + ( t1*( S012 + t1*S022) + s1*(S102 + t1*(S112 + t1*S122)) )
+
+  ks = ks_0 + p1*(ks_1 + p1*ks_2)
+  dks_dp = ks_1 + 2.0*p1*ks_2
+  I_denom = 1.0 / (ks - p1)
+
+  ! Compute the in situ density, rho(s,theta,p), and its derivative with pressure.
+  rho = rho0*ks * I_denom
+  ! The factor of 1.0e-5 is because pressure here is in bars, not Pa.
+  drho_dp = 1.0e-5 * ((rho0 * (ks - p1*dks_dp)) * I_denom**2)
+
+end subroutine calculate_compress_elem_UNESCO
 
 !> Return the range of temperatures, salinities and pressures for which Jackett and McDougall (1995)
 !! refit the UNESCO equation of state has been fitted to observations.  Care should be taken when
 !! applying this equation of state outside of its fit range.
-subroutine EoS_fit_range_UNESCO(T_min, T_max, S_min, S_max, p_min, p_max)
+subroutine EoS_fit_range_UNESCO(this, T_min, T_max, S_min, S_max, p_min, p_max)
+  class(UNESCO_EOS), intent(in) :: this !< This EOS
   real, optional, intent(out) :: T_min !< The minimum potential temperature over which this EoS is fitted [degC]
   real, optional, intent(out) :: T_max !< The maximum potential temperature over which this EoS is fitted [degC]
   real, optional, intent(out) :: S_min !< The minimum practical salinity over which this EoS is fitted [PSU]

--- a/src/equation_of_state/MOM_EOS_Wright_full.F90
+++ b/src/equation_of_state/MOM_EOS_Wright_full.F90
@@ -1,44 +1,16 @@
-!> The equation of state using the Wright 1997 expressions
+!> The equation of state using the Wright 1997 expressions with full range of data.
 module MOM_EOS_Wright_full
 
 ! This file is part of MOM6. See LICENSE.md for the license.
 
+use MOM_EOS_base_type, only : EOS_base
 use MOM_hor_index, only : hor_index_type
 
 implicit none ; private
 
-public calculate_compress_wright_full, calculate_density_wright_full, calculate_spec_vol_wright_full
-public calculate_density_derivs_wright_full, calculate_specvol_derivs_wright_full
-public calculate_density_second_derivs_wright_full, EoS_fit_range_Wright_full
+public Wright_full_EOS
 public int_density_dz_wright_full, int_spec_vol_dp_wright_full
 public avg_spec_vol_Wright_full
-
-!> Compute the in situ density of sea water (in [kg m-3]), or its anomaly with respect to
-!! a reference density, from salinity in practical salinity units ([PSU]), potential
-!! temperature (in degrees Celsius [degC]), and pressure [Pa], using the expressions from
-!! Wright, 1997, J. Atmos. Ocean. Tech., 14, 735-740 with the full range fit coefficients.
-interface calculate_density_wright_full
-  module procedure calculate_density_scalar_wright, calculate_density_array_wright
-end interface calculate_density_wright_full
-
-!> Compute the in situ specific volume of sea water (in [m3 kg-1]), or an anomaly with respect
-!! to a reference specific volume, from salinity in practical salinity units ([PSU]), potential
-!! temperature (in degrees Celsius [degC]), and pressure [Pa], using the expressions from
-!! Wright, 1997, J. Atmos. Ocean. Tech., 14, 735-740 with the full range fit coefficients.
-interface calculate_spec_vol_wright_full
-  module procedure calculate_spec_vol_scalar_wright, calculate_spec_vol_array_wright
-end interface calculate_spec_vol_wright_full
-
-!> Compute the derivatives of density with temperature and salinity
-interface calculate_density_derivs_wright_full
-  module procedure calculate_density_derivs_scalar_wright, calculate_density_derivs_array_wright
-end interface calculate_density_derivs_wright_full
-
-!> Compute the second derivatives of density with various combinations
-!! of temperature, salinity, and pressure
-interface calculate_density_second_derivs_wright_full
-  module procedure calculate_density_second_derivs_scalar_wright, calculate_density_second_derivs_array_wright
-end interface calculate_density_second_derivs_wright_full
 
 !>@{ Parameters in the Wright equation of state using the full range formula, which is a fit to the UNESCO
 !    equation of state for the full range: -2 < theta < 40 [degC], 0 < S < 40 [PSU], 0  < p < 1e8 [Pa].
@@ -63,119 +35,98 @@ real, parameter :: c4 = -1.664201e2  ! A parameter in the Wright lambda fit [m2 
 real, parameter :: c5 = -2.765195    ! A parameter in the Wright lambda fit [m2 s-2 degC-1 PSU-1]
 !>@}
 
+!> The EOS_base implementation of the full range Wright 1997 equation of state
+type, extends (EOS_base) :: Wright_full_EOS
+
+contains
+  !> Implementation of the in-situ density as an elemental function [kg m-3]
+  procedure :: density_elem => density_elem_Wright_full
+  !> Implementation of the in-situ density anomaly as an elemental function [kg m-3]
+  procedure :: density_anomaly_elem => density_anomaly_elem_Wright_full
+  !> Implementation of the in-situ specific volume as an elemental function [m3 kg-1]
+  procedure :: spec_vol_elem => spec_vol_elem_Wright_full
+  !> Implementation of the in-situ specific volume anomaly as an elemental function [m3 kg-1]
+  procedure :: spec_vol_anomaly_elem => spec_vol_anomaly_elem_Wright_full
+  !> Implementation of the calculation of derivatives of density
+  procedure :: calculate_density_derivs_elem => calculate_density_derivs_elem_Wright_full
+  !> Implementation of the calculation of second derivatives of density
+  procedure :: calculate_density_second_derivs_elem => calculate_density_second_derivs_elem_Wright_full
+  !> Implementation of the calculation of derivatives of specific volume
+  procedure :: calculate_specvol_derivs_elem => calculate_specvol_derivs_elem_Wright_full
+  !> Implementation of the calculation of compressibility
+  procedure :: calculate_compress_elem => calculate_compress_elem_Wright_full
+  !> Implementation of the range query function
+  procedure :: EOS_fit_range => EOS_fit_range_Wright_full
+
+  !> Local implementation of generic calculate_density_array for efficiency
+  procedure :: calculate_density_array => calculate_density_array_Wright_full
+  !> Local implementation of generic calculate_spec_vol_array for efficiency
+  procedure :: calculate_spec_vol_array => calculate_spec_vol_array_Wright_full
+
+end type Wright_full_EOS
+
 contains
 
-!> Computes the in situ density of sea water for scalar inputs and outputs.
+!> In situ density of sea water using a full range fit by Wright, 1997 [kg m-3]
 !!
-!! Returns the in situ density of sea water (rho in [kg m-3]) from salinity (S [PSU]),
-!! potential temperature (T [degC]), and pressure [Pa].  It uses the expression from
-!! Wright, 1997, J. Atmos. Ocean. Tech., 14, 735-740 with the full range fit coefficients.
-subroutine calculate_density_scalar_wright(T, S, pressure, rho, rho_ref)
-  real,           intent(in)  :: T        !< Potential temperature relative to the surface [degC].
-  real,           intent(in)  :: S        !< Salinity [PSU].
-  real,           intent(in)  :: pressure !< pressure [Pa].
-  real,           intent(out) :: rho      !< In situ density [kg m-3].
-  real, optional, intent(in)  :: rho_ref  !< A reference density [kg m-3].
-
-  ! Local variables
-  real, dimension(1) :: T0    ! A 1-d array with a copy of the potential temperature [degC]
-  real, dimension(1) :: S0    ! A 1-d array with a copy of the salinity [PSU]
-  real, dimension(1) :: pressure0 ! A 1-d array with a copy of the pressure [Pa]
-  real, dimension(1) :: rho0  ! A 1-d array with a copy of the density [kg m-3]
-
-  T0(1) = T
-  S0(1) = S
-  pressure0(1) = pressure
-
-  call calculate_density_array_wright(T0, S0, pressure0, rho0, 1, 1, rho_ref)
-  rho = rho0(1)
-
-end subroutine calculate_density_scalar_wright
-
-!> Computes the in situ density of sea water for 1-d array inputs and outputs.
-!!
-!! Returns the in situ density of sea water (rho in [kg m-3]) from salinity (S [PSU]),
-!! potential temperature (T [degC]), and pressure [Pa].  It uses the expression from
-!! Wright, 1997, J. Atmos. Ocean. Tech., 14, 735-740 with the full range fit coefficients.
-subroutine calculate_density_array_wright(T, S, pressure, rho, start, npts, rho_ref)
-  real, dimension(:), intent(in)    :: T        !< potential temperature relative to the surface [degC].
-  real, dimension(:), intent(in)    :: S        !< salinity [PSU].
-  real, dimension(:), intent(in)    :: pressure !< pressure [Pa].
-  real, dimension(:), intent(inout) :: rho      !< in situ density [kg m-3].
-  integer,            intent(in)    :: start    !< the starting point in the arrays.
-  integer,            intent(in)    :: npts     !< the number of values to calculate.
-  real,     optional, intent(in)    :: rho_ref  !< A reference density [kg m-3].
+!! This is an elemental function that can be applied to any combination of scalar and array inputs.
+real elemental function density_elem_Wright_full(this, T, S, pressure)
+  class(Wright_full_EOS), intent(in) :: this !< This EOS
+  real, intent(in) :: T        !< Potential temperature relative to the surface [degC]
+  real, intent(in) :: S        !< Salinity [PSU]
+  real, intent(in) :: pressure !< Pressure [Pa]
 
   ! Local variables
   real :: al0     ! The specific volume at 0 lambda in the Wright EOS [m3 kg-1]
   real :: p0      ! The pressure offset in the Wright EOS [Pa]
   real :: lambda  ! The sound speed squared at 0 alpha in the Wright EOS [m2 s-2]
+
+  al0 = a0 + (a1*T + a2*S)
+  p0 = b0 + ( b4*S + T * (b1 + (T*(b2 + b3*T) + b5*S)) )
+  lambda = c0 + ( c4*S + T * (c1 + (T*(c2 + c3*T) + c5*S)) )
+  density_elem_Wright_full = (pressure + p0) / (lambda + al0*(pressure + p0))
+
+end function density_elem_Wright_full
+
+!> In situ density anomaly of sea water using a full range fit by Wright, 1997 [kg m-3]
+!!
+!! This is an elemental function that can be applied to any combination of scalar and array inputs.
+real elemental function density_anomaly_elem_Wright_full(this, T, S, pressure, rho_ref)
+  class(Wright_full_EOS), intent(in) :: this !< This EOS
+  real, intent(in) :: T        !< Potential temperature relative to the surface [degC]
+  real, intent(in) :: S        !< Salinity [PSU]
+  real, intent(in) :: pressure !< Pressure [Pa]
+  real, intent(in) :: rho_ref  !< A reference density [kg m-3]
+
+  ! Local variables
+  real :: al0     ! The specific volume at 0 lambda in the Wright EOS [m3 kg-1]
   real :: al_TS   ! The contributions of temperature and salinity to al0 [m3 kg-1]
   real :: p_TSp   ! A combination of the pressure and the temperature and salinity contributions to p0 [Pa]
   real :: lam_TS  ! The contributions of temperature and salinity to lambda [m2 s-2]
   real :: pa_000  ! A corrected offset to the pressure, including contributions from rho_ref [Pa]
-  integer :: j
 
-  if (present(rho_ref)) pa_000 = b0*(1.0 - a0*rho_ref) - rho_ref*c0
-  if (present(rho_ref)) then ; do j=start,start+npts-1
-    al_TS = a1*T(j) + a2*S(j)
-    al0 = a0 + al_TS
-    p_TSp = pressure(j) + (b4*S(j) + T(j) * (b1 + (T(j)*(b2 + b3*T(j)) + b5*S(j))))
-    lam_TS = c4*S(j) + T(j) * (c1 + (T(j)*(c2 + c3*T(j)) + c5*S(j)))
+  pa_000 = b0*(1.0 - a0*rho_ref) - rho_ref*c0
+  al_TS = a1*T + a2*S
+  al0 = a0 + al_TS
+  p_TSp = pressure + (b4*S + T * (b1 + (T*(b2 + b3*T) + b5*S)))
+  lam_TS = c4*S + T * (c1 + (T*(c2 + c3*T) + c5*S))
 
-    ! The following two expressions are mathematically equivalent.
-    ! rho(j) = (b0 + p0_TSp) / ((c0 + lam_TS) + al0*(b0 + p0_TSp)) - rho_ref
-    rho(j) = (pa_000 + (p_TSp - rho_ref*(p_TSp*al0 + (b0*al_TS + lam_TS)))) / &
-             ( (c0 + lam_TS) + al0*(b0 + p_TSp) )
-  enddo ; else ; do j=start,start+npts-1
-    al0 = a0 + (a1*T(j) + a2*S(j))
-    p0 = b0 + ( b4*S(j) + T(j) * (b1 + (T(j)*(b2 + b3*T(j)) + b5*S(j))) )
-    lambda = c0 + ( c4*S(j) + T(j) * (c1 + (T(j)*(c2 + c3*T(j)) + c5*S(j))) )
-    rho(j) = (pressure(j) + p0) / (lambda + al0*(pressure(j) + p0))
-  enddo ; endif
+  ! The following two expressions are mathematically equivalent.
+  ! rho = (b0 + p0_TSp) / ((c0 + lam_TS) + al0*(b0 + p0_TSp)) - rho_ref
+  density_anomaly_elem_Wright_full = &
+           (pa_000 + (p_TSp - rho_ref*(p_TSp*al0 + (b0*al_TS + lam_TS)))) / &
+           ( (c0 + lam_TS) + al0*(b0 + p_TSp) )
 
-end subroutine calculate_density_array_wright
+end function density_anomaly_elem_Wright_full
 
-!> Computes the Wright in situ specific volume of sea water for scalar inputs and outputs.
+!> In situ specific volume of sea water using a full range fit by Wright, 1997 [kg m-3]
 !!
-!! Returns the in situ specific volume of sea water (specvol in [m3 kg-1]) from salinity (S [PSU]),
-!! potential temperature (T [degC]) and pressure [Pa].  It uses the expression from
-!! Wright, 1997, J. Atmos. Ocean. Tech., 14, 735-740 with the full range fit coefficients.
-!! If spv_ref is present, specvol is an anomaly from spv_ref.
-subroutine calculate_spec_vol_scalar_wright(T, S, pressure, specvol, spv_ref)
-  real,           intent(in)  :: T        !< potential temperature relative to the surface [degC].
-  real,           intent(in)  :: S        !< salinity [PSU].
-  real,           intent(in)  :: pressure !< pressure [Pa].
-  real,           intent(out) :: specvol  !< in situ specific volume [m3 kg-1].
-  real, optional, intent(in)  :: spv_ref  !< A reference specific volume [m3 kg-1].
-
-  ! Local variables
-  real, dimension(1) :: T0    ! A 1-d array with a copy of the potential temperature [degC]
-  real, dimension(1) :: S0    ! A 1-d array with a copy of the salinity [PSU]
-  real, dimension(1) :: pressure0 ! A 1-d array with a copy of the pressure [Pa]
-  real, dimension(1) :: spv0  ! A 1-d array with a copy of the specific volume [m3 kg-1]
-
-  T0(1) = T ; S0(1) = S ; pressure0(1) = pressure
-
-  call calculate_spec_vol_array_wright(T0, S0, pressure0, spv0, 1, 1, spv_ref)
-  specvol = spv0(1)
-end subroutine calculate_spec_vol_scalar_wright
-
-!> Computes the Wright in situ specific volume of sea water for 1-d array inputs and outputs.
-!!
-!! Returns the in situ specific volume of sea water (specvol in [m3 kg-1]) from salinity (S [PSU]),
-!! potential temperature (T [degC]) and pressure [Pa].  It uses the expression from
-!! Wright, 1997, J. Atmos. Ocean. Tech., 14, 735-740 with the full range fit coefficients.
-!! If spv_ref is present, specvol is an anomaly from spv_ref.
-subroutine calculate_spec_vol_array_wright(T, S, pressure, specvol, start, npts, spv_ref)
-  real, dimension(:), intent(in)    :: T        !< potential temperature relative to the
-                                                !! surface [degC].
-  real, dimension(:), intent(in)    :: S        !< salinity [PSU].
-  real, dimension(:), intent(in)    :: pressure !< pressure [Pa].
-  real, dimension(:), intent(inout) :: specvol  !< in situ specific volume [m3 kg-1].
-  integer,            intent(in)    :: start    !< the starting point in the arrays.
-  integer,            intent(in)    :: npts     !< the number of values to calculate.
-  real,     optional, intent(in)    :: spv_ref  !< A reference specific volume [m3 kg-1].
+!! This is an elemental function that can be applied to any combination of scalar and array inputs.
+real elemental function spec_vol_elem_Wright_full(this, T, S, pressure)
+  class(Wright_full_EOS), intent(in) :: this !< This EOS
+  real,           intent(in) :: T        !< Potential temperature relative to the surface [degC]
+  real,           intent(in) :: S        !< Salinity [PSU]
+  real,           intent(in) :: pressure !< Pressure [Pa]
 
   ! Local variables
   real :: al0     ! The specific volume at 0 lambda in the Wright EOS [m3 kg-1]
@@ -185,109 +136,89 @@ subroutine calculate_spec_vol_array_wright(T, S, pressure, specvol, start, npts,
   real :: al_TS   ! The contributions of temperature and salinity to al0 [m3 kg-1]
   real :: p_TSp   ! A combination of the pressure and the temperature and salinity contributions to p0 [Pa]
   real :: lam_000 ! A corrected offset to lambda, including contributions from spv_ref [m2 s-2]
-  integer :: j
 
-  if (present(spv_ref)) then
-    lam_000 = c0 + (a0 - spv_ref)*b0
-    do j=start,start+npts-1
-      al_TS = a1*T(j) + a2*S(j)
-      p_TSp = pressure(j) + (b4*S(j) + T(j) * (b1 + (T(j)*(b2 + b3*T(j)) + b5*S(j))))
-      lambda = lam_000 + ( c4*S(j) + T(j) * (c1 + (T(j)*(c2 + c3*T(j)) + c5*S(j))) )
-      ! This is equivalent to the expression below minus spv_ref, but less sensitive to roundoff.
-      specvol(j) = al_TS + (lambda + (a0 - spv_ref)*p_TSp) / (b0 + p_TSp)
-    enddo
-  else
-    do j=start,start+npts-1
-      al0 = a0 + (a1*T(j) + a2*S(j))
-      p0 = b0 + ( b4*S(j) + T(j) * (b1 + (T(j)*(b2 + b3*T(j)) + b5*S(j))) )
-      lambda = c0 + ( c4*S(j) + T(j) * (c1 + (T(j)*(c2 + c3*T(j)) + c5*S(j))) )
-      specvol(j) = al0 + lambda / (pressure(j) + p0)
-    enddo
-  endif
-end subroutine calculate_spec_vol_array_wright
+  al0 = a0 + (a1*T + a2*S)
+  p0 = b0 + ( b4*S + T * (b1 + (T*(b2 + b3*T) + b5*S)) )
+  lambda = c0 + ( c4*S + T * (c1 + (T*(c2 + c3*T) + c5*S)) )
+  spec_vol_elem_Wright_full = al0 + lambda / (pressure + p0)
 
-!> Return the thermal/haline expansion coefficients for 1-d array inputs and outputs
-subroutine calculate_density_derivs_array_wright(T, S, pressure, drho_dT, drho_dS, start, npts)
-  real,    intent(in),    dimension(:) :: T        !< Potential temperature relative to the
-                                                   !! surface [degC].
-  real,    intent(in),    dimension(:) :: S        !< Salinity [PSU].
-  real,    intent(in),    dimension(:) :: pressure !< pressure [Pa].
-  real,    intent(inout), dimension(:) :: drho_dT  !< The partial derivative of density with potential
-                                                   !! temperature [kg m-3 degC-1].
-  real,    intent(inout), dimension(:) :: drho_dS  !< The partial derivative of density with salinity,
-                                                   !! in [kg m-3 PSU-1].
-  integer, intent(in)                  :: start    !< The starting point in the arrays.
-  integer, intent(in)                  :: npts     !< The number of values to calculate.
+end function spec_vol_elem_Wright_full
 
+!> In situ specific volume anomaly of sea water using a full range fit by Wright, 1997 [kg m-3]
+!!
+!! This is an elemental function that can be applied to any combination of scalar and array inputs.
+real elemental function spec_vol_anomaly_elem_Wright_full(this, T, S, pressure, spv_ref)
+  class(Wright_full_EOS), intent(in) :: this !< This EOS
+  real,           intent(in) :: T        !< Potential temperature relative to the surface [degC]
+  real,           intent(in) :: S        !< Salinity [PSU]
+  real,           intent(in) :: pressure !< Pressure [Pa]
+  real,           intent(in) :: spv_ref  !< A reference specific volume [m3 kg-1]
+
+  ! Local variables
+  real :: al0     ! The specific volume at 0 lambda in the Wright EOS [m3 kg-1]
+  real :: p0      ! The pressure offset in the Wright EOS [Pa]
+  real :: lambda  ! The sound speed squared at 0 alpha in the Wright EOS [m2 s-2], perhaps with
+                  ! an offset to account for spv_ref
+  real :: al_TS   ! The contributions of temperature and salinity to al0 [m3 kg-1]
+  real :: p_TSp   ! A combination of the pressure and the temperature and salinity contributions to p0 [Pa]
+  real :: lam_000 ! A corrected offset to lambda, including contributions from spv_ref [m2 s-2]
+
+  lam_000 = c0 + (a0 - spv_ref)*b0
+  al_TS = a1*T + a2*S
+  p_TSp = pressure + (b4*S + T * (b1 + (T*(b2 + b3*T) + b5*S)))
+  lambda = lam_000 + ( c4*S + T * (c1 + (T*(c2 + c3*T) + c5*S)) )
+  ! This is equivalent to the expression below minus spv_ref, but less sensitive to roundoff.
+  spec_vol_anomaly_elem_Wright_full = al_TS + (lambda + (a0 - spv_ref)*p_TSp) / (b0 + p_TSp)
+
+end function spec_vol_anomaly_elem_Wright_full
+
+!> Calculate the partial derivatives of density with potential temperature and salinity
+!! using the full range equation of state, as fit by Wright, 1997
+elemental subroutine calculate_density_derivs_elem_Wright_full(this, T, S, pressure, drho_dT, drho_dS)
+  class(Wright_full_EOS), intent(in) :: this  !< This EOS
+  real,               intent(in)  :: T        !< Potential temperature relative to the surface [degC]
+  real,               intent(in)  :: S        !< Salinity [PSU]
+  real,               intent(in)  :: pressure !< Pressure [Pa]
+  real,               intent(out) :: drho_dT  !< The partial derivative of density with potential
+                                              !! temperature [kg m-3 degC-1]
+  real,               intent(out) :: drho_dS  !< The partial derivative of density with salinity,
+                                              !! in [kg m-3 PSU-1]
   ! Local variables
   real :: al0     ! The specific volume at 0 lambda in the Wright EOS [m3 kg-1]
   real :: p0      ! The pressure offset in the Wright EOS [Pa]
   real :: lambda  ! The sound speed squared at 0 alpha in the Wright EOS [m2 s-2]
   real :: I_denom2 ! The inverse of the square of the denominator of density in the Wright EOS [s4 m-4]
-  integer :: j
 
-  do j=start,start+npts-1
-    al0 = a0 + (a1*T(j) + a2*S(j))
-    p0 = b0 + ( b4*S(j) + T(j) * (b1 + (T(j)*(b2 + b3*T(j)) + b5*S(j))) )
-    lambda = c0 + ( c4*S(j) + T(j) * (c1 + (T(j)*(c2 + c3*T(j)) + c5*S(j))) )
+  al0 = a0 + (a1*T + a2*S)
+  p0 = b0 + ( b4*S + T * (b1 + (T*(b2 + b3*T) + b5*S)) )
+  lambda = c0 + ( c4*S + T * (c1 + (T*(c2 + c3*T) + c5*S)) )
 
-    I_denom2 = 1.0 / (lambda + al0*(pressure(j) + p0))**2
-    drho_dT(j) = I_denom2 * (lambda * (b1 + (T(j)*(2.0*b2 + 3.0*b3*T(j)) + b5*S(j))) - &
-       (pressure(j)+p0) * ( (pressure(j)+p0)*a1 + (c1 + (T(j)*(c2*2.0 + c3*3.0*T(j)) + c5*S(j))) ))
-    drho_dS(j) = I_denom2 * (lambda * (b4 + b5*T(j)) - &
-       (pressure(j)+p0) * ( (pressure(j)+p0)*a2 + (c4 + c5*T(j)) ))
-  enddo
+  I_denom2 = 1.0 / (lambda + al0*(pressure + p0))**2
+  drho_dT = I_denom2 * (lambda * (b1 + (T*(2.0*b2 + 3.0*b3*T) + b5*S)) - &
+     (pressure+p0) * ( (pressure+p0)*a1 + (c1 + (T*(c2*2.0 + c3*3.0*T) + c5*S)) ))
+  drho_dS = I_denom2 * (lambda * (b4 + b5*T) - &
+     (pressure+p0) * ( (pressure+p0)*a2 + (c4 + c5*T) ))
 
-end subroutine calculate_density_derivs_array_wright
+end subroutine calculate_density_derivs_elem_Wright_full
 
-!> Return the thermal/haline expansion coefficients for scalar inputs and outputs
-!!
-!! The scalar version of calculate_density_derivs promotes scalar inputs to 1-element array
-!! and then demotes the output back to a scalar
-subroutine calculate_density_derivs_scalar_wright(T, S, pressure, drho_dT, drho_dS)
-  real,    intent(in)  :: T        !< Potential temperature relative to the surface [degC].
-  real,    intent(in)  :: S        !< Salinity [PSU].
-  real,    intent(in)  :: pressure !< pressure [Pa].
-  real,    intent(out) :: drho_dT  !< The partial derivative of density with potential
-                                   !! temperature [kg m-3 degC-1].
-  real,    intent(out) :: drho_dS  !< The partial derivative of density with salinity,
-                                   !! in [kg m-3 PSU-1].
-
-  ! Local variables needed to promote the input/output scalars to 1-element arrays
-  real, dimension(1) :: T0    ! A 1-d array with a copy of the temperature [degC]
-  real, dimension(1) :: S0    ! A 1-d array with a copy of the salinity [PSU]
-  real, dimension(1) :: p0    ! A 1-d array with a copy of the pressure [Pa]
-  real, dimension(1) :: drdt0 ! The derivative of density with temperature [kg m-3 degC-1]
-  real, dimension(1) :: drds0 ! The derivative of density with salinity [kg m-3 PSU-1]
-
-  T0(1) = T
-  S0(1) = S
-  P0(1) = pressure
-  call calculate_density_derivs_array_wright(T0, S0, P0, drdt0, drds0, 1, 1)
-  drho_dT = drdt0(1)
-  drho_dS = drds0(1)
-
-end subroutine calculate_density_derivs_scalar_wright
-
-!> Second derivatives of density with respect to temperature, salinity, and pressure for 1-d array inputs and outputs.
-subroutine calculate_density_second_derivs_array_wright(T, S, P, drho_ds_ds, drho_ds_dt, drho_dt_dt, &
-                                                         drho_ds_dp, drho_dt_dp, start, npts)
-  real, dimension(:), intent(in   ) :: T !< Potential temperature referenced to 0 dbar [degC]
-  real, dimension(:), intent(in   ) :: S !< Salinity [PSU]
-  real, dimension(:), intent(in   ) :: P !< Pressure [Pa]
-  real, dimension(:), intent(inout) :: drho_ds_ds !< Partial derivative of beta with respect
-                                                  !! to S [kg m-3 PSU-2]
-  real, dimension(:), intent(inout) :: drho_ds_dt !< Partial derivative of beta with respect
-                                                  !! to T [kg m-3 PSU-1 degC-1]
-  real, dimension(:), intent(inout) :: drho_dt_dt !< Partial derivative of alpha with respect
-                                                  !! to T [kg m-3 degC-2]
-  real, dimension(:), intent(inout) :: drho_ds_dp !< Partial derivative of beta with respect
-                                                  !! to pressure [kg m-3 PSU-1 Pa-1] = [s2 m-2 PSU-1]
-  real, dimension(:), intent(inout) :: drho_dt_dp !< Partial derivative of alpha with respect
-                                                  !! to pressure [kg m-3 degC-1 Pa-1] = [s2 m-2 degC-1]
-  integer,            intent(in   ) :: start !< Starting index in T,S,P
-  integer,            intent(in   ) :: npts  !< Number of points to loop over
-
+!> Second derivatives of density with respect to temperature, salinity, and pressure,
+!! using the full range equation of state, as fit by Wright, 1997
+elemental subroutine calculate_density_second_derivs_elem_Wright_full(this, T, S, pressure, &
+                              drho_ds_ds, drho_ds_dt, drho_dt_dt, drho_ds_dp, drho_dt_dp)
+  class(Wright_full_EOS), intent(in) :: this !< This EOS
+  real,                intent(in)    :: T !< Potential temperature referenced to 0 dbar [degC]
+  real,                intent(in)    :: S !< Salinity [PSU]
+  real,                intent(in)    :: pressure   !< Pressure [Pa]
+  real,                intent(inout) :: drho_ds_ds !< Partial derivative of beta with respect
+                                                   !! to S [kg m-3 PSU-2]
+  real,                intent(inout) :: drho_ds_dt !< Partial derivative of beta with respect
+                                                   !! to T [kg m-3 PSU-1 degC-1]
+  real,                intent(inout) :: drho_dt_dt !< Partial derivative of alpha with respect
+                                                   !! to T [kg m-3 degC-2]
+  real,                intent(inout) :: drho_ds_dp !< Partial derivative of beta with respect
+                                                   !! to pressure [kg m-3 PSU-1 Pa-1] = [s2 m-2 PSU-1]
+  real,                intent(inout) :: drho_dt_dp !< Partial derivative of alpha with respect
+                                                   !! to pressure [kg m-3 degC-1 Pa-1] = [s2 m-2 degC-1]
   ! Local variables
   real :: al0     ! The specific volume at 0 lambda in the Wright EOS [m3 kg-1]
   real :: lambda  ! The sound speed squared at 0 alpha in the Wright EOS [m2 s-2]
@@ -304,152 +235,99 @@ subroutine calculate_density_second_derivs_array_wright(T, S, P, drho_ds_ds, drh
   real :: I_denom   ! The inverse of the denominator of density in the Wright EOS [s2 m-2]
   real :: I_denom2  ! The inverse of the square of the denominator of density in the Wright EOS [s4 m-4]
   real :: I_denom3  ! The inverse of the cube of the denominator of density in the Wright EOS [s6 m-6]
-  integer :: j
 
-  do j = start,start+npts-1
-    al0 = a0 + (a1*T(j) + a2*S(j))
-    p_p0 = P(j) + ( b0 + (b4*S(j) + T(j)*(b1 + (b5*S(j) + T(j)*(b2 + b3*T(j))))) ) ! P + p0
-    lambda = c0 + ( c4*S(j) + T(j) * (c1 + (T(j)*(c2 + c3*T(j)) + c5*S(j))) )
-    dp0_dT = b1 + (b5*S(j) + T(j)*(2.*b2 + 3.*b3*T(j)))
-    dp0_dS = b4 + b5*T(j)
-    dlam_dT = c1 + (c5*S(j) + T(j)*(2.*c2 + 3.*c3*T(j)))
-    dlam_dS = c4 + c5*T(j)
-    I_denom = 1.0 / (lambda + al0*p_p0)
-    I_denom2 = I_denom*I_denom
-    I_denom3 = I_denom*I_denom2
+  al0 = a0 + (a1*T + a2*S)
+  p_p0 = pressure + ( b0 + (b4*S + T*(b1 + (b5*S + T*(b2 + b3*T)))) ) ! P + p0
+  lambda = c0 + ( c4*S + T * (c1 + (T*(c2 + c3*T) + c5*S)) )
+  dp0_dT = b1 + (b5*S + T*(2.*b2 + 3.*b3*T))
+  dp0_dS = b4 + b5*T
+  dlam_dT = c1 + (c5*S + T*(2.*c2 + 3.*c3*T))
+  dlam_dS = c4 + c5*T
+  I_denom = 1.0 / (lambda + al0*p_p0)
+  I_denom2 = I_denom*I_denom
+  I_denom3 = I_denom*I_denom2
 
-    ddenom_dS = (dlam_dS + a2*p_p0) + al0*dp0_dS
-    ddenom_dT = (dlam_dT + a1*p_p0) + al0*dp0_dT
-    dRdS_num = dp0_dS*lambda - p_p0*(dlam_dS + a2*p_p0)
-    dRdT_num = dp0_dT*lambda - p_p0*(dlam_dT + a1*p_p0)
+  ddenom_dS = (dlam_dS + a2*p_p0) + al0*dp0_dS
+  ddenom_dT = (dlam_dT + a1*p_p0) + al0*dp0_dT
+  dRdS_num = dp0_dS*lambda - p_p0*(dlam_dS + a2*p_p0)
+  dRdT_num = dp0_dT*lambda - p_p0*(dlam_dT + a1*p_p0)
 
-    ! In deriving the following, it is useful to note that:
-    !   rho(j) = p_p0 / (lambda + al0*p_p0)
-    !   drho_dp(j) = lambda * I_denom2
-    !   drho_dT(j) = (dp0_dT*lambda - p_p0*(dlam_dT + a1*p_p0)) * I_denom2 = dRdT_num * I_denom2
-    !   drho_dS(j) = (dp0_dS*lambda - p_p0*(dlam_dS + a2*p_p0)) * I_denom2 = dRdS_num * I_denom2
-    drho_ds_ds(j) = -2.*(p_p0*(a2*dp0_dS)) * I_denom2 - 2.*(dRdS_num*ddenom_dS) * I_denom3
-    drho_ds_dt(j) = ((b5*lambda - p_p0*(c5 + 2.*a2*dp0_dT)) + (dp0_dS*dlam_dT - dp0_dT*dlam_dS))*I_denom2 - &
-                    2.*(ddenom_dT*dRdS_num) * I_denom3
-    drho_dt_dt(j) = 2.*((b2 + 3.*b3*T(j))*lambda - p_p0*((c2 + 3.*c3*T(j)) + a1*dp0_dT))*I_denom2 - &
-                    2.*(dRdT_num * ddenom_dT) * I_denom3
+  ! In deriving the following, it is useful to note that:
+  !   rho = p_p0 / (lambda + al0*p_p0)
+  !   drho_dp = lambda * I_denom2
+  !   drho_dT = (dp0_dT*lambda - p_p0*(dlam_dT + a1*p_p0)) * I_denom2 = dRdT_num * I_denom2
+  !   drho_dS = (dp0_dS*lambda - p_p0*(dlam_dS + a2*p_p0)) * I_denom2 = dRdS_num * I_denom2
+  drho_ds_ds = -2.*(p_p0*(a2*dp0_dS)) * I_denom2 - 2.*(dRdS_num*ddenom_dS) * I_denom3
+  drho_ds_dt = ((b5*lambda - p_p0*(c5 + 2.*a2*dp0_dT)) + (dp0_dS*dlam_dT - dp0_dT*dlam_dS))*I_denom2 - &
+                  2.*(ddenom_dT*dRdS_num) * I_denom3
+  drho_dt_dt = 2.*((b2 + 3.*b3*T)*lambda - p_p0*((c2 + 3.*c3*T) + a1*dp0_dT))*I_denom2 - &
+                  2.*(dRdT_num * ddenom_dT) * I_denom3
 
-    ! The following is a rearranged form that is equivalent to
-    ! drho_ds_dp(j) = dlam_dS * I_denom2 - 2.0 * lambda * (dlam_dS + a2*p_p0 + al0*dp0_ds) * Idenom3
-    drho_ds_dp(j) = (-dlam_dS - 2.*a2*p_p0) * I_denom2 - (2.*al0*dRdS_num) * I_denom3
-    drho_dt_dp(j) = (-dlam_dT - 2.*a1*p_p0) * I_denom2 - (2.*al0*dRdT_num) * I_denom3
-  enddo
+  ! The following is a rearranged form that is equivalent to
+  ! drho_ds_dp = dlam_dS * I_denom2 - 2.0 * lambda * (dlam_dS + a2*p_p0 + al0*dp0_ds) * Idenom3
+  drho_ds_dp = (-dlam_dS - 2.*a2*p_p0) * I_denom2 - (2.*al0*dRdS_num) * I_denom3
+  drho_dt_dp = (-dlam_dT - 2.*a1*p_p0) * I_denom2 - (2.*al0*dRdT_num) * I_denom3
 
-end subroutine calculate_density_second_derivs_array_wright
+end subroutine calculate_density_second_derivs_elem_Wright_full
 
-!> Second derivatives of density with respect to temperature, salinity, and pressure for scalar inputs.
-!!
-!! The scalar version of calculate_density_second_derivs promotes scalar inputs to 1-element array
-!! and then demotes the output back to a scalar
-subroutine calculate_density_second_derivs_scalar_wright(T, S, P, drho_ds_ds, drho_ds_dt, drho_dt_dt, &
-                                                         drho_ds_dp, drho_dt_dp)
-  real, intent(in   ) :: T          !< Potential temperature referenced to 0 dbar
-  real, intent(in   ) :: S          !< Salinity [PSU]
-  real, intent(in   ) :: P          !< pressure [Pa]
-  real, intent(  out) :: drho_ds_ds !< Partial derivative of beta with respect
-                                    !! to S [kg m-3 PSU-2]
-  real, intent(  out) :: drho_ds_dt !< Partial derivative of beta with respect
-                                    !! to T [kg m-3 PSU-1 degC-1]
-  real, intent(  out) :: drho_dt_dt !< Partial derivative of alpha with respect
-                                    !! to T [kg m-3 degC-2]
-  real, intent(  out) :: drho_ds_dp !< Partial derivative of beta with respect
-                                    !! to pressure [kg m-3 PSU-1 Pa-1] = [s2 m-2 PSU-1]
-  real, intent(  out) :: drho_dt_dp !< Partial derivative of alpha with respect
-                                    !! to pressure [kg m-3 degC-1 Pa-1] = [s2 m-2 degC-1]
-  ! Local variables
-  real, dimension(1) :: T0    ! A 1-d array with a copy of the temperature [degC]
-  real, dimension(1) :: S0    ! A 1-d array with a copy of the salinity [PSU]
-  real, dimension(1) :: p0    ! A 1-d array with a copy of the pressure [Pa]
-  real, dimension(1) :: drdsds ! The second derivative of density with salinity [kg m-3 PSU-2]
-  real, dimension(1) :: drdsdt ! The second derivative of density with salinity and
-                               ! temperature [kg m-3 PSU-1 degC-1]
-  real, dimension(1) :: drdtdt ! The second derivative of density with temperature [kg m-3 degC-2]
-  real, dimension(1) :: drdsdp ! The second derivative of density with salinity and
-                               ! pressure [kg m-3 PSU-1 Pa-1] = [s2 m-2 PSU-1]
-  real, dimension(1) :: drdtdp ! The second derivative of density with temperature and
-                               ! pressure [kg m-3 degC-1 Pa-1] = [s2 m-2 degC-1]
-
-  T0(1) = T
-  S0(1) = S
-  P0(1) = P
-  call calculate_density_second_derivs_array_wright(T0, S0, P0, drdsds, drdsdt, drdtdt, drdsdp, drdtdp, 1, 1)
-  drho_ds_ds = drdsds(1)
-  drho_ds_dt = drdsdt(1)
-  drho_dt_dt = drdtdt(1)
-  drho_ds_dp = drdsdp(1)
-  drho_dt_dp = drdtdp(1)
-
-end subroutine calculate_density_second_derivs_scalar_wright
-
-!> Return the partial derivatives of specific volume with temperature and salinity
-!! for 1-d array inputs and outputs
-subroutine calculate_specvol_derivs_wright_full(T, S, pressure, dSV_dT, dSV_dS, start, npts)
-  real,    intent(in),    dimension(:) :: T        !< Potential temperature relative to the surface [degC].
-  real,    intent(in),    dimension(:) :: S        !< Salinity [PSU].
-  real,    intent(in),    dimension(:) :: pressure !< pressure [Pa].
-  real,    intent(inout), dimension(:) :: dSV_dT   !< The partial derivative of specific volume with
-                                                   !! potential temperature [m3 kg-1 degC-1].
-  real,    intent(inout), dimension(:) :: dSV_dS   !< The partial derivative of specific volume with
-                                                   !! salinity [m3 kg-1 PSU-1].
-  integer, intent(in)                  :: start    !< The starting point in the arrays.
-  integer, intent(in)                  :: npts     !< The number of values to calculate.
-
+!> Calculate the partial derivatives of specific volume with temperature and salinity
+!! using the full range equation of state, as fit by Wright, 1997
+elemental subroutine calculate_specvol_derivs_elem_Wright_full(this,T, S, pressure, dSV_dT, dSV_dS)
+  class(Wright_full_EOS), intent(in) :: this     !< This EOS
+  real,                intent(in)    :: T        !< Potential temperature [degC]
+  real,                intent(in)    :: S        !< Salinity [PSU]
+  real,                intent(in)    :: pressure !< Pressure [Pa]
+  real,                intent(inout) :: dSV_dT   !< The partial derivative of specific volume with
+                                                 !! potential temperature [m3 kg-1 degC-1]
+  real,                intent(inout) :: dSV_dS   !< The partial derivative of specific volume with
+                                                 !! salinity [m3 kg-1 PSU-1]
   ! Local variables
   real :: p0      ! The pressure offset in the Wright EOS [Pa]
   real :: lambda  ! The sound speed squared at 0 alpha in the Wright EOS [m2 s-2]
   real :: I_denom ! The inverse of the denominator of specific volume in the Wright EOS [Pa-1]
-  integer :: j
 
-  do j=start,start+npts-1
-!    al0 = a0 + (a1*T(j) + a2*S(j))
-    p0 = b0 + ( b4*S(j) + T(j) * (b1 + (T(j)*(b2 + b3*T(j)) + b5*S(j))) )
-    lambda = c0 + ( c4*S(j) + T(j) * (c1 + (T(j)*(c2 + c3*T(j)) + c5*S(j))) )
+  ! al0 = a0 + (a1*T + a2*S)
+  p0 = b0 + ( b4*S + T * (b1 + (T*(b2 + b3*T) + b5*S)) )
+  lambda = c0 + ( c4*S + T * (c1 + (T*(c2 + c3*T) + c5*S)) )
 
-    ! SV = al0 + lambda / (pressure(j) + p0)
+  ! SV = al0 + lambda / (pressure + p0)
 
-    I_denom = 1.0 / (pressure(j) + p0)
-    dSV_dT(j) = a1 + I_denom * ((c1 + (T(j)*(2.0*c2 + 3.0*c3*T(j)) + c5*S(j))) - &
-                                (I_denom * lambda) * (b1 + (T(j)*(2.0*b2 + 3.0*b3*T(j)) + b5*S(j))))
-    dSV_dS(j) = a2 + I_denom * ((c4 + c5*T(j)) - &
-                                (I_denom * lambda) * (b4 + b5*T(j)))
-  enddo
+  I_denom = 1.0 / (pressure + p0)
+  dSV_dT = a1 + I_denom * ((c1 + (T*(2.0*c2 + 3.0*c3*T) + c5*S)) - &
+                              (I_denom * lambda) * (b1 + (T*(2.0*b2 + 3.0*b3*T) + b5*S)))
+  dSV_dS = a2 + I_denom * ((c4 + c5*T) - &
+                              (I_denom * lambda) * (b4 + b5*T))
 
-end subroutine calculate_specvol_derivs_wright_full
+end subroutine calculate_specvol_derivs_elem_Wright_full
 
-!> Computes the compressibility of seawater for 1-d array inputs and outputs
-subroutine calculate_compress_wright_full(T, S, pressure, rho, drho_dp, start, npts)
-  real,    intent(in),    dimension(:) :: T        !< Potential temperature relative to the surface [degC].
-  real,    intent(in),    dimension(:) :: S        !< Salinity [PSU].
-  real,    intent(in),    dimension(:) :: pressure !< pressure [Pa].
-  real,    intent(inout), dimension(:) :: rho      !< In situ density [kg m-3].
-  real,    intent(inout), dimension(:) :: drho_dp  !< The partial derivative of density with pressure
-                                                   !! (also the inverse of the square of sound speed)
-                                                   !! [s2 m-2].
-  integer, intent(in)                  :: start    !< The starting point in the arrays.
-  integer, intent(in)                  :: npts     !< The number of values to calculate.
+!> Compute the in situ density of sea water (rho) and the compressibility (drho/dp == C_sound^-2)
+!! at the given salinity, potential temperature and pressure
+!! using the full range equation of state, as fit by Wright, 1997
+elemental subroutine calculate_compress_elem_Wright_full(this, T, S, pressure, rho, drho_dp)
+  class(Wright_full_EOS), intent(in) :: this  !< This EOS
+  real,               intent(in)  :: T        !< Potential temperature relative to the surface [degC]
+  real,               intent(in)  :: S        !< Salinity [PSU]
+  real,               intent(in)  :: pressure !< Pressure [Pa]
+  real,               intent(out) :: rho      !< In situ density [kg m-3]
+  real,               intent(out) :: drho_dp  !< The partial derivative of density with pressure
+                                              !! (also the inverse of the square of sound speed)
+                                              !! [s2 m-2]
 
   ! Local variables
   real :: al0     ! The specific volume at 0 lambda in the Wright EOS [m3 kg-1]
   real :: p0      ! The pressure offset in the Wright EOS [Pa]
   real :: lambda  ! The sound speed squared at 0 alpha in the Wright EOS [m2 s-2]
   real :: I_denom ! The inverse of the denominator of density in the Wright EOS [s2 m-2]
-  integer :: j
 
-  do j=start,start+npts-1
-    al0 = a0 + (a1*T(j) + a2*S(j))
-    p0 = b0 + ( b4*S(j) + T(j) * (b1 + (T(j)*(b2 + b3*T(j)) + b5*S(j))) )
-    lambda = c0 + ( c4*S(j) + T(j) * (c1 + (T(j)*(c2 + c3*T(j)) + c5*S(j))) )
+  al0 = a0 + (a1*T + a2*S)
+  p0 = b0 + ( b4*S + T * (b1 + (T*(b2 + b3*T) + b5*S)) )
+  lambda = c0 + ( c4*S + T * (c1 + (T*(c2 + c3*T) + c5*S)) )
 
-    I_denom = 1.0 / (lambda + al0*(pressure(j) + p0))
-    rho(j) = (pressure(j) + p0) * I_denom
-    drho_dp(j) = lambda * I_denom**2
-  enddo
-end subroutine calculate_compress_wright_full
+  I_denom = 1.0 / (lambda + al0*(pressure + p0))
+  rho = (pressure + p0) * I_denom
+  drho_dp = lambda * I_denom**2
+
+end subroutine calculate_compress_elem_Wright_full
 
 !> Calculates analytical and nearly-analytical integrals, in pressure across layers, to determine
 !! the layer-average specific volumes.  There are essentially no free assumptions, apart from a
@@ -474,7 +352,7 @@ subroutine avg_spec_vol_Wright_full(T, S, p_t, dp, SpV_avg, start, npts)
   real, parameter :: C1_3 = 1.0/3.0, C1_7 = 1.0/7.0, C1_9 = 1.0/9.0 ! Rational constants [nondim]
   integer :: j
 
-  !  alpha(j) = al0 + lambda / (pressure(j) + p0)
+  !  alpha = al0 + lambda / (pressure + p0)
   do j=start,start+npts-1
     al0 = a0 + (a1*T(j) + a2*S(j))
     p0 = b0 + ( b4*S(j) + T(j) * (b1 + (T(j)*(b2 + b3*T(j)) + b5*S(j))) )
@@ -485,12 +363,14 @@ subroutine avg_spec_vol_Wright_full(T, S, p_t, dp, SpV_avg, start, npts)
     SpV_avg(j) = al0 + (lambda * I_pterm) * &
                          (1.0 + eps2*(C1_3 + eps2*(0.2 + eps2*(C1_7 + eps2*C1_9))))
   enddo
+
 end subroutine avg_spec_vol_Wright_full
 
 !> Return the range of temperatures, salinities and pressures for which full-range equation
 !! of state from Wright (1997) has been fitted to observations.  Care should be taken when applying
 !! this equation of state outside of its fit range.
-subroutine EoS_fit_range_Wright_full(T_min, T_max, S_min, S_max, p_min, p_max)
+subroutine EoS_fit_range_Wright_full(this, T_min, T_max, S_min, S_max, p_min, p_max)
+  class(Wright_full_EOS), intent(in) :: this !< This EOS
   real, optional, intent(out) :: T_min !< The minimum potential temperature over which this EoS is fitted [degC]
   real, optional, intent(out) :: T_max !< The maximum potential temperature over which this EoS is fitted [degC]
   real, optional, intent(out) :: S_min !< The minimum practical salinity over which this EoS is fitted [PSU]
@@ -673,7 +553,7 @@ subroutine int_density_dz_wright_full(T, S, z_t, z_b, rho_ref, rho_0, G_e, HI, &
     I_Lzz = 1.0 / ((p0 + p_ave) + lambda * I_al0)
     eps = 0.5*(GxRho*dz)*I_Lzz ; eps2 = eps*eps
 
-!     rho(j) = (pressure(j) + p0) / (lambda + al0*(pressure(j) + p0))
+!     rho = (pressure + p0) / (lambda + al0*(pressure + p0))
 
     rho_anom = (p0 + p_ave)*(I_Lzz*I_al0) - rho_ref_mks
     rem = (I_Rho * (lambda * I_al0**2)) * (eps2 * (C1_3 + eps2*(0.2 + eps2*(C1_7 + C1_9*eps2))))
@@ -905,7 +785,7 @@ subroutine int_spec_vol_dp_wright_full(T, S, p_t, p_b, spv_ref, HI, dza, &
 !        "dP_neglect must be present if useMassWghtInterp is present and true.")
   endif ; endif
 
-  !  alpha(j) = (lambda + al0*(pressure(j) + p0)) / (pressure(j) + p0)
+  !  alpha = (lambda + al0*(pressure + p0)) / (pressure + p0)
   do j=jsh,jeh ; do i=ish,ieh
     al0_2d(i,j) = al0_scale * ( a0 + (a1s*T(i,j) + a2s*S(i,j)) )
     p0_2d(i,j) = p0_scale * ( b0 + ( b4s*S(i,j) + T(i,j) * (b1s + (T(i,j)*(b2s + b3s*T(i,j)) + b5s*S(i,j))) ) )
@@ -1008,6 +888,58 @@ subroutine int_spec_vol_dp_wright_full(T, S, p_t, p_b, spv_ref, HI, dza, &
                            12.0*intp(3))
   enddo ; enddo ; endif
 end subroutine int_spec_vol_dp_wright_full
+
+!> Calculate the in-situ density for 1D arraya inputs and outputs.
+subroutine calculate_density_array_Wright_full(this, T, S, pressure, rho, start, npts, rho_ref)
+  class(Wright_full_EOS), intent(in) :: this  !< This EOS
+  real, dimension(:), intent(in)  :: T        !< Potential temperature relative to the surface [degC]
+  real, dimension(:), intent(in)  :: S        !< Salinity [PSU]
+  real, dimension(:), intent(in)  :: pressure !< Pressure [Pa]
+  real, dimension(:), intent(out) :: rho      !< In situ density [kg m-3]
+  integer,            intent(in)  :: start    !< The starting index for calculations
+  integer,            intent(in)  :: npts     !< The number of values to calculate
+  real,     optional, intent(in)  :: rho_ref  !< A reference density [kg m-3]
+
+  ! Local variables
+  integer :: j
+
+  if (present(rho_ref)) then
+    do j = start, start+npts-1
+      rho(j) = density_anomaly_elem_Wright_full(this, T(j), S(j), pressure(j), rho_ref)
+    enddo
+  else
+    do j = start, start+npts-1
+      rho(j) = density_elem_Wright_full(this, T(j), S(j), pressure(j))
+    enddo
+  endif
+
+end subroutine calculate_density_array_Wright_full
+
+!> Calculate the in-situ specific volume for 1D array inputs and outputs.
+subroutine calculate_spec_vol_array_Wright_full(this, T, S, pressure, specvol, start, npts, spv_ref)
+  class(Wright_full_EOS), intent(in) :: this  !< This EOS
+  real, dimension(:), intent(in)  :: T        !< Potential temperature relative to the surface [degC]
+  real, dimension(:), intent(in)  :: S        !< Salinity [PSU]
+  real, dimension(:), intent(in)  :: pressure !< Pressure [Pa]
+  real, dimension(:), intent(out) :: specvol  !< In situ specific volume [m3 kg-1]
+  integer,            intent(in)  :: start    !< The starting index for calculations
+  integer,            intent(in)  :: npts     !< The number of values to calculate
+  real,     optional, intent(in)  :: spv_ref  !< A reference specific volume [m3 kg-1]
+
+  ! Local variables
+  integer :: j
+
+  if (present(spv_ref)) then
+    do j = start, start+npts-1
+      specvol(j) = spec_vol_anomaly_elem_Wright_full(this, T(j), S(j), pressure(j), spv_ref)
+    enddo
+  else
+    do j = start, start+npts-1
+      specvol(j) = spec_vol_elem_Wright_full(this, T(j), S(j), pressure(j) )
+    enddo
+  endif
+
+end subroutine calculate_spec_vol_array_Wright_full
 
 
 !> \namespace mom_eos_wright_full

--- a/src/equation_of_state/MOM_EOS_Wright_red.F90
+++ b/src/equation_of_state/MOM_EOS_Wright_red.F90
@@ -1,44 +1,16 @@
-!> The equation of state using the Wright 1997 expressions
+!> The equation of state using the Wright 1997 expressions with reduced range of data.
 module MOM_EOS_Wright_red
 
 ! This file is part of MOM6. See LICENSE.md for the license.
 
+use MOM_EOS_base_type, only : EOS_base
 use MOM_hor_index, only : hor_index_type
 
 implicit none ; private
 
-public calculate_compress_wright_red, calculate_density_wright_red, calculate_spec_vol_wright_red
-public calculate_density_derivs_wright_red, calculate_specvol_derivs_wright_red
-public calculate_density_second_derivs_wright_red, EoS_fit_range_Wright_red
+public Wright_red_EOS
 public int_density_dz_wright_red, int_spec_vol_dp_wright_red
 public avg_spec_vol_Wright_red
-
-!> Compute the in situ density of sea water (in [kg m-3]), or its anomaly with respect to
-!! a reference density, from salinity in practical salinity units ([PSU]), potential
-!! temperature (in degrees Celsius [degC]), and pressure [Pa], using the expressions from
-!! Wright, 1997, J. Atmos. Ocean. Tech., 14, 735-740 with the reduced range fit coefficients.
-interface calculate_density_wright_red
-  module procedure calculate_density_scalar_wright, calculate_density_array_wright
-end interface calculate_density_wright_red
-
-!> Compute the in situ specific volume of sea water (in [m3 kg-1]), or an anomaly with respect
-!! to a reference specific volume, from salinity in practical salinity units ([PSU]), potential
-!! temperature (in degrees Celsius [degC]), and pressure [Pa], using the expressions from
-!! Wright, 1997, J. Atmos. Ocean. Tech., 14, 735-740 with the reduced range fit coefficients.
-interface calculate_spec_vol_wright_red
-  module procedure calculate_spec_vol_scalar_wright, calculate_spec_vol_array_wright
-end interface calculate_spec_vol_wright_red
-
-!> Compute the derivatives of density with temperature and salinity
-interface calculate_density_derivs_wright_red
-  module procedure calculate_density_derivs_scalar_wright, calculate_density_derivs_array_wright
-end interface calculate_density_derivs_wright_red
-
-!> Compute the second derivatives of density with various combinations
-!! of temperature, salinity, and pressure
-interface calculate_density_second_derivs_wright_red
-  module procedure calculate_density_second_derivs_scalar_wright, calculate_density_second_derivs_array_wright
-end interface calculate_density_second_derivs_wright_red
 
 !>@{ Parameters in the Wright equation of state using the reduced range formula, which is a fit to the UNESCO
 !    equation of state for the restricted range: -2 < theta < 30 [degC], 28 < S < 38 [PSU], 0  < p < 5e7 [Pa].
@@ -63,119 +35,98 @@ real, parameter :: c4 = -2.302158e2  ! A parameter in the Wright lambda fit [m2 
 real, parameter :: c5 = -3.079464    ! A parameter in the Wright lambda fit [m2 s-2 degC-1 PSU-1]
 !>@}
 
+!> The EOS_base implementation of the reduced range Wright 1997 equation of state
+type, extends (EOS_base) :: Wright_red_EOS
+
+contains
+  !> Implementation of the in-situ density as an elemental function [kg m-3]
+  procedure :: density_elem => density_elem_Wright_red
+  !> Implementation of the in-situ density anomaly as an elemental function [kg m-3]
+  procedure :: density_anomaly_elem => density_anomaly_elem_Wright_red
+  !> Implementation of the in-situ specific volume as an elemental function [m3 kg-1]
+  procedure :: spec_vol_elem => spec_vol_elem_Wright_red
+  !> Implementation of the in-situ specific volume anomaly as an elemental function [m3 kg-1]
+  procedure :: spec_vol_anomaly_elem => spec_vol_anomaly_elem_Wright_red
+  !> Implementation of the calculation of derivatives of density
+  procedure :: calculate_density_derivs_elem => calculate_density_derivs_elem_Wright_red
+  !> Implementation of the calculation of second derivatives of density
+  procedure :: calculate_density_second_derivs_elem => calculate_density_second_derivs_elem_Wright_red
+  !> Implementation of the calculation of derivatives of specific volume
+  procedure :: calculate_specvol_derivs_elem => calculate_specvol_derivs_elem_Wright_red
+  !> Implementation of the calculation of compressibility
+  procedure :: calculate_compress_elem => calculate_compress_elem_Wright_red
+  !> Implementation of the range query function
+  procedure :: EOS_fit_range => EOS_fit_range_Wright_red
+
+  !> Local implementation of generic calculate_density_array for efficiency
+  procedure :: calculate_density_array => calculate_density_array_Wright_red
+  !> Local implementation of generic calculate_spec_vol_array for efficiency
+  procedure :: calculate_spec_vol_array => calculate_spec_vol_array_Wright_red
+
+end type Wright_red_EOS
+
 contains
 
-!> Computes the in situ density of sea water for scalar inputs and outputs.
+!> In situ density of sea water using a reduced range fit by Wright, 1997 [kg m-3]
 !!
-!! Returns the in situ density of sea water (rho in [kg m-3]) from salinity (S [PSU]),
-!! potential temperature (T [degC]), and pressure [Pa].  It uses the expression from
-!! Wright, 1997, J. Atmos. Ocean. Tech., 14, 735-740 with the reduced range fit coefficients.
-subroutine calculate_density_scalar_wright(T, S, pressure, rho, rho_ref)
-  real,           intent(in)  :: T        !< Potential temperature relative to the surface [degC].
-  real,           intent(in)  :: S        !< Salinity [PSU].
-  real,           intent(in)  :: pressure !< pressure [Pa].
-  real,           intent(out) :: rho      !< In situ density [kg m-3].
-  real, optional, intent(in)  :: rho_ref  !< A reference density [kg m-3].
-
-  ! Local variables
-  real, dimension(1) :: T0    ! A 1-d array with a copy of the potential temperature [degC]
-  real, dimension(1) :: S0    ! A 1-d array with a copy of the salinity [PSU]
-  real, dimension(1) :: pressure0 ! A 1-d array with a copy of the pressure [Pa]
-  real, dimension(1) :: rho0  ! A 1-d array with a copy of the density [kg m-3]
-
-  T0(1) = T
-  S0(1) = S
-  pressure0(1) = pressure
-
-  call calculate_density_array_wright(T0, S0, pressure0, rho0, 1, 1, rho_ref)
-  rho = rho0(1)
-
-end subroutine calculate_density_scalar_wright
-
-!> Computes the in situ density of sea water for 1-d array inputs and outputs.
-!!
-!! Returns the in situ density of sea water (rho in [kg m-3]) from salinity (S [PSU]),
-!! potential temperature (T [degC]), and pressure [Pa].  It uses the expression from
-!! Wright, 1997, J. Atmos. Ocean. Tech., 14, 735-740 with the reduced range fit coefficients.
-subroutine calculate_density_array_wright(T, S, pressure, rho, start, npts, rho_ref)
-  real, dimension(:), intent(in)    :: T        !< potential temperature relative to the surface [degC].
-  real, dimension(:), intent(in)    :: S        !< salinity [PSU].
-  real, dimension(:), intent(in)    :: pressure !< pressure [Pa].
-  real, dimension(:), intent(inout) :: rho      !< in situ density [kg m-3].
-  integer,            intent(in)    :: start    !< the starting point in the arrays.
-  integer,            intent(in)    :: npts     !< the number of values to calculate.
-  real,     optional, intent(in)    :: rho_ref  !< A reference density [kg m-3].
+!! This is an elemental function that can be applied to any combination of scalar and array inputs.
+real elemental function density_elem_Wright_red(this, T, S, pressure)
+  class(Wright_red_EOS), intent(in) :: this !< This EOS
+  real,           intent(in) :: T        !< potential temperature relative to the surface [degC].
+  real,           intent(in) :: S        !< salinity [PSU].
+  real,           intent(in) :: pressure !< pressure [Pa].
 
   ! Local variables
   real :: al0     ! The specific volume at 0 lambda in the Wright EOS [m3 kg-1]
   real :: p0      ! The pressure offset in the Wright EOS [Pa]
   real :: lambda  ! The sound speed squared at 0 alpha in the Wright EOS [m2 s-2]
+
+  al0 = a0 + (a1*T + a2*S)
+  p0 = b0 + ( b4*S + T * (b1 + (T*(b2 + b3*T) + b5*S)) )
+  lambda = c0 + ( c4*S + T * (c1 + (T*(c2 + c3*T) + c5*S)) )
+  density_elem_Wright_red = (pressure + p0) / (lambda + al0*(pressure + p0))
+
+end function density_elem_Wright_red
+
+!> In situ density anomaly of sea water using a reduced range fit by Wright, 1997 [kg m-3]
+!!
+!! This is an elemental function that can be applied to any combination of scalar and array inputs.
+real elemental function density_anomaly_elem_Wright_red(this, T, S, pressure, rho_ref)
+  class(Wright_red_EOS), intent(in) :: this !< This EOS
+  real, intent(in) :: T        !< potential temperature relative to the surface [degC].
+  real, intent(in) :: S        !< salinity [PSU].
+  real, intent(in) :: pressure !< pressure [Pa].
+  real, intent(in) :: rho_ref  !< A reference density [kg m-3].
+
+  ! Local variables
+  real :: al0     ! The specific volume at 0 lambda in the Wright EOS [m3 kg-1]
   real :: al_TS   ! The contributions of temperature and salinity to al0 [m3 kg-1]
   real :: p_TSp   ! A combination of the pressure and the temperature and salinity contributions to p0 [Pa]
   real :: lam_TS  ! The contributions of temperature and salinity to lambda [m2 s-2]
   real :: pa_000  ! A corrected offset to the pressure, including contributions from rho_ref [Pa]
-  integer :: j
 
-  if (present(rho_ref)) pa_000 = b0*(1.0 - a0*rho_ref) - rho_ref*c0
-  if (present(rho_ref)) then ; do j=start,start+npts-1
-    al_TS = a1*T(j) + a2*S(j)
-    al0 = a0 + al_TS
-    p_TSp = pressure(j) + (b4*S(j) + T(j) * (b1 + (T(j)*(b2 + b3*T(j)) + b5*S(j))))
-    lam_TS = c4*S(j) + T(j) * (c1 + (T(j)*(c2 + c3*T(j)) + c5*S(j)))
+  pa_000 = b0*(1.0 - a0*rho_ref) - rho_ref*c0
+  al_TS = a1*T + a2*S
+  al0 = a0 + al_TS
+  p_TSp = pressure + (b4*S + T * (b1 + (T*(b2 + b3*T) + b5*S)))
+  lam_TS = c4*S + T * (c1 + (T*(c2 + c3*T) + c5*S))
 
-    ! The following two expressions are mathematically equivalent.
-    ! rho(j) = (b0 + p0_TSp) / ((c0 + lam_TS) + al0*(b0 + p0_TSp)) - rho_ref
-    rho(j) = (pa_000 + (p_TSp - rho_ref*(p_TSp*al0 + (b0*al_TS + lam_TS)))) / &
-             ( (c0 + lam_TS) + al0*(b0 + p_TSp) )
-  enddo ; else ; do j=start,start+npts-1
-    al0 = a0 + (a1*T(j) + a2*S(j))
-    p0 = b0 + ( b4*S(j) + T(j) * (b1 + (T(j)*(b2 + b3*T(j)) + b5*S(j))) )
-    lambda = c0 + ( c4*S(j) + T(j) * (c1 + (T(j)*(c2 + c3*T(j)) + c5*S(j))) )
-    rho(j) = (pressure(j) + p0) / (lambda + al0*(pressure(j) + p0))
-  enddo ; endif
+  ! The following two expressions are mathematically equivalent.
+  ! rho = (b0 + p0_TSp) / ((c0 + lam_TS) + al0*(b0 + p0_TSp)) - rho_ref
+  density_anomaly_elem_Wright_red = &
+           (pa_000 + (p_TSp - rho_ref*(p_TSp*al0 + (b0*al_TS + lam_TS)))) / &
+           ( (c0 + lam_TS) + al0*(b0 + p_TSp) )
 
-end subroutine calculate_density_array_wright
+end function density_anomaly_elem_Wright_red
 
-!> Computes the Wright in situ specific volume of sea water for scalar inputs and outputs.
+!> In situ specific volume of sea water using a reduced range fit by Wright, 1997 [m3 kg-1]
 !!
-!! Returns the in situ specific volume of sea water (specvol in [m3 kg-1]) from salinity (S [PSU]),
-!! potential temperature (T [degC]) and pressure [Pa].  It uses the expression from
-!! Wright, 1997, J. Atmos. Ocean. Tech., 14, 735-740 with the reduced range fit coefficients.
-!! If spv_ref is present, specvol is an anomaly from spv_ref.
-subroutine calculate_spec_vol_scalar_wright(T, S, pressure, specvol, spv_ref)
-  real,           intent(in)  :: T        !< potential temperature relative to the surface [degC].
-  real,           intent(in)  :: S        !< salinity [PSU].
-  real,           intent(in)  :: pressure !< pressure [Pa].
-  real,           intent(out) :: specvol  !< in situ specific volume [m3 kg-1].
-  real, optional, intent(in)  :: spv_ref  !< A reference specific volume [m3 kg-1].
-
-  ! Local variables
-  real, dimension(1) :: T0    ! A 1-d array with a copy of the potential temperature [degC]
-  real, dimension(1) :: S0    ! A 1-d array with a copy of the salinity [PSU]
-  real, dimension(1) :: pressure0 ! A 1-d array with a copy of the pressure [Pa]
-  real, dimension(1) :: spv0  ! A 1-d array with a copy of the specific volume [m3 kg-1]
-
-  T0(1) = T ; S0(1) = S ; pressure0(1) = pressure
-
-  call calculate_spec_vol_array_wright(T0, S0, pressure0, spv0, 1, 1, spv_ref)
-  specvol = spv0(1)
-end subroutine calculate_spec_vol_scalar_wright
-
-!> Computes the Wright in situ specific volume of sea water for 1-d array inputs and outputs.
-!!
-!! Returns the in situ specific volume of sea water (specvol in [m3 kg-1]) from salinity (S [PSU]),
-!! potential temperature (T [degC]) and pressure [Pa].  It uses the expression from
-!! Wright, 1997, J. Atmos. Ocean. Tech., 14, 735-740 with the reduced range fit coefficients.
-!! If spv_ref is present, specvol is an anomaly from spv_ref.
-subroutine calculate_spec_vol_array_wright(T, S, pressure, specvol, start, npts, spv_ref)
-  real, dimension(:), intent(in)    :: T        !< potential temperature relative to the
-                                                !! surface [degC].
-  real, dimension(:), intent(in)    :: S        !< salinity [PSU].
-  real, dimension(:), intent(in)    :: pressure !< pressure [Pa].
-  real, dimension(:), intent(inout) :: specvol  !< in situ specific volume [m3 kg-1].
-  integer,            intent(in)    :: start    !< the starting point in the arrays.
-  integer,            intent(in)    :: npts     !< the number of values to calculate.
-  real,     optional, intent(in)    :: spv_ref  !< A reference specific volume [m3 kg-1].
+!! This is an elemental function that can be applied to any combination of scalar and array inputs.
+real elemental function spec_vol_elem_Wright_red(this, T, S, pressure)
+  class(Wright_red_EOS), intent(in) :: this !< This EOS
+  real,           intent(in) :: T        !< potential temperature relative to the surface [degC]
+  real,           intent(in) :: S        !< salinity [PSU]
+  real,           intent(in) :: pressure !< pressure [Pa]
 
   ! Local variables
   real :: al0     ! The specific volume at 0 lambda in the Wright EOS [m3 kg-1]
@@ -185,108 +136,90 @@ subroutine calculate_spec_vol_array_wright(T, S, pressure, specvol, start, npts,
   real :: al_TS   ! The contributions of temperature and salinity to al0 [m3 kg-1]
   real :: p_TSp   ! A combination of the pressure and the temperature and salinity contributions to p0 [Pa]
   real :: lam_000 ! A corrected offset to lambda, including contributions from spv_ref [m2 s-2]
-  integer :: j
 
-  if (present(spv_ref)) then
+  al0 = a0 + (a1*T + a2*S)
+  p0 = b0 + ( b4*S + T * (b1 + (T*(b2 + b3*T) + b5*S)) )
+  lambda = c0 + ( c4*S + T * (c1 + (T*(c2 + c3*T) + c5*S)) )
+  spec_vol_elem_Wright_red = al0 + lambda / (pressure + p0)
+
+end function spec_vol_elem_Wright_red
+
+!> In situ specific volume anomaly of sea water using a reduced range fit by Wright, 1997 [m3 kg-1]
+!!
+!! This is an elemental function that can be applied to any combination of scalar and array inputs.
+real elemental function spec_vol_anomaly_elem_Wright_red(this, T, S, pressure, spv_ref)
+  class(Wright_red_EOS), intent(in) :: this !< This EOS
+  real,           intent(in) :: T        !< potential temperature relative to the surface [degC]
+  real,           intent(in) :: S        !< salinity [PSU]
+  real,           intent(in) :: pressure !< pressure [Pa]
+  real,           intent(in) :: spv_ref  !< A reference specific volume [m3 kg-1]
+
+  ! Local variables
+  real :: al0     ! The specific volume at 0 lambda in the Wright EOS [m3 kg-1]
+  real :: p0      ! The pressure offset in the Wright EOS [Pa]
+  real :: lambda  ! The sound speed squared at 0 alpha in the Wright EOS [m2 s-2], perhaps with
+                  ! an offset to account for spv_ref
+  real :: al_TS   ! The contributions of temperature and salinity to al0 [m3 kg-1]
+  real :: p_TSp   ! A combination of the pressure and the temperature and salinity contributions to p0 [Pa]
+  real :: lam_000 ! A corrected offset to lambda, including contributions from spv_ref [m2 s-2]
+
     lam_000 = c0 + (a0 - spv_ref)*b0
-    do j=start,start+npts-1
-      al_TS = a1*T(j) + a2*S(j)
-      p_TSp = pressure(j) + (b4*S(j) + T(j) * (b1 + (T(j)*(b2 + b3*T(j)) + b5*S(j))))
-      lambda = lam_000 + ( c4*S(j) + T(j) * (c1 + (T(j)*(c2 + c3*T(j)) + c5*S(j))) )
-      ! This is equivalent to the expression below minus spv_ref, but less sensitive to roundoff.
-      specvol(j) = al_TS + (lambda + (a0 - spv_ref)*p_TSp) / (b0 + p_TSp)
-    enddo
-  else
-    do j=start,start+npts-1
-      al0 = a0 + (a1*T(j) + a2*S(j))
-      p0 = b0 + ( b4*S(j) + T(j) * (b1 + (T(j)*(b2 + b3*T(j)) + b5*S(j))) )
-      lambda = c0 + ( c4*S(j) + T(j) * (c1 + (T(j)*(c2 + c3*T(j)) + c5*S(j))) )
-      specvol(j) = al0 + lambda / (pressure(j) + p0)
-    enddo
-  endif
-end subroutine calculate_spec_vol_array_wright
+    al_TS = a1*T + a2*S
+    p_TSp = pressure + (b4*S + T * (b1 + (T*(b2 + b3*T) + b5*S)))
+    lambda = lam_000 + ( c4*S + T * (c1 + (T*(c2 + c3*T) + c5*S)) )
+    ! This is equivalent to the expression below minus spv_ref, but less sensitive to roundoff.
+    spec_vol_anomaly_elem_Wright_red = al_TS + (lambda + (a0 - spv_ref)*p_TSp) / (b0 + p_TSp)
 
-!> Return the thermal/haline expansion coefficients for 1-d array inputs and outputs
-subroutine calculate_density_derivs_array_wright(T, S, pressure, drho_dT, drho_dS, start, npts)
-  real,    intent(in),    dimension(:) :: T        !< Potential temperature relative to the
-                                                   !! surface [degC].
-  real,    intent(in),    dimension(:) :: S        !< Salinity [PSU].
-  real,    intent(in),    dimension(:) :: pressure !< pressure [Pa].
-  real,    intent(inout), dimension(:) :: drho_dT  !< The partial derivative of density with potential
-                                                   !! temperature [kg m-3 degC-1].
-  real,    intent(inout), dimension(:) :: drho_dS  !< The partial derivative of density with salinity,
-                                                   !! in [kg m-3 PSU-1].
-  integer, intent(in)                  :: start    !< The starting point in the arrays.
-  integer, intent(in)                  :: npts     !< The number of values to calculate.
+end function spec_vol_anomaly_elem_Wright_red
+
+!> Calculate the partial derivatives of density with potential temperature and salinity
+!! using the reduced range equation of state, as fit by Wright, 1997
+elemental subroutine calculate_density_derivs_elem_Wright_red(this, T, S, pressure, drho_dT, drho_dS)
+  class(Wright_red_EOS), intent(in) :: this   !< This EOS
+  real,               intent(in)  :: T        !< Potential temperature relative to the surface [degC]
+  real,               intent(in)  :: S        !< Salinity [PSU]
+  real,               intent(in)  :: pressure !< Pressure [Pa]
+  real,               intent(out) :: drho_dT  !< The partial derivative of density with potential
+                                              !! temperature [kg m-3 degC-1]
+  real,               intent(out) :: drho_dS  !< The partial derivative of density with salinity,
+                                              !! in [kg m-3 PSU-1]
 
   ! Local variables
   real :: al0     ! The specific volume at 0 lambda in the Wright EOS [m3 kg-1]
   real :: p0      ! The pressure offset in the Wright EOS [Pa]
   real :: lambda  ! The sound speed squared at 0 alpha in the Wright EOS [m2 s-2]
   real :: I_denom2 ! The inverse of the square of the denominator of density in the Wright EOS [s4 m-4]
-  integer :: j
 
-  do j=start,start+npts-1
-    al0 = a0 + (a1*T(j) + a2*S(j))
-    p0 = b0 + ( b4*S(j) + T(j) * (b1 + (T(j)*(b2 + b3*T(j)) + b5*S(j))) )
-    lambda = c0 + ( c4*S(j) + T(j) * (c1 + (T(j)*(c2 + c3*T(j)) + c5*S(j))) )
+  al0 = a0 + (a1*T + a2*S)
+  p0 = b0 + ( b4*S + T * (b1 + (T*(b2 + b3*T) + b5*S)) )
+  lambda = c0 + ( c4*S + T * (c1 + (T*(c2 + c3*T) + c5*S)) )
 
-    I_denom2 = 1.0 / (lambda + al0*(pressure(j) + p0))**2
-    drho_dT(j) = I_denom2 * (lambda * (b1 + (T(j)*(2.0*b2 + 3.0*b3*T(j)) + b5*S(j))) - &
-       (pressure(j)+p0) * ( (pressure(j)+p0)*a1 + (c1 + (T(j)*(c2*2.0 + c3*3.0*T(j)) + c5*S(j))) ))
-    drho_dS(j) = I_denom2 * (lambda * (b4 + b5*T(j)) - &
-       (pressure(j)+p0) * ( (pressure(j)+p0)*a2 + (c4 + c5*T(j)) ))
-  enddo
+  I_denom2 = 1.0 / (lambda + al0*(pressure + p0))**2
+  drho_dT = I_denom2 * (lambda * (b1 + (T*(2.0*b2 + 3.0*b3*T) + b5*S)) - &
+     (pressure+p0) * ( (pressure+p0)*a1 + (c1 + (T*(c2*2.0 + c3*3.0*T) + c5*S)) ))
+  drho_dS = I_denom2 * (lambda * (b4 + b5*T) - &
+     (pressure+p0) * ( (pressure+p0)*a2 + (c4 + c5*T) ))
 
-end subroutine calculate_density_derivs_array_wright
+end subroutine calculate_density_derivs_elem_Wright_red
 
-!> Return the thermal/haline expansion coefficients for scalar inputs and outputs
-!!
-!! The scalar version of calculate_density_derivs promotes scalar inputs to 1-element array
-!! and then demotes the output back to a scalar
-subroutine calculate_density_derivs_scalar_wright(T, S, pressure, drho_dT, drho_dS)
-  real,    intent(in)  :: T        !< Potential temperature relative to the surface [degC].
-  real,    intent(in)  :: S        !< Salinity [PSU].
-  real,    intent(in)  :: pressure !< pressure [Pa].
-  real,    intent(out) :: drho_dT  !< The partial derivative of density with potential
-                                   !! temperature [kg m-3 degC-1].
-  real,    intent(out) :: drho_dS  !< The partial derivative of density with salinity,
-                                   !! in [kg m-3 PSU-1].
-
-  ! Local variables needed to promote the input/output scalars to 1-element arrays
-  real, dimension(1) :: T0    ! A 1-d array with a copy of the temperature [degC]
-  real, dimension(1) :: S0    ! A 1-d array with a copy of the salinity [PSU]
-  real, dimension(1) :: p0    ! A 1-d array with a copy of the pressure [Pa]
-  real, dimension(1) :: drdt0 ! The derivative of density with temperature [kg m-3 degC-1]
-  real, dimension(1) :: drds0 ! The derivative of density with salinity [kg m-3 PSU-1]
-
-  T0(1) = T
-  S0(1) = S
-  P0(1) = pressure
-  call calculate_density_derivs_array_wright(T0, S0, P0, drdt0, drds0, 1, 1)
-  drho_dT = drdt0(1)
-  drho_dS = drds0(1)
-
-end subroutine calculate_density_derivs_scalar_wright
-
-!> Second derivatives of density with respect to temperature, salinity, and pressure for 1-d array inputs and outputs.
-subroutine calculate_density_second_derivs_array_wright(T, S, P, drho_ds_ds, drho_ds_dt, drho_dt_dt, &
-                                                         drho_ds_dp, drho_dt_dp, start, npts)
-  real, dimension(:), intent(in   ) :: T !< Potential temperature referenced to 0 dbar [degC]
-  real, dimension(:), intent(in   ) :: S !< Salinity [PSU]
-  real, dimension(:), intent(in   ) :: P !< Pressure [Pa]
-  real, dimension(:), intent(inout) :: drho_ds_ds !< Partial derivative of beta with respect
+!> Second derivatives of density with respect to temperature, salinity, and pressure,
+!! using the reduced range equation of state, as fit by Wright, 1997
+elemental subroutine calculate_density_second_derivs_elem_Wright_red(this, T, S, pressure, &
+                              drho_ds_ds, drho_ds_dt, drho_dt_dt, drho_ds_dp, drho_dt_dp)
+  class(Wright_red_EOS), intent(in) :: this       !< This EOS
+  real,               intent(in)    :: T          !< Potential temperature referenced to 0 dbar [degC]
+  real,               intent(in)    :: S          !< Salinity [PSU]
+  real,               intent(in)    :: pressure   !< Pressure [Pa]
+  real,               intent(inout) :: drho_ds_ds !< Partial derivative of beta with respect
                                                   !! to S [kg m-3 PSU-2]
-  real, dimension(:), intent(inout) :: drho_ds_dt !< Partial derivative of beta with respect
+  real,               intent(inout) :: drho_ds_dt !< Partial derivative of beta with respect
                                                   !! to T [kg m-3 PSU-1 degC-1]
-  real, dimension(:), intent(inout) :: drho_dt_dt !< Partial derivative of alpha with respect
+  real,               intent(inout) :: drho_dt_dt !< Partial derivative of alpha with respect
                                                   !! to T [kg m-3 degC-2]
-  real, dimension(:), intent(inout) :: drho_ds_dp !< Partial derivative of beta with respect
+  real,               intent(inout) :: drho_ds_dp !< Partial derivative of beta with respect
                                                   !! to pressure [kg m-3 PSU-1 Pa-1] = [s2 m-2 PSU-1]
-  real, dimension(:), intent(inout) :: drho_dt_dp !< Partial derivative of alpha with respect
+  real,               intent(inout) :: drho_dt_dp !< Partial derivative of alpha with respect
                                                   !! to pressure [kg m-3 degC-1 Pa-1] = [s2 m-2 degC-1]
-  integer,            intent(in   ) :: start !< Starting index in T,S,P
-  integer,            intent(in   ) :: npts  !< Number of points to loop over
 
   ! Local variables
   real :: al0     ! The specific volume at 0 lambda in the Wright EOS [m3 kg-1]
@@ -304,152 +237,100 @@ subroutine calculate_density_second_derivs_array_wright(T, S, P, drho_ds_ds, drh
   real :: I_denom   ! The inverse of the denominator of density in the Wright EOS [s2 m-2]
   real :: I_denom2  ! The inverse of the square of the denominator of density in the Wright EOS [s4 m-4]
   real :: I_denom3  ! The inverse of the cube of the denominator of density in the Wright EOS [s6 m-6]
-  integer :: j
 
-  do j = start,start+npts-1
-    al0 = a0 + (a1*T(j) + a2*S(j))
-    p_p0 = P(j) + ( b0 + (b4*S(j) + T(j)*(b1 + (b5*S(j) + T(j)*(b2 + b3*T(j))))) ) ! P + p0
-    lambda = c0 + ( c4*S(j) + T(j) * (c1 + (T(j)*(c2 + c3*T(j)) + c5*S(j))) )
-    dp0_dT = b1 + (b5*S(j) + T(j)*(2.*b2 + 3.*b3*T(j)))
-    dp0_dS = b4 + b5*T(j)
-    dlam_dT = c1 + (c5*S(j) + T(j)*(2.*c2 + 3.*c3*T(j)))
-    dlam_dS = c4 + c5*T(j)
-    I_denom = 1.0 / (lambda + al0*p_p0)
-    I_denom2 = I_denom*I_denom
-    I_denom3 = I_denom*I_denom2
+  al0 = a0 + (a1*T + a2*S)
+  p_p0 = pressure + ( b0 + (b4*S + T*(b1 + (b5*S + T*(b2 + b3*T)))) ) ! P + p0
+  lambda = c0 + ( c4*S + T * (c1 + (T*(c2 + c3*T) + c5*S)) )
+  dp0_dT = b1 + (b5*S + T*(2.*b2 + 3.*b3*T))
+  dp0_dS = b4 + b5*T
+  dlam_dT = c1 + (c5*S + T*(2.*c2 + 3.*c3*T))
+  dlam_dS = c4 + c5*T
+  I_denom = 1.0 / (lambda + al0*p_p0)
+  I_denom2 = I_denom*I_denom
+  I_denom3 = I_denom*I_denom2
 
-    ddenom_dS = (dlam_dS + a2*p_p0) + al0*dp0_dS
-    ddenom_dT = (dlam_dT + a1*p_p0) + al0*dp0_dT
-    dRdS_num = dp0_dS*lambda - p_p0*(dlam_dS + a2*p_p0)
-    dRdT_num = dp0_dT*lambda - p_p0*(dlam_dT + a1*p_p0)
+  ddenom_dS = (dlam_dS + a2*p_p0) + al0*dp0_dS
+  ddenom_dT = (dlam_dT + a1*p_p0) + al0*dp0_dT
+  dRdS_num = dp0_dS*lambda - p_p0*(dlam_dS + a2*p_p0)
+  dRdT_num = dp0_dT*lambda - p_p0*(dlam_dT + a1*p_p0)
 
-    ! In deriving the following, it is useful to note that:
-    !   rho(j) = p_p0 / (lambda + al0*p_p0)
-    !   drho_dp(j) = lambda * I_denom2
-    !   drho_dT(j) = (dp0_dT*lambda - p_p0*(dlam_dT + a1*p_p0)) * I_denom2 = dRdT_num * I_denom2
-    !   drho_dS(j) = (dp0_dS*lambda - p_p0*(dlam_dS + a2*p_p0)) * I_denom2 = dRdS_num * I_denom2
-    drho_ds_ds(j) = -2.*(p_p0*(a2*dp0_dS)) * I_denom2 - 2.*(dRdS_num*ddenom_dS) * I_denom3
-    drho_ds_dt(j) = ((b5*lambda - p_p0*(c5 + 2.*a2*dp0_dT)) + (dp0_dS*dlam_dT - dp0_dT*dlam_dS))*I_denom2 - &
-                    2.*(ddenom_dT*dRdS_num) * I_denom3
-    drho_dt_dt(j) = 2.*((b2 + 3.*b3*T(j))*lambda - p_p0*((c2 + 3.*c3*T(j)) + a1*dp0_dT))*I_denom2 - &
-                    2.*(dRdT_num * ddenom_dT) * I_denom3
+  ! In deriving the following, it is useful to note that:
+  !   rho = p_p0 / (lambda + al0*p_p0)
+  !   drho_dp = lambda * I_denom2
+  !   drho_dT = (dp0_dT*lambda - p_p0*(dlam_dT + a1*p_p0)) * I_denom2 = dRdT_num * I_denom2
+  !   drho_dS = (dp0_dS*lambda - p_p0*(dlam_dS + a2*p_p0)) * I_denom2 = dRdS_num * I_denom2
+  drho_ds_ds = -2.*(p_p0*(a2*dp0_dS)) * I_denom2 - 2.*(dRdS_num*ddenom_dS) * I_denom3
+  drho_ds_dt = ((b5*lambda - p_p0*(c5 + 2.*a2*dp0_dT)) + (dp0_dS*dlam_dT - dp0_dT*dlam_dS))*I_denom2 - &
+                  2.*(ddenom_dT*dRdS_num) * I_denom3
+  drho_dt_dt = 2.*((b2 + 3.*b3*T)*lambda - p_p0*((c2 + 3.*c3*T) + a1*dp0_dT))*I_denom2 - &
+                  2.*(dRdT_num * ddenom_dT) * I_denom3
 
-    ! The following is a rearranged form that is equivalent to
-    ! drho_ds_dp(j) = dlam_dS * I_denom2 - 2.0 * lambda * (dlam_dS + a2*p_p0 + al0*dp0_ds) * Idenom3
-    drho_ds_dp(j) = (-dlam_dS - 2.*a2*p_p0) * I_denom2 - (2.*al0*dRdS_num) * I_denom3
-    drho_dt_dp(j) = (-dlam_dT - 2.*a1*p_p0) * I_denom2 - (2.*al0*dRdT_num) * I_denom3
-  enddo
+  ! The following is a rearranged form that is equivalent to
+  ! drho_ds_dp = dlam_dS * I_denom2 - 2.0 * lambda * (dlam_dS + a2*p_p0 + al0*dp0_ds) * Idenom3
+  drho_ds_dp = (-dlam_dS - 2.*a2*p_p0) * I_denom2 - (2.*al0*dRdS_num) * I_denom3
+  drho_dt_dp = (-dlam_dT - 2.*a1*p_p0) * I_denom2 - (2.*al0*dRdT_num) * I_denom3
 
-end subroutine calculate_density_second_derivs_array_wright
+end subroutine calculate_density_second_derivs_elem_Wright_red
 
-!> Second derivatives of density with respect to temperature, salinity, and pressure for scalar inputs.
-!!
-!! The scalar version of calculate_density_second_derivs promotes scalar inputs to 1-element array
-!! and then demotes the output back to a scalar
-subroutine calculate_density_second_derivs_scalar_wright(T, S, P, drho_ds_ds, drho_ds_dt, drho_dt_dt, &
-                                                         drho_ds_dp, drho_dt_dp)
-  real, intent(in   ) :: T          !< Potential temperature referenced to 0 dbar
-  real, intent(in   ) :: S          !< Salinity [PSU]
-  real, intent(in   ) :: P          !< pressure [Pa]
-  real, intent(  out) :: drho_ds_ds !< Partial derivative of beta with respect
-                                    !! to S [kg m-3 PSU-2]
-  real, intent(  out) :: drho_ds_dt !< Partial derivative of beta with respect
-                                    !! to T [kg m-3 PSU-1 degC-1]
-  real, intent(  out) :: drho_dt_dt !< Partial derivative of alpha with respect
-                                    !! to T [kg m-3 degC-2]
-  real, intent(  out) :: drho_ds_dp !< Partial derivative of beta with respect
-                                    !! to pressure [kg m-3 PSU-1 Pa-1] = [s2 m-2 PSU-1]
-  real, intent(  out) :: drho_dt_dp !< Partial derivative of alpha with respect
-                                    !! to pressure [kg m-3 degC-1 Pa-1] = [s2 m-2 degC-1]
-  ! Local variables
-  real, dimension(1) :: T0    ! A 1-d array with a copy of the temperature [degC]
-  real, dimension(1) :: S0    ! A 1-d array with a copy of the salinity [PSU]
-  real, dimension(1) :: p0    ! A 1-d array with a copy of the pressure [Pa]
-  real, dimension(1) :: drdsds ! The second derivative of density with salinity [kg m-3 PSU-2]
-  real, dimension(1) :: drdsdt ! The second derivative of density with salinity and
-                               ! temperature [kg m-3 PSU-1 degC-1]
-  real, dimension(1) :: drdtdt ! The second derivative of density with temperature [kg m-3 degC-2]
-  real, dimension(1) :: drdsdp ! The second derivative of density with salinity and
-                               ! pressure [kg m-3 PSU-1 Pa-1] = [s2 m-2 PSU-1]
-  real, dimension(1) :: drdtdp ! The second derivative of density with temperature and
-                               ! pressure [kg m-3 degC-1 Pa-1] = [s2 m-2 degC-1]
-
-  T0(1) = T
-  S0(1) = S
-  P0(1) = P
-  call calculate_density_second_derivs_array_wright(T0, S0, P0, drdsds, drdsdt, drdtdt, drdsdp, drdtdp, 1, 1)
-  drho_ds_ds = drdsds(1)
-  drho_ds_dt = drdsdt(1)
-  drho_dt_dt = drdtdt(1)
-  drho_ds_dp = drdsdp(1)
-  drho_dt_dp = drdtdp(1)
-
-end subroutine calculate_density_second_derivs_scalar_wright
-
-!> Return the partial derivatives of specific volume with temperature and salinity
-!! for 1-d array inputs and outputs
-subroutine calculate_specvol_derivs_wright_red(T, S, pressure, dSV_dT, dSV_dS, start, npts)
-  real,    intent(in),    dimension(:) :: T        !< Potential temperature relative to the surface [degC].
-  real,    intent(in),    dimension(:) :: S        !< Salinity [PSU].
-  real,    intent(in),    dimension(:) :: pressure !< pressure [Pa].
-  real,    intent(inout), dimension(:) :: dSV_dT   !< The partial derivative of specific volume with
-                                                   !! potential temperature [m3 kg-1 degC-1].
-  real,    intent(inout), dimension(:) :: dSV_dS   !< The partial derivative of specific volume with
-                                                   !! salinity [m3 kg-1 PSU-1].
-  integer, intent(in)                  :: start    !< The starting point in the arrays.
-  integer, intent(in)                  :: npts     !< The number of values to calculate.
+!> Calculate the partial derivatives of specific volume with temperature and salinity
+!! using the reduced range equation of state, as fit by Wright, 1997
+elemental subroutine calculate_specvol_derivs_elem_Wright_red(this, T, S, pressure, dSV_dT, dSV_dS)
+  class(Wright_red_EOS), intent(in) :: this     !< This EOS
+  real,               intent(in)    :: T        !< Potential temperature [degC]
+  real,               intent(in)    :: S        !< Salinity [PSU]
+  real,               intent(in)    :: pressure !< Pressure [Pa]
+  real,               intent(inout) :: dSV_dT   !< The partial derivative of specific volume with
+                                                !! potential temperature [m3 kg-1 degC-1]
+  real,               intent(inout) :: dSV_dS   !< The partial derivative of specific volume with
+                                                !! salinity [m3 kg-1 PSU-1]
 
   ! Local variables
   real :: p0      ! The pressure offset in the Wright EOS [Pa]
   real :: lambda  ! The sound speed squared at 0 alpha in the Wright EOS [m2 s-2]
   real :: I_denom ! The inverse of the denominator of specific volume in the Wright EOS [Pa-1]
-  integer :: j
 
-  do j=start,start+npts-1
-!    al0 = a0 + (a1*T(j) + a2*S(j))
-    p0 = b0 + ( b4*S(j) + T(j) * (b1 + (T(j)*(b2 + b3*T(j)) + b5*S(j))) )
-    lambda = c0 + ( c4*S(j) + T(j) * (c1 + (T(j)*(c2 + c3*T(j)) + c5*S(j))) )
+  !al0 = a0 + (a1*T + a2*S)
+  p0 = b0 + ( b4*S + T * (b1 + (T*(b2 + b3*T) + b5*S)) )
+  lambda = c0 + ( c4*S + T * (c1 + (T*(c2 + c3*T) + c5*S)) )
 
-    ! SV = al0 + lambda / (pressure(j) + p0)
+  ! SV = al0 + lambda / (pressure + p0)
 
-    I_denom = 1.0 / (pressure(j) + p0)
-    dSV_dT(j) = a1 + I_denom * ((c1 + (T(j)*(2.0*c2 + 3.0*c3*T(j)) + c5*S(j))) - &
-                                (I_denom * lambda) * (b1 + (T(j)*(2.0*b2 + 3.0*b3*T(j)) + b5*S(j))))
-    dSV_dS(j) = a2 + I_denom * ((c4 + c5*T(j)) - &
-                                (I_denom * lambda) * (b4 + b5*T(j)))
-  enddo
+  I_denom = 1.0 / (pressure + p0)
+  dSV_dT = a1 + I_denom * ((c1 + (T*(2.0*c2 + 3.0*c3*T) + c5*S)) - &
+                              (I_denom * lambda) * (b1 + (T*(2.0*b2 + 3.0*b3*T) + b5*S)))
+  dSV_dS = a2 + I_denom * ((c4 + c5*T) - &
+                              (I_denom * lambda) * (b4 + b5*T))
 
-end subroutine calculate_specvol_derivs_wright_red
+end subroutine calculate_specvol_derivs_elem_Wright_red
 
-!> Computes the compressibility of seawater for 1-d array inputs and outputs
-subroutine calculate_compress_wright_red(T, S, pressure, rho, drho_dp, start, npts)
-  real,    intent(in),    dimension(:) :: T        !< Potential temperature relative to the surface [degC].
-  real,    intent(in),    dimension(:) :: S        !< Salinity [PSU].
-  real,    intent(in),    dimension(:) :: pressure !< pressure [Pa].
-  real,    intent(inout), dimension(:) :: rho      !< In situ density [kg m-3].
-  real,    intent(inout), dimension(:) :: drho_dp  !< The partial derivative of density with pressure
-                                                   !! (also the inverse of the square of sound speed)
-                                                   !! [s2 m-2].
-  integer, intent(in)                  :: start    !< The starting point in the arrays.
-  integer, intent(in)                  :: npts     !< The number of values to calculate.
+!> Compute the in situ density of sea water (rho) and the compressibility (drho/dp == C_sound^-2)
+!! at the given salinity, potential temperature and pressure
+!! using the reduced range equation of state, as fit by Wright, 1997
+elemental subroutine calculate_compress_elem_Wright_red(this, T, S, pressure, rho, drho_dp)
+  class(Wright_red_EOS), intent(in) :: this   !< This EOS
+  real,               intent(in)  :: T        !< Potential temperature relative to the surface [degC]
+  real,               intent(in)  :: S        !< Salinity [PSU]
+  real,               intent(in)  :: pressure !< Pressure [Pa]
+  real,               intent(out) :: rho      !< In situ density [kg m-3]
+  real,               intent(out) :: drho_dp  !< The partial derivative of density with pressure
+                                              !! (also the inverse of the square of sound speed)
+                                              !! [s2 m-2].
 
   ! Local variables
   real :: al0     ! The specific volume at 0 lambda in the Wright EOS [m3 kg-1]
   real :: p0      ! The pressure offset in the Wright EOS [Pa]
   real :: lambda  ! The sound speed squared at 0 alpha in the Wright EOS [m2 s-2]
   real :: I_denom ! The inverse of the denominator of density in the Wright EOS [s2 m-2]
-  integer :: j
 
-  do j=start,start+npts-1
-    al0 = a0 + (a1*T(j) + a2*S(j))
-    p0 = b0 + ( b4*S(j) + T(j) * (b1 + (T(j)*(b2 + b3*T(j)) + b5*S(j))) )
-    lambda = c0 + ( c4*S(j) + T(j) * (c1 + (T(j)*(c2 + c3*T(j)) + c5*S(j))) )
+  al0 = a0 + (a1*T + a2*S)
+  p0 = b0 + ( b4*S + T * (b1 + (T*(b2 + b3*T) + b5*S)) )
+  lambda = c0 + ( c4*S + T * (c1 + (T*(c2 + c3*T) + c5*S)) )
 
-    I_denom = 1.0 / (lambda + al0*(pressure(j) + p0))
-    rho(j) = (pressure(j) + p0) * I_denom
-    drho_dp(j) = lambda * I_denom**2
-  enddo
-end subroutine calculate_compress_wright_red
+  I_denom = 1.0 / (lambda + al0*(pressure + p0))
+  rho = (pressure + p0) * I_denom
+  drho_dp = lambda * I_denom**2
+
+end subroutine calculate_compress_elem_Wright_red
 
 !> Calculates analytical and nearly-analytical integrals, in pressure across layers, to determine
 !! the layer-average specific volumes.  There are essentially no free assumptions, apart from a
@@ -490,7 +371,8 @@ end subroutine avg_spec_vol_Wright_red
 !> Return the range of temperatures, salinities and pressures for which the reduced-range equation
 !! of state from Wright (1997) has been fitted to observations.  Care should be taken when applying
 !! this equation of state outside of its fit range.
-subroutine EoS_fit_range_Wright_red(T_min, T_max, S_min, S_max, p_min, p_max)
+subroutine EoS_fit_range_Wright_red(this, T_min, T_max, S_min, S_max, p_min, p_max)
+  class(Wright_red_EOS), intent(in) :: this !< This EOS
   real, optional, intent(out) :: T_min !< The minimum potential temperature over which this EoS is fitted [degC]
   real, optional, intent(out) :: T_max !< The maximum potential temperature over which this EoS is fitted [degC]
   real, optional, intent(out) :: S_min !< The minimum practical salinity over which this EoS is fitted [PSU]
@@ -1008,6 +890,58 @@ subroutine int_spec_vol_dp_wright_red(T, S, p_t, p_b, spv_ref, HI, dza, &
                            12.0*intp(3))
   enddo ; enddo ; endif
 end subroutine int_spec_vol_dp_wright_red
+
+!> Calculate the in-situ density for 1D arraya inputs and outputs.
+subroutine calculate_density_array_Wright_red(this, T, S, pressure, rho, start, npts, rho_ref)
+  class(Wright_red_EOS), intent(in) :: this  !< This EOS
+  real, dimension(:), intent(in)  :: T        !< Potential temperature relative to the surface [degC]
+  real, dimension(:), intent(in)  :: S        !< Salinity [PSU]
+  real, dimension(:), intent(in)  :: pressure !< Pressure [Pa]
+  real, dimension(:), intent(out) :: rho      !< In situ density [kg m-3]
+  integer,            intent(in)  :: start    !< The starting index for calculations
+  integer,            intent(in)  :: npts     !< The number of values to calculate
+  real,     optional, intent(in)  :: rho_ref  !< A reference density [kg m-3]
+
+  ! Local variables
+  integer :: j
+
+  if (present(rho_ref)) then
+    do j = start, start+npts-1
+      rho(j) = density_anomaly_elem_Wright_red(this, T(j), S(j), pressure(j), rho_ref)
+    enddo
+  else
+    do j = start, start+npts-1
+      rho(j) = density_elem_Wright_red(this, T(j), S(j), pressure(j))
+    enddo
+  endif
+
+end subroutine calculate_density_array_Wright_red
+
+!> Calculate the in-situ specific volume for 1D array inputs and outputs.
+subroutine calculate_spec_vol_array_Wright_red(this, T, S, pressure, specvol, start, npts, spv_ref)
+  class(Wright_red_EOS),  intent(in) :: this  !< This EOS
+  real, dimension(:), intent(in)  :: T        !< Potential temperature relative to the surface [degC]
+  real, dimension(:), intent(in)  :: S        !< Salinity [PSU]
+  real, dimension(:), intent(in)  :: pressure !< Pressure [Pa]
+  real, dimension(:), intent(out) :: specvol  !< In situ specific volume [m3 kg-1]
+  integer,            intent(in)  :: start    !< The starting index for calculations
+  integer,            intent(in)  :: npts     !< The number of values to calculate
+  real,     optional, intent(in)  :: spv_ref  !< A reference specific volume [m3 kg-1]
+
+  ! Local variables
+  integer :: j
+
+  if (present(spv_ref)) then
+    do j = start, start+npts-1
+      specvol(j) = spec_vol_anomaly_elem_Wright_red(this, T(j), S(j), pressure(j), spv_ref)
+    enddo
+  else
+    do j = start, start+npts-1
+      specvol(j) = spec_vol_elem_Wright_red(this, T(j), S(j), pressure(j) )
+    enddo
+  endif
+
+end subroutine calculate_spec_vol_array_Wright_red
 
 
 !> \namespace mom_eos_wright_red

--- a/src/equation_of_state/MOM_EOS_base_type.F90
+++ b/src/equation_of_state/MOM_EOS_base_type.F90
@@ -1,0 +1,464 @@
+!> A generic type for equations of state
+module MOM_EOS_base_type
+
+! This file is part of MOM6. See LICENSE.md for the license.
+
+implicit none ; private
+
+public EOS_base
+
+!> The base class for implementations of the equation of state
+type, abstract :: EOS_base
+
+contains
+
+  ! The following functions/subroutines are deferred and must be provided specifically by each EOS
+
+  !> Deferred implementation of the in-situ density as an elemental function [kg m-3]
+  procedure(i_density_elem), deferred :: density_elem
+  !> Deferred implementation of the in-situ density anomaly as an elemental function [kg m-3]
+  procedure(i_density_anomaly_elem), deferred :: density_anomaly_elem
+  !> Deferred implementation of the in-situ specific volume as an elemental function [m3 kg-1]
+  procedure(i_spec_vol_elem), deferred :: spec_vol_elem
+  !> Deferred implementation of the in-situ specific volume anomaly as an elemental function [m3 kg-1]
+  procedure(i_spec_vol_anomaly_elem), deferred :: spec_vol_anomaly_elem
+  !> Deferred implementation of the calculation of derivatives of density
+  procedure(i_calculate_density_derivs_elem), deferred :: calculate_density_derivs_elem
+  !> Deferred implementation of the calculation of second derivatives of density
+  procedure(i_calculate_density_second_derivs_elem), deferred :: calculate_density_second_derivs_elem
+  !> Deferred implementation of the calculation of derivatives of specific volume
+  procedure(i_calculate_specvol_derivs_elem), deferred :: calculate_specvol_derivs_elem
+  !> Deferred implementation of the calculation of compressibility
+  procedure(i_calculate_compress_elem), deferred :: calculate_compress_elem
+  !> Deferred implementation of the range query function
+  procedure(i_EOS_fit_range), deferred :: EOS_fit_range
+
+  ! The following functions/subroutines are shared across all EOS and provided by this module
+  !> Returns the in-situ density or density anomaly [kg m-3]
+  procedure :: density_fn => a_density_fn
+  !> Returns the in-situ specific volume or specific volume anomaly [m3 kg-1]
+  procedure :: spec_vol_fn => a_spec_vol_fn
+  !> Calculates the in-situ density or density anomaly for scalar inputs [m3 kg-1]
+  procedure :: calculate_density_scalar => a_calculate_density_scalar
+  !> Calculates the in-situ density or density anomaly for array inputs [m3 kg-1]
+  procedure :: calculate_density_array => a_calculate_density_array
+  !> Calculates the in-situ specific volume or specific volume anomaly for scalar inputs [m3 kg-1]
+  procedure :: calculate_spec_vol_scalar => a_calculate_spec_vol_scalar
+  !> Calculates the in-situ specific volume or specific volume anomaly for array inputs [m3 kg-1]
+  procedure :: calculate_spec_vol_array => a_calculate_spec_vol_array
+  !> Calculates the derivatives of density for scalar inputs
+  procedure :: calculate_density_derivs_scalar => a_calculate_density_derivs_scalar
+  !> Calculates the derivatives of density for array inputs
+  procedure :: calculate_density_derivs_array => a_calculate_density_derivs_array
+  !> Calculates the second derivatives of density for scalar inputs
+  procedure :: calculate_density_second_derivs_scalar => a_calculate_density_second_derivs_scalar
+  !> Calculates the second derivatives of density for array inputs
+  procedure :: calculate_density_second_derivs_array => a_calculate_density_second_derivs_array
+  !> Calculates the derivatives of specific volume for array inputs
+  procedure :: calculate_specvol_derivs_array => a_calculate_specvol_derivs_array
+  !> Calculates the compressibility for array inputs
+  procedure :: calculate_compress_array => a_calculate_compress_array
+
+end type EOS_base
+
+interface
+
+  !> In situ density [kg m-3]
+  !!
+  !! This is an elemental function that can be applied to any combination of scalar and array inputs.
+  real elemental function i_density_elem(this, T, S, pressure)
+    import :: EOS_base
+    class(EOS_base), intent(in) :: this     !< This EOS
+    real,            intent(in) :: T        !< Potential temperature relative to the surface [degC]
+    real,            intent(in) :: S        !< Salinity [PSU]
+    real,            intent(in) :: pressure !< Pressure [Pa]
+
+  end function i_density_elem
+
+  !> In situ density anomaly [kg m-3]
+  !!
+  !! This is an elemental function that can be applied to any combination of scalar and array inputs.
+  real elemental function i_density_anomaly_elem(this, T, S, pressure, rho_ref)
+    import :: EOS_base
+    class(EOS_base), intent(in) :: this     !< This EOS
+    real,            intent(in) :: T        !< Potential temperature relative to the surface [degC]
+    real,            intent(in) :: S        !< Salinity [PSU]
+    real,            intent(in) :: pressure !< Pressure [Pa]
+    real,            intent(in) :: rho_ref  !< A reference density [kg m-3]
+
+  end function i_density_anomaly_elem
+
+  !> In situ specific volume [m3 kg-1]
+  !!
+  !! This is an elemental function that can be applied to any combination of scalar and array inputs.
+  real elemental function i_spec_vol_elem(this, T, S, pressure)
+    import :: EOS_base
+    class(EOS_base), intent(in) :: this     !< This EOS
+    real,            intent(in) :: T        !< Potential temperature relative to the surface [degC]
+    real,            intent(in) :: S        !< Salinity [PSU]
+    real,            intent(in) :: pressure !< Pressure [Pa]
+
+  end function i_spec_vol_elem
+
+  !> In situ specific volume anomaly [m3 kg-1]
+  !!
+  !! This is an elemental function that can be applied to any combination of scalar and array inputs.
+  real elemental function i_spec_vol_anomaly_elem(this, T, S, pressure, spv_ref)
+    import :: EOS_base
+    class(EOS_base), intent(in) :: this     !< This EOS
+    real,            intent(in) :: T        !< Potential temperature relative to the surface [degC]
+    real,            intent(in) :: S        !< Salinity [PSU]
+    real,            intent(in) :: pressure !< Pressure [Pa]
+    real,            intent(in) :: spv_ref  !< A reference specific volume [m3 kg-1]
+
+  end function i_spec_vol_anomaly_elem
+
+  !> Calculate the partial derivatives of density with potential temperature and salinity
+  elemental subroutine i_calculate_density_derivs_elem(this, T, S, pressure, drho_dT, drho_dS)
+    import :: EOS_base
+    class(EOS_base), intent(in) :: this      !< This EOS
+    real,            intent(in)  :: T        !< Potential temperature relative to the surface [degC]
+    real,            intent(in)  :: S        !< Salinity [PSU]
+    real,            intent(in)  :: pressure !< Pressure [Pa]
+    real,            intent(out) :: drho_dT  !< The partial derivative of density with potential
+                                             !! temperature [kg m-3 degC-1]
+    real,            intent(out) :: drho_dS  !< The partial derivative of density with salinity,
+                                             !! in [kg m-3 PSU-1]
+
+  end subroutine i_calculate_density_derivs_elem
+
+  !> Calculate the partial derivatives of specific volume with temperature and salinity
+  elemental subroutine i_calculate_specvol_derivs_elem(this, T, S, pressure, dSV_dT, dSV_dS)
+    import :: EOS_base
+    class(EOS_base), intent(in)    :: this     !< This EOS
+    real,            intent(in)    :: T        !< Potential temperature [degC]
+    real,            intent(in)    :: S        !< Salinity [PSU]
+    real,            intent(in)    :: pressure !< Pressure [Pa]
+    real,            intent(inout) :: dSV_dT   !< The partial derivative of specific volume with
+                                               !! potential temperature [m3 kg-1 degC-1]
+    real,            intent(inout) :: dSV_dS   !< The partial derivative of specific volume with
+                                               !! salinity [m3 kg-1 PSU-1]
+
+  end subroutine i_calculate_specvol_derivs_elem
+
+  !> Calculate second derivatives of density with respect to temperature, salinity, and pressure
+  elemental subroutine i_calculate_density_second_derivs_elem(this, T, S, pressure, &
+                          drho_ds_ds, drho_ds_dt, drho_dt_dt, drho_ds_dp, drho_dt_dp)
+    import :: EOS_base
+    class(EOS_base), intent(in)    :: this     !< This EOS
+    real,            intent(in)    :: T !< Potential temperature referenced to 0 dbar [degC]
+    real,            intent(in)    :: S !< Salinity [PSU]
+    real,            intent(in)    :: pressure !< Pressure [Pa]
+    real,            intent(inout) :: drho_ds_ds !< Partial derivative of beta with respect
+                                                 !! to S [kg m-3 PSU-2]
+    real,            intent(inout) :: drho_ds_dt !< Partial derivative of beta with respect
+                                                 !! to T [kg m-3 PSU-1 degC-1]
+    real,            intent(inout) :: drho_dt_dt !< Partial derivative of alpha with respect
+                                                 !! to T [kg m-3 degC-2]
+    real,            intent(inout) :: drho_ds_dp !< Partial derivative of beta with respect
+                                                 !! to pressure [kg m-3 PSU-1 Pa-1] = [s2 m-2 PSU-1]
+    real,            intent(inout) :: drho_dt_dp !< Partial derivative of alpha with respect
+                                                 !! to pressure [kg m-3 degC-1 Pa-1] = [s2 m-2 degC-1]
+
+  end subroutine i_calculate_density_second_derivs_elem
+
+  !> Compute the in situ density of sea water (rho) and the compressibility (drho/dp == C_sound^-2)
+  !! at the given salinity, potential temperature and pressure
+  elemental subroutine i_calculate_compress_elem(this, T, S, pressure, rho, drho_dp)
+    import :: EOS_base
+    class(EOS_base), intent(in)  :: this     !< This EOS
+    real,            intent(in)  :: T        !< Potential temperature relative to the surface [degC]
+    real,            intent(in)  :: S        !< Salinity [PSU]
+    real,            intent(in)  :: pressure !< Pressure [Pa]
+    real,            intent(out) :: rho      !< In situ density [kg m-3]
+    real,            intent(out) :: drho_dp  !< The partial derivative of density with pressure (or
+                                             !! the inverse of the square of sound speed) [s2 m-2]
+
+  end subroutine i_calculate_compress_elem
+
+  !> Return the range of temperatures, salinities and pressures for which the equations of state has been
+  !! fitted or is valid. Care should be taken when applying this equation of state outside of its fit range.
+  subroutine i_EOS_fit_range(this, T_min, T_max, S_min, S_max, p_min, p_max)
+    import :: EOS_base
+    class(EOS_base), intent(in) :: this     !< This EOS
+    real, optional, intent(out) :: T_min !< The minimum potential temperature over which this EoS is fitted [degC]
+    real, optional, intent(out) :: T_max !< The maximum potential temperature over which this EoS is fitted [degC]
+    real, optional, intent(out) :: S_min !< The minimum practical salinity over which this EoS is fitted [PSU]
+    real, optional, intent(out) :: S_max !< The maximum practical salinity over which this EoS is fitted [PSU]
+    real, optional, intent(out) :: p_min !< The minimum pressure over which this EoS is fitted [Pa]
+    real, optional, intent(out) :: p_max !< The maximum pressure over which this EoS is fitted [Pa]
+
+  end subroutine i_EOS_fit_range
+
+end interface
+
+contains
+
+  !> In situ density [kg m-3]
+  real function a_density_fn(this, T, S, pressure, rho_ref)
+    class(EOS_base), intent(in) :: this     !< This EOS
+    real,           intent(in) :: T        !< Potential temperature relative to the surface [degC]
+    real,           intent(in) :: S        !< Salinity [PSU]
+    real,           intent(in) :: pressure !< Pressure [Pa]
+    real, optional, intent(in) :: rho_ref  !< A reference density [kg m-3]
+
+    if (present(rho_ref)) then
+      a_density_fn = this%density_anomaly_elem(T, S, pressure, rho_ref)
+    else
+      a_density_fn = this%density_elem(T, S, pressure)
+    endif
+
+  end function a_density_fn
+
+  !> Calculate the in-situ density for scalar inputs and outputs.
+  subroutine a_calculate_density_scalar(this, T, S, pressure, rho, rho_ref)
+    class(EOS_base), intent(in) :: this     !< This EOS
+    real,           intent(in)  :: T        !< Potential temperature relative to the surface [degC]
+    real,           intent(in)  :: S        !< Salinity [PSU]
+    real,           intent(in)  :: pressure !< Pressure [Pa]
+    real,           intent(out) :: rho      !< In situ density [kg m-3]
+    real, optional, intent(in)  :: rho_ref  !< A reference density [kg m-3]
+
+    if (present(rho_ref)) then
+      rho = this%density_anomaly_elem(T, S, pressure, rho_ref)
+    else
+      rho = this%density_elem(T, S, pressure)
+    endif
+
+  end subroutine a_calculate_density_scalar
+
+  !> Calculate the in-situ density for 1D arraya inputs and outputs.
+  subroutine a_calculate_density_array(this, T, S, pressure, rho, start, npts, rho_ref)
+    class(EOS_base), intent(in) :: this     !< This EOS
+    real, dimension(:), intent(in)  :: T        !< Potential temperature relative to the surface [degC]
+    real, dimension(:), intent(in)  :: S        !< Salinity [PSU]
+    real, dimension(:), intent(in)  :: pressure !< Pressure [Pa]
+    real, dimension(:), intent(out) :: rho      !< In situ density [kg m-3]
+    integer,            intent(in)  :: start    !< The starting index for calculations
+    integer,            intent(in)  :: npts     !< The number of values to calculate
+    real,     optional, intent(in)  :: rho_ref  !< A reference density [kg m-3]
+
+    ! Local variables
+    integer :: js, je
+
+    js = start
+    je = start+npts-1
+
+    if (present(rho_ref)) then
+      rho(js:je) = this%density_anomaly_elem(T(js:je), S(js:je), pressure(js:je), rho_ref)
+    else
+      rho(js:je) = this%density_elem(T(js:je), S(js:je), pressure(js:je))
+    endif
+
+  end subroutine a_calculate_density_array
+
+  !> In situ specific volume [m3 kg-1]
+  real function a_spec_vol_fn(this, T, S, pressure, spv_ref)
+    class(EOS_base), intent(in) :: this     !< This EOS
+    real,           intent(in) :: T        !< Potential temperature relative to the surface [degC]
+    real,           intent(in) :: S        !< Salinity [PSU]
+    real,           intent(in) :: pressure !< Pressure [Pa]
+    real, optional, intent(in) :: spv_ref  !< A reference specific volume [m3 kg-1]
+
+    if (present(spv_ref)) then
+      a_spec_vol_fn = this%spec_vol_anomaly_elem(T, S, pressure, spv_ref)
+    else
+      a_spec_vol_fn = this%spec_vol_elem(T, S, pressure)
+    endif
+
+  end function a_spec_vol_fn
+
+  !> Calculate the in-situ specific volume for scalar inputs and outputs.
+  subroutine a_calculate_spec_vol_scalar(this, T, S, pressure, specvol, spv_ref)
+    class(EOS_base), intent(in) :: this     !< This EOS
+    real,           intent(in)  :: T        !< Potential temperature relative to the surface [degC]
+    real,           intent(in)  :: S        !< Salinity [PSU]
+    real,           intent(in)  :: pressure !< Pressure [Pa]
+    real,           intent(out) :: specvol  !< In situ specific volume [m3 kg-1]
+    real, optional, intent(in)  :: spv_ref  !< A reference specific volume [m3 kg-1]
+
+    if (present(spv_ref)) then
+      specvol = this%spec_vol_anomaly_elem(T, S, pressure, spv_ref)
+    else
+      specvol = this%spec_vol_elem(T, S, pressure)
+    endif
+
+  end subroutine a_calculate_spec_vol_scalar
+
+  !> Calculate the in-situ specific volume for 1D array inputs and outputs.
+  subroutine a_calculate_spec_vol_array(this, T, S, pressure, specvol, start, npts, spv_ref)
+    class(EOS_base), intent(in) :: this     !< This EOS
+    real, dimension(:), intent(in)  :: T        !< Potential temperature relative to the surface [degC]
+    real, dimension(:), intent(in)  :: S        !< Salinity [PSU]
+    real, dimension(:), intent(in)  :: pressure !< Pressure [Pa]
+    real, dimension(:), intent(out) :: specvol  !< In situ specific volume [m3 kg-1]
+    integer,            intent(in)  :: start    !< The starting index for calculations
+    integer,            intent(in)  :: npts     !< The number of values to calculate
+    real,     optional, intent(in)  :: spv_ref  !< A reference specific volume [m3 kg-1]
+
+    ! Local variables
+    integer :: js, je
+
+    js = start
+    je = start+npts-1
+
+    if (present(spv_ref)) then
+      specvol(js:je) = this%spec_vol_anomaly_elem(T(js:je), S(js:je), pressure(js:je), spv_ref)
+    else
+      specvol(js:je) = this%spec_vol_elem(T(js:je), S(js:je), pressure(js:je) )
+    endif
+
+  end subroutine a_calculate_spec_vol_array
+
+  !> Calculate the derivatives of density with respect to temperature, salinity and pressure
+  !! for scalar inputs
+  subroutine a_calculate_density_derivs_scalar(this, T, S, P, drho_dT, drho_dS)
+    class(EOS_base), intent(in) :: this !< This EOS
+    real, intent(in)  :: T       !< Potential temperature referenced to 0 dbar
+    real, intent(in)  :: S       !< Salinity [PSU]
+    real, intent(in)  :: P       !< Pressure [Pa]
+    real, intent(out) :: drho_dT !< The partial derivative of density with potential
+                                 !! temperature [kg m-3 degC-1]
+    real, intent(out) :: drho_dS !< The partial derivative of density with salinity,
+                                 !! in [kg m-3 PSU-1]
+
+    call this%calculate_density_derivs_elem(T, S, P, drho_dt, drho_ds)
+
+  end subroutine a_calculate_density_derivs_scalar
+
+  !> Calculate the derivatives of density with respect to temperature, salinity and pressure
+  !! for array inputs
+  subroutine a_calculate_density_derivs_array(this, T, S, pressure, drho_dT, drho_dS, start, npts)
+    class(EOS_base),    intent(in)  :: this     !< This EOS
+    real, dimension(:), intent(in)  :: T        !< Potential temperature relative to the surface [degC]
+    real, dimension(:), intent(in)  :: S        !< Salinity [PSU]
+    real, dimension(:), intent(in)  :: pressure !< Pressure [Pa]
+    real, dimension(:), intent(out) :: drho_dT  !< The partial derivative of density with potential
+                                                !! temperature [kg m-3 degC-1]
+    real, dimension(:), intent(out) :: drho_dS  !< The partial derivative of density with salinity,
+                                                !! in [kg m-3 PSU-1]
+    integer,            intent(in)  :: start    !< The starting index for calculations
+    integer,            intent(in)  :: npts     !< The number of values to calculate
+
+    ! Local variables
+    integer :: js, je
+
+    js = start
+    je = start+npts-1
+
+    call this%calculate_density_derivs_elem(T(js:je), S(js:je), pressure(js:je), drho_dt(js:je), drho_ds(js:je))
+
+  end subroutine a_calculate_density_derivs_array
+
+  !> Calculate the second derivatives of density with respect to temperature, salinity and pressure
+  !! for scalar inputs
+  subroutine a_calculate_density_second_derivs_scalar(this, T, S, pressure, &
+                     drho_ds_ds, drho_ds_dt, drho_dt_dt, drho_ds_dp, drho_dt_dp)
+    class(EOS_base), intent(in)  :: this       !< This EOS
+    real,            intent(in)  :: T          !< Potential temperature referenced to 0 dbar
+    real,            intent(in)  :: S          !< Salinity [PSU]
+    real,            intent(in)  :: pressure   !< Pressure [Pa]
+    real,            intent(out) :: drho_ds_ds !< Partial derivative of beta with respect
+                                               !! to S [kg m-3 PSU-2]
+    real,            intent(out) :: drho_ds_dt !< Partial derivative of beta with respect
+                                               !! to T [kg m-3 PSU-1 degC-1]
+    real,            intent(out) :: drho_dt_dt !< Partial derivative of alpha with respect
+                                               !! to T [kg m-3 degC-2]
+    real,            intent(out) :: drho_ds_dp !< Partial derivative of beta with respect
+                                               !! to pressure [kg m-3 PSU-1 Pa-1] = [s2 m-2 PSU-1]
+    real,            intent(out) :: drho_dt_dp !< Partial derivative of alpha with respect
+                                               !! to pressure [kg m-3 degC-1 Pa-1] = [s2 m-2 degC-1]
+
+    call this%calculate_density_second_derivs_elem(T, S, pressure, &
+                      drho_ds_ds, drho_ds_dt, drho_dt_dt, drho_ds_dp, drho_dt_dp)
+
+  end subroutine a_calculate_density_second_derivs_scalar
+
+  !> Calculate the second derivatives of density with respect to temperature, salinity and pressure
+  !! for array inputs
+  subroutine a_calculate_density_second_derivs_array(this, T, S, pressure, &
+                     drho_ds_ds, drho_ds_dt, drho_dt_dt, drho_ds_dp, drho_dt_dp, start, npts)
+    class(EOS_base),    intent(in)  :: this       !< This EOS
+    real, dimension(:), intent(in)  :: T          !< Potential temperature referenced to 0 dbar
+    real, dimension(:), intent(in)  :: S          !< Salinity [PSU]
+    real, dimension(:), intent(in)  :: pressure   !< Pressure [Pa]
+    real, dimension(:), intent(out) :: drho_ds_ds !< Partial derivative of beta with respect
+                                                  !! to S [kg m-3 PSU-2]
+    real, dimension(:), intent(out) :: drho_ds_dt !< Partial derivative of beta with respect
+                                                  !! to T [kg m-3 PSU-1 degC-1]
+    real, dimension(:), intent(out) :: drho_dt_dt !< Partial derivative of alpha with respect
+                                                  !! to T [kg m-3 degC-2]
+    real, dimension(:), intent(out) :: drho_ds_dp !< Partial derivative of beta with respect
+                                                  !! to pressure [kg m-3 PSU-1 Pa-1] = [s2 m-2 PSU-1]
+    real, dimension(:), intent(out) :: drho_dt_dp !< Partial derivative of alpha with respect
+                                                  !! to pressure [kg m-3 degC-1 Pa-1] = [s2 m-2 degC-1]
+    integer,            intent(in)  :: start      !< The starting index for calculations
+    integer,            intent(in)  :: npts       !< The number of values to calculate
+
+    ! Local variables
+    integer :: js, je
+
+    js = start
+    je = start+npts-1
+
+    call this%calculate_density_second_derivs_elem(T(js:je), S(js:je), pressure(js:je), &
+                              drho_ds_ds(js:je), drho_ds_dt(js:je), drho_dt_dt(js:je), &
+                              drho_ds_dp(js:je), drho_dt_dp(js:je))
+
+  end subroutine a_calculate_density_second_derivs_array
+
+  !> Calculate the partial derivatives of specific volume with temperature and salinity
+  !! for array inputs
+  subroutine a_calculate_specvol_derivs_array(this, T, S, pressure, dSV_dT, dSV_dS, start, npts)
+    class(EOS_base),    intent(in)    :: this     !< This EOS
+    real, dimension(:), intent(in)    :: T        !< Potential temperature [degC]
+    real, dimension(:), intent(in)    :: S        !< Salinity [PSU]
+    real, dimension(:), intent(in)    :: pressure !< Pressure [Pa]
+    real, dimension(:), intent(inout) :: dSV_dT   !< The partial derivative of specific volume with
+                                                  !! potential temperature [m3 kg-1 degC-1]
+    real, dimension(:), intent(inout) :: dSV_dS   !< The partial derivative of specific volume with
+                                                  !! salinity [m3 kg-1 PSU-1]
+    integer,            intent(in)    :: start    !< The starting index for calculations
+    integer,            intent(in)    :: npts     !< The number of values to calculate
+
+    ! Local variables
+    integer :: js, je
+
+    js = start
+    je = start+npts-1
+
+    call this%calculate_specvol_derivs_elem(T(js:je), S(js:je), pressure(js:je), &
+                                            dSV_dT(js:je), dSV_dS(js:je))
+
+  end subroutine a_calculate_specvol_derivs_array
+
+  !> Compute the in situ density of sea water (rho) and the compressibility (drho/dp == C_sound^-2)
+  !! at the given salinity, potential temperature and pressure for array inputs
+  subroutine a_calculate_compress_array(this, T, S, pressure, rho, drho_dp, start, npts)
+    class(EOS_base),    intent(in)  :: this     !< This EOS
+    real, dimension(:), intent(in)  :: T        !< Potential temperature relative to the surface [degC]
+    real, dimension(:), intent(in)  :: S        !< Salinity [PSU]
+    real, dimension(:), intent(in)  :: pressure !< Pressure [Pa]
+    real, dimension(:), intent(out) :: rho      !< In situ density [kg m-3]
+    real, dimension(:), intent(out) :: drho_dp  !< The partial derivative of density with pressure (or
+                                                !! the inverse of the square of sound speed) [s2 m-2]
+    integer,            intent(in)  :: start    !< The starting index for calculations
+    integer,            intent(in)  :: npts     !< The number of values to calculate
+
+    ! Local variables
+    integer :: js, je
+
+    js = start
+    je = start+npts-1
+
+    call this%calculate_compress_elem(T(js:je), S(js:je), pressure(js:je), &
+                                      rho(js:je), drho_dp(js:je))
+
+  end subroutine a_calculate_compress_array
+
+!> \namespace mom_eos_base_type
+!!
+!! \section section_EOS_base_type Generic EOS type
+!!
+
+end module MOM_EOS_base_type

--- a/src/equation_of_state/MOM_EOS_linear.F90
+++ b/src/equation_of_state/MOM_EOS_linear.F90
@@ -167,7 +167,7 @@ elemental subroutine calculate_specvol_derivs_elem_linear(this, T, S, pressure, 
   real,               intent(inout) :: dSV_dT   !< The partial derivative of specific volume with
                                                 !! potential temperature [m3 kg-1 degC-1]
   ! Local variables
-  real :: I_rho2
+  real :: I_rho2  ! The inverse of density squared [m6 kg-2]
 
   ! Sv = 1.0 / (Rho_T0_S0 + dRho_dT*T + dRho_dS*S)
   I_rho2 = 1.0 / (this%Rho_T0_S0 + (this%dRho_dT*T + this%dRho_dS*S))**2
@@ -317,7 +317,7 @@ subroutine int_density_dz_linear(T, S, z_t, z_b, rho_ref, rho_0_pres, G_e, HI, &
   real :: intz(5)    ! The integrals of density with height at the
                      ! 5 sub-column locations [R L2 T-2 ~> Pa]
   logical :: do_massWeight ! Indicates whether to do mass weighting.
-  real, parameter :: C1_6 = 1.0/6.0, C1_90 = 1.0/90.0  ! Rational constants.
+  real, parameter :: C1_6 = 1.0/6.0, C1_90 = 1.0/90.0  ! Rational constants [nondim].
   integer :: is, ie, js, je, Isq, Ieq, Jsq, Jeq, i, j, m
 
   ! These array bounds work for the indexing convention of the input arrays, but
@@ -488,7 +488,7 @@ subroutine int_spec_vol_dp_linear(T, S, p_t, p_b, alpha_ref, HI, Rho_T0_S0, &
   real :: intp(5)    ! The integrals of specific volume with pressure at the
                      ! 5 sub-column locations [L2 T-2 ~> m2 s-2]
   logical :: do_massWeight ! Indicates whether to do mass weighting.
-  real, parameter :: C1_6 = 1.0/6.0, C1_90 = 1.0/90.0  ! Rational constants.
+  real, parameter :: C1_6 = 1.0/6.0, C1_90 = 1.0/90.0  ! Rational constants [nondim].
   integer :: Isq, Ieq, Jsq, Jeq, ish, ieh, jsh, jeh, i, j, m, halo
 
   Isq = HI%IscB ; Ieq = HI%IecB ; Jsq = HI%JscB ; Jeq = HI%JecB

--- a/src/equation_of_state/MOM_EOS_linear.F90
+++ b/src/equation_of_state/MOM_EOS_linear.F90
@@ -59,7 +59,7 @@ contains
 real elemental function density_elem_linear(this, T, S, pressure)
   class(linear_EOS), intent(in) :: this     !< This EOS
   real, intent(in) :: T        !< Potential temperature relative to the surface [degC]
-  real, intent(in) :: S        !< Salinity [PSU]
+  real, intent(in) :: S        !< Salinity [ppt]
   real, intent(in) :: pressure !< Pressure [Pa]
 
   density_elem_linear = this%Rho_T0_S0 + this%dRho_dT*T + this%dRho_dS*S
@@ -73,7 +73,7 @@ end function density_elem_linear
 real elemental function density_anomaly_elem_linear(this, T, S, pressure, rho_ref)
   class(linear_EOS), intent(in) :: this     !< This EOS
   real, intent(in) :: T        !< Potential temperature relative to the surface [degC]
-  real, intent(in) :: S        !< Salinity [PSU]
+  real, intent(in) :: S        !< Salinity [ppt]
   real, intent(in) :: pressure !< Pressure [Pa]
   real, intent(in) :: rho_ref  !< A reference density [kg m-3]
 
@@ -87,9 +87,8 @@ end function density_anomaly_elem_linear
 !! scalar and array inputs.
 real elemental function spec_vol_elem_linear(this, T, S, pressure)
   class(linear_EOS), intent(in) :: this     !< This EOS
-  real,              intent(in) :: T        !< potential temperature relative to the surface
-                                            !! [degC].
-  real,              intent(in) :: S        !< Salinity [PSU].
+  real,              intent(in) :: T        !< Potential temperature relative to the surface [degC].
+  real,              intent(in) :: S        !< Salinity [ppt].
   real,              intent(in) :: pressure !< Pressure [Pa].
 
   spec_vol_elem_linear = 1.0 / ( this%Rho_T0_S0 + (this%dRho_dT*T + this%dRho_dS*S))
@@ -102,9 +101,8 @@ end function spec_vol_elem_linear
 !! scalar and array inputs.
 real elemental function spec_vol_anomaly_elem_linear(this, T, S, pressure, spv_ref)
   class(linear_EOS), intent(in) :: this     !< This EOS
-  real,              intent(in) :: T        !< potential temperature relative to the surface
-                                            !! [degC].
-  real,              intent(in) :: S        !< Salinity [PSU].
+  real,              intent(in) :: T        !< Potential temperature relative to the surface [degC].
+  real,              intent(in) :: S        !< Salinity [ppt].
   real,              intent(in) :: pressure !< Pressure [Pa].
   real,              intent(in) :: spv_ref  !< A reference specific volume [m3 kg-1].
 
@@ -118,9 +116,8 @@ end function spec_vol_anomaly_elem_linear
 !! with potential temperature and salinity.
 elemental subroutine calculate_density_derivs_elem_linear(this,T, S, pressure, dRho_dT, dRho_dS)
   class(linear_EOS),    intent(in)   :: this     !< This EOS
-  real,    intent(in)  :: T        !< Potential temperature relative to the surface
-                                   !! [degC].
-  real,    intent(in)  :: S        !< Salinity [PSU].
+  real,    intent(in)  :: T        !< Potential temperature relative to the surface [degC].
+  real,    intent(in)  :: S        !< Salinity [ppt].
   real,    intent(in)  :: pressure !< Pressure [Pa].
   real,    intent(out) :: drho_dT  !< The partial derivative of density with
                                    !! potential temperature [kg m-3 degC-1].
@@ -138,16 +135,16 @@ elemental subroutine calculate_density_second_derivs_elem_linear(this, T, S, pre
                                   drho_dS_dS, drho_dS_dT, drho_dT_dT, drho_dS_dP, drho_dT_dP)
   class(linear_EOS), intent(in) :: this !< This EOS
   real, intent(in)    :: T           !< Potential temperature relative to the surface [degC].
-  real, intent(in)    :: S           !< Salinity [PSU].
+  real, intent(in)    :: S           !< Salinity [ppt].
   real, intent(in)    :: pressure    !< pressure [Pa].
   real, intent(inout) :: drho_dS_dS  !< The second derivative of density with
-                                     !! salinity [kg m-3 PSU-2].
+                                     !! salinity [kg m-3 ppt-2].
   real, intent(inout) :: drho_dS_dT  !< The second derivative of density with
                                      !! temperature and salinity [kg m-3 ppt-1 degC-1].
   real, intent(inout) :: drho_dT_dT  !< The second derivative of density with
                                      !! temperature [kg m-3 degC-2].
   real, intent(inout) :: drho_dS_dP  !< The second derivative of density with
-                                     !! salinity and pressure [kg m-3 PSU-1 Pa-1].
+                                     !! salinity and pressure [kg m-3 ppt-1 Pa-1].
   real, intent(inout) :: drho_dT_dP  !< The second derivative of density with
                                      !! temperature and pressure [kg m-3 degC-1 Pa-1].
 
@@ -163,10 +160,10 @@ end subroutine calculate_density_second_derivs_elem_linear
 elemental subroutine calculate_specvol_derivs_elem_linear(this, T, S, pressure, dSV_dT, dSV_dS)
   class(linear_EOS),  intent(in)    :: this     !< This EOS
   real,               intent(in)    :: T        !< Potential temperature [degC]
-  real,               intent(in)    :: S        !< Salinity [PSU]
+  real,               intent(in)    :: S        !< Salinity [ppt]
   real,               intent(in)    :: pressure !< pressure [Pa]
   real,               intent(inout) :: dSV_dS   !< The partial derivative of specific volume with
-                                                !! salinity [m3 kg-1 PSU-1]
+                                                !! salinity [m3 kg-1 ppt-1]
   real,               intent(inout) :: dSV_dT   !< The partial derivative of specific volume with
                                                 !! potential temperature [m3 kg-1 degC-1]
   ! Local variables
@@ -184,9 +181,8 @@ end subroutine calculate_specvol_derivs_elem_linear
 !! salinity, potential temperature, and pressure.
 elemental subroutine calculate_compress_elem_linear(this, T, S, pressure, rho, drho_dp)
   class(linear_EOS), intent(in)  :: this      !< This EOS
-  real,              intent(in)  :: T         !< Potential temperature relative to the surface
-                                              !! [degC].
-  real,              intent(in)  :: S         !< Salinity [PSU].
+  real,              intent(in)  :: T         !< Potential temperature relative to the surface [degC].
+  real,              intent(in)  :: S         !< Salinity [ppt].
   real,              intent(in)  :: pressure  !< pressure [Pa].
   real,              intent(out) :: rho       !< In situ density [kg m-3].
   real,              intent(out) :: drho_dp   !< The partial derivative of density with pressure
@@ -201,7 +197,7 @@ end subroutine calculate_compress_elem_linear
 !> Calculates the layer average specific volumes.
 subroutine avg_spec_vol_linear(T, S, p_t, dp, SpV_avg, start, npts, Rho_T0_S0, dRho_dT, dRho_dS)
   real, dimension(:), intent(in)    :: T         !< Potential temperature [degC]
-  real, dimension(:), intent(in)    :: S         !< Salinity [PSU]
+  real, dimension(:), intent(in)    :: S         !< Salinity [ppt]
   real, dimension(:), intent(in)    :: p_t       !< Pressure at the top of the layer [Pa]
   real, dimension(:), intent(in)    :: dp        !< Pressure change in the layer [Pa]
   real, dimension(:), intent(inout) :: SpV_avg   !< The vertical average specific volume
@@ -268,7 +264,7 @@ subroutine int_density_dz_linear(T, S, z_t, z_b, rho_ref, rho_0_pres, G_e, HI, &
                         intent(in)  :: T         !< Potential temperature relative to the surface
                                                  !! [C ~> degC].
   real, dimension(HI%isd:HI%ied,HI%jsd:HI%jed), &
-                        intent(in)  :: S         !< Salinity [S ~> PSU].
+                        intent(in)  :: S         !< Salinity [S ~> ppt].
   real, dimension(HI%isd:HI%ied,HI%jsd:HI%jed), &
                         intent(in)  :: z_t       !< Height at the top of the layer in depth units [Z ~> m].
   real, dimension(HI%isd:HI%ied,HI%jsd:HI%jed), &
@@ -439,7 +435,7 @@ subroutine int_spec_vol_dp_linear(T, S, p_t, p_b, alpha_ref, HI, Rho_T0_S0, &
                         intent(in)  :: T         !< Potential temperature relative to the surface
                                                  !! [C ~> degC].
   real, dimension(HI%isd:HI%ied,HI%jsd:HI%jed),  &
-                        intent(in)  :: S         !< Salinity [S ~> PSU].
+                        intent(in)  :: S         !< Salinity [S ~> ppt].
   real, dimension(HI%isd:HI%ied,HI%jsd:HI%jed),  &
                         intent(in)  :: p_t       !< Pressure at the top of the layer [R L2 T-2 ~> Pa]
   real, dimension(HI%isd:HI%ied,HI%jsd:HI%jed),  &
@@ -614,7 +610,7 @@ end subroutine int_spec_vol_dp_linear
 subroutine calculate_density_array_linear(this, T, S, pressure, rho, start, npts, rho_ref)
   class(linear_EOS),  intent(in) :: this      !< This EOS
   real, dimension(:), intent(in)  :: T        !< Potential temperature relative to the surface [degC]
-  real, dimension(:), intent(in)  :: S        !< Salinity [PSU]
+  real, dimension(:), intent(in)  :: S        !< Salinity [ppt]
   real, dimension(:), intent(in)  :: pressure !< Pressure [Pa]
   real, dimension(:), intent(out) :: rho      !< In situ density [kg m-3]
   integer,            intent(in)  :: start    !< The starting index for calculations
@@ -640,7 +636,7 @@ end subroutine calculate_density_array_linear
 subroutine calculate_spec_vol_array_linear(this, T, S, pressure, specvol, start, npts, spv_ref)
   class(linear_EOS),  intent(in) :: this      !< This EOS
   real, dimension(:), intent(in)  :: T        !< Potential temperature relative to the surface [degC]
-  real, dimension(:), intent(in)  :: S        !< Salinity [PSU]
+  real, dimension(:), intent(in)  :: S        !< Salinity [ppt]
   real, dimension(:), intent(in)  :: pressure !< Pressure [Pa]
   real, dimension(:), intent(out) :: specvol  !< In situ specific volume [m3 kg-1]
   integer,            intent(in)  :: start    !< The starting index for calculations

--- a/src/framework/MOM_diag_mediator.F90
+++ b/src/framework/MOM_diag_mediator.F90
@@ -14,7 +14,6 @@ use MOM_diag_manager_infra, only : diag_axis_init=>MOM_diag_axis_init, get_MOM_d
 use MOM_diag_manager_infra, only : send_data_infra, MOM_diag_field_add_attribute, EAST, NORTH
 use MOM_diag_manager_infra, only : register_diag_field_infra, register_static_field_infra
 use MOM_diag_manager_infra, only : get_MOM_diag_field_id, DIAG_FIELD_NOT_FOUND
-use MOM_diag_manager_infra, only : diag_send_complete_infra
 use MOM_diag_remap,       only : diag_remap_ctrl, diag_remap_update, diag_remap_calc_hmask
 use MOM_diag_remap,       only : diag_remap_init, diag_remap_end, diag_remap_do_remap
 use MOM_diag_remap,       only : vertically_reintegrate_diag_field, vertically_interpolate_diag_field
@@ -2079,10 +2078,8 @@ end subroutine enable_averages
 subroutine disable_averaging(diag_cs)
   type(diag_ctrl), intent(inout) :: diag_CS !< Structure used to regulate diagnostic output
 
-  call diag_send_complete_infra()
   diag_cs%time_int = 0.0
   diag_cs%ave_enabled = .false.
-
 end subroutine disable_averaging
 
 !> Call this subroutine to determine whether the averaging is

--- a/src/framework/MOM_diag_mediator.F90
+++ b/src/framework/MOM_diag_mediator.F90
@@ -243,7 +243,7 @@ type, public :: diag_ctrl
                                           !! This file is open if available_diag_doc_unit is > 0.
   logical :: diag_as_chksum  !< If true, log chksums in a text file instead of posting diagnostics
   logical :: show_call_tree  !< Display the call tree while running. Set by VERBOSITY level.
-  logical :: grid_space_axes !< If true, diagnostic horizontal coordinates axes are in grid space.
+  logical :: index_space_axes !< If true, diagnostic horizontal coordinates axes are in index space.
 ! The following fields are used for the output of the data.
   integer :: is  !< The start i-index of cell centers within the computational domain
   integer :: ie  !< The end i-index of cell centers within the computational domain
@@ -371,7 +371,7 @@ subroutine set_axes_info(G, GV, US, param_file, diag_cs, set_vertical)
   set_vert = .true. ; if (present(set_vertical)) set_vert = set_vertical
 
 
-  if (diag_cs%grid_space_axes) then
+  if (diag_cs%index_space_axes) then
     allocate(IaxB(G%IsgB:G%IegB))
     do i=G%IsgB, G%IegB
       Iaxb(i)=real(i)
@@ -392,7 +392,7 @@ subroutine set_axes_info(G, GV, US, param_file, diag_cs, set_vertical)
 
   ! Horizontal axes for the native grids
   if (G%symmetric) then
-    if (diag_cs%grid_space_axes) then
+    if (diag_cs%index_space_axes) then
       id_xq = diag_axis_init('iq', IaxB(G%isgB:G%iegB), 'none', 'x', &
           'q point grid-space longitude', G%Domain, position=EAST)
       id_yq = diag_axis_init('jq', JaxB(G%jsgB:G%jegB), 'none', 'y', &
@@ -404,7 +404,7 @@ subroutine set_axes_info(G, GV, US, param_file, diag_cs, set_vertical)
           'q point nominal latitude', G%Domain, position=NORTH)
     endif
   else
-    if (diag_cs%grid_space_axes) then
+    if (diag_cs%index_space_axes) then
       id_xq = diag_axis_init('Iq', IaxB(G%isg:G%ieg), 'none', 'x', &
           'q point grid-space longitude', G%Domain, position=EAST)
       id_yq = diag_axis_init('Jq', JaxB(G%jsg:G%jeg), 'none', 'y', &
@@ -417,7 +417,7 @@ subroutine set_axes_info(G, GV, US, param_file, diag_cs, set_vertical)
     endif
   endif
 
-  if (diag_cs%grid_space_axes) then
+  if (diag_cs%index_space_axes) then
     id_xh = diag_axis_init('ih', iax(G%isg:G%ieg), 'none', 'x', &
         'h point grid-space longitude', G%Domain)
     id_yh = diag_axis_init('jh', jax(G%jsg:G%jeg), 'none', 'y', &
@@ -579,7 +579,7 @@ subroutine set_axes_info(G, GV, US, param_file, diag_cs, set_vertical)
     endif
   enddo
 
-  if (diag_cs%grid_space_axes) then
+  if (diag_cs%index_space_axes) then
     deallocate(IaxB, iax, JaxB, jax)
   endif
   !Define the downsampled axes
@@ -3287,7 +3287,7 @@ subroutine diag_mediator_init(G, GV, US, nz, param_file, diag_cs, doc_file_dir)
                  "robust and accurate forms of mathematically equivalent expressions.", &
                  default=default_answer_date, do_not_log=.not.GV%Boussinesq)
   if (.not.GV%Boussinesq) remap_answer_date = max(remap_answer_date, 20230701)
-  call get_param(param_file, mdl, 'USE_GRID_SPACE_DIAGNOSTIC_AXES', diag_cs%grid_space_axes, &
+  call get_param(param_file, mdl, 'USE_INDEX_DIAGNOSTIC_AXES', diag_cs%index_space_axes, &
                  'If true, use a grid index coordinate convention for diagnostic axes. ',&
                  default=.false.)
 

--- a/src/framework/MOM_diag_mediator.F90
+++ b/src/framework/MOM_diag_mediator.F90
@@ -419,9 +419,9 @@ subroutine set_axes_info(G, GV, US, param_file, diag_cs, set_vertical)
 
   if (diag_cs%grid_space_axes) then
     id_xh = diag_axis_init('ih', iax(G%isg:G%ieg), 'none', 'x', &
-        'h point grid-space longitude', G%Domain, position=EAST)
+        'h point grid-space longitude', G%Domain)
     id_yh = diag_axis_init('jh', jax(G%jsg:G%jeg), 'none', 'y', &
-        'h point grid space latitude', G%Domain, position=NORTH)
+        'h point grid space latitude', G%Domain)
   else
     id_xh = diag_axis_init('xh', G%gridLonT(G%isg:G%ieg), G%x_axis_units, 'x', &
         'h point nominal longitude', G%Domain)

--- a/src/framework/MOM_diag_mediator.F90
+++ b/src/framework/MOM_diag_mediator.F90
@@ -872,43 +872,51 @@ subroutine set_masks_for_axes_dsamp(G, diag_cs)
     do c=1, diag_cs%num_diag_coords
       ! Level/layer h-points in diagnostic coordinate
       axes => diag_cs%remap_axesTL(c)
-      call downsample_mask(axes%mask3d, diag_cs%dsamp(dl)%remap_axesTL(c)%dsamp(dl)%mask3d, dl,G%isc, G%jsc,  &
+      call downsample_mask(axes%mask3d, diag_cs%dsamp(dl)%remap_axesTL(c)%dsamp(dl)%mask3d, &
+              dl, G%isc, G%jsc, G%isd, G%jsd, &
               G%HId2%isc, G%HId2%iec, G%HId2%jsc, G%HId2%jec, G%HId2%isd, G%HId2%ied, G%HId2%jsd, G%HId2%jed)
       diag_cs%dsamp(dl)%remap_axesTL(c)%mask3d => axes%mask3d !set non-downsampled mask
       ! Level/layer u-points in diagnostic coordinate
       axes => diag_cs%remap_axesCuL(c)
-      call downsample_mask(axes%mask3d, diag_cs%dsamp(dl)%remap_axesCuL(c)%dsamp(dl)%mask3d, dl,G%IscB,G%JscB, &
-               G%HId2%IscB,G%HId2%IecB,G%HId2%jsc, G%HId2%jec,G%HId2%IsdB,G%HId2%IedB,G%HId2%jsd, G%HId2%jed)
+      call downsample_mask(axes%mask3d, diag_cs%dsamp(dl)%remap_axesCuL(c)%dsamp(dl)%mask3d, &
+              dl, G%IscB, G%jsc, G%IsdB, G%jsd, &
+              G%HId2%IscB, G%HId2%IecB, G%HId2%jsc, G%HId2%jec, G%HId2%IsdB, G%HId2%IedB, G%HId2%jsd, G%HId2%jed)
       diag_cs%dsamp(dl)%remap_axesCul(c)%mask3d => axes%mask3d !set non-downsampled mask
       ! Level/layer v-points in diagnostic coordinate
       axes => diag_cs%remap_axesCvL(c)
-      call downsample_mask(axes%mask3d, diag_cs%dsamp(dl)%remap_axesCvL(c)%dsamp(dl)%mask3d, dl,G%isc ,G%JscB, &
-              G%HId2%isc ,G%HId2%iec, G%HId2%JscB,G%HId2%JecB,G%HId2%isd ,G%HId2%ied, G%HId2%JsdB,G%HId2%JedB)
+      call downsample_mask(axes%mask3d, diag_cs%dsamp(dl)%remap_axesCvL(c)%dsamp(dl)%mask3d, &
+              dl, G%isc, G%JscB, G%isd, G%JsdB, &
+              G%HId2%isc, G%HId2%iec, G%HId2%JscB, G%HId2%JecB, G%HId2%isd, G%HId2%ied, G%HId2%JsdB, G%HId2%JedB)
       diag_cs%dsamp(dl)%remap_axesCvL(c)%mask3d => axes%mask3d !set non-downsampled mask
       ! Level/layer q-points in diagnostic coordinate
       axes => diag_cs%remap_axesBL(c)
-      call downsample_mask(axes%mask3d, diag_cs%dsamp(dl)%remap_axesBL(c)%dsamp(dl)%mask3d, dl,G%IscB,G%JscB, &
-              G%HId2%IscB,G%HId2%IecB,G%HId2%JscB,G%HId2%JecB,G%HId2%IsdB,G%HId2%IedB,G%HId2%JsdB,G%HId2%JedB)
+      call downsample_mask(axes%mask3d, diag_cs%dsamp(dl)%remap_axesBL(c)%dsamp(dl)%mask3d, &
+              dl, G%IscB, G%JscB, G%IsdB, G%JsdB, &
+              G%HId2%IscB, G%HId2%IecB, G%HId2%JscB, G%HId2%JecB, G%HId2%IsdB, G%HId2%IedB, G%HId2%JsdB, G%HId2%JedB)
       diag_cs%dsamp(dl)%remap_axesBL(c)%mask3d => axes%mask3d !set non-downsampled mask
       ! Interface h-points in diagnostic coordinate (w-point)
       axes => diag_cs%remap_axesTi(c)
-      call downsample_mask(axes%mask3d, diag_cs%dsamp(dl)%remap_axesTi(c)%dsamp(dl)%mask3d, dl,G%isc, G%jsc,  &
+      call downsample_mask(axes%mask3d, diag_cs%dsamp(dl)%remap_axesTi(c)%dsamp(dl)%mask3d,  &
+              dl, G%isc, G%jsc, G%isd, G%jsd, &
               G%HId2%isc, G%HId2%iec, G%HId2%jsc, G%HId2%jec, G%HId2%isd, G%HId2%ied, G%HId2%jsd, G%HId2%jed)
       diag_cs%dsamp(dl)%remap_axesTi(c)%mask3d => axes%mask3d !set non-downsampled mask
       ! Interface u-points in diagnostic coordinate
       axes => diag_cs%remap_axesCui(c)
-      call downsample_mask(axes%mask3d, diag_cs%dsamp(dl)%remap_axesCui(c)%dsamp(dl)%mask3d, dl,G%IscB,G%JscB, &
-              G%HId2%IscB,G%HId2%IecB,G%HId2%jsc, G%HId2%jec,G%HId2%IsdB,G%HId2%IedB,G%HId2%jsd, G%HId2%jed)
+      call downsample_mask(axes%mask3d, diag_cs%dsamp(dl)%remap_axesCui(c)%dsamp(dl)%mask3d,  &
+              dl, G%IscB, G%jsc, G%IsdB, G%jsd, &
+              G%HId2%IscB, G%HId2%IecB, G%HId2%jsc, G%HId2%jec, G%HId2%IsdB, G%HId2%IedB, G%HId2%jsd, G%HId2%jed)
       diag_cs%dsamp(dl)%remap_axesCui(c)%mask3d => axes%mask3d !set non-downsampled mask
       ! Interface v-points in diagnostic coordinate
       axes => diag_cs%remap_axesCvi(c)
-      call downsample_mask(axes%mask3d, diag_cs%dsamp(dl)%remap_axesCvi(c)%dsamp(dl)%mask3d, dl,G%isc ,G%JscB, &
-              G%HId2%isc ,G%HId2%iec, G%HId2%JscB,G%HId2%JecB,G%HId2%isd ,G%HId2%ied, G%HId2%JsdB,G%HId2%JedB)
+      call downsample_mask(axes%mask3d, diag_cs%dsamp(dl)%remap_axesCvi(c)%dsamp(dl)%mask3d,  &
+              dl, G%isc, G%JscB, G%isd, G%JsdB, &
+              G%HId2%isc, G%HId2%iec, G%HId2%JscB, G%HId2%JecB, G%HId2%isd, G%HId2%ied, G%HId2%JsdB, G%HId2%JedB)
       diag_cs%dsamp(dl)%remap_axesCvi(c)%mask3d => axes%mask3d !set non-downsampled mask
       ! Interface q-points in diagnostic coordinate
       axes => diag_cs%remap_axesBi(c)
-      call downsample_mask(axes%mask3d, diag_cs%dsamp(dl)%remap_axesBi(c)%dsamp(dl)%mask3d, dl,G%IscB,G%JscB, &
-              G%HId2%IscB,G%HId2%IecB,G%HId2%JscB,G%HId2%JecB,G%HId2%IsdB,G%HId2%IedB,G%HId2%JsdB,G%HId2%JedB)
+      call downsample_mask(axes%mask3d, diag_cs%dsamp(dl)%remap_axesBi(c)%dsamp(dl)%mask3d,  &
+              dl, G%IscB, G%JscB, G%IsdB, G%JsdB, &
+              G%HId2%IscB, G%HId2%IecB, G%HId2%JscB, G%HId2%JecB, G%HId2%IsdB, G%HId2%IedB, G%HId2%JsdB, G%HId2%JedB)
       diag_cs%dsamp(dl)%remap_axesBi(c)%mask3d => axes%mask3d !set non-downsampled mask
     enddo
   enddo
@@ -3998,13 +4006,13 @@ subroutine downsample_diag_masks_set(G, nz, diag_cs)
 
   do dl=2,MAX_DSAMP_LEV
     ! 2d mask
-    call downsample_mask(G%mask2dT, diag_cs%dsamp(dl)%mask2dT,  dl,G%isc, G%jsc,  &
+    call downsample_mask(G%mask2dT, diag_cs%dsamp(dl)%mask2dT,  dl, G%isc, G%jsc, G%isd, G%jsd, &
             G%HId2%isc, G%HId2%iec, G%HId2%jsc, G%HId2%jec, G%HId2%isd, G%HId2%ied, G%HId2%jsd, G%HId2%jed)
-    call downsample_mask(G%mask2dBu,diag_cs%dsamp(dl)%mask2dBu, dl,G%IscB,G%JscB, &
-            G%HId2%IscB,G%HId2%IecB,G%HId2%JscB,G%HId2%JecB,G%HId2%IsdB,G%HId2%IedB,G%HId2%JsdB,G%HId2%JedB)
-    call downsample_mask(G%mask2dCu,diag_cs%dsamp(dl)%mask2dCu, dl,G%IscB,G%JscB, &
-            G%HId2%IscB,G%HId2%IecB,G%HId2%jsc, G%HId2%jec,G%HId2%IsdB,G%HId2%IedB,G%HId2%jsd, G%HId2%jed)
-    call downsample_mask(G%mask2dCv,diag_cs%dsamp(dl)%mask2dCv, dl,G%isc ,G%JscB, &
+    call downsample_mask(G%mask2dBu, diag_cs%dsamp(dl)%mask2dBu, dl,G%IscB, G%JscB, G%IsdB, G%JsdB, &
+            G%HId2%IscB,G%HId2%IecB, G%HId2%JscB,G%HId2%JecB,G%HId2%IsdB,G%HId2%IedB,G%HId2%JsdB,G%HId2%JedB)
+    call downsample_mask(G%mask2dCu, diag_cs%dsamp(dl)%mask2dCu, dl, G%IscB, G%jsc, G%IsdB, G%jsd, &
+            G%HId2%IscB,G%HId2%IecB, G%HId2%jsc, G%HId2%jec,G%HId2%IsdB,G%HId2%IedB,G%HId2%jsd, G%HId2%jed)
+    call downsample_mask(G%mask2dCv, diag_cs%dsamp(dl)%mask2dCv, dl,G %isc ,G%JscB, G%isd, G%JsdB, &
             G%HId2%isc ,G%HId2%iec, G%HId2%JscB,G%HId2%JecB,G%HId2%isd ,G%HId2%ied, G%HId2%JsdB,G%HId2%JedB)
     ! 3d native masks are needed by diag_manager but the native variables
     ! can only be masked 2d - for ocean points, all layers exists.
@@ -4517,10 +4525,12 @@ end subroutine downsample_field_2d
 !> Allocate and compute the 2d down sampled mask
 !! The masks are down sampled based on a minority rule, i.e., a coarse cell is open (1)
 !! if at least one of the sub-cells are open, otherwise it's closed (0)
-subroutine downsample_mask_2d(field_in, field_out, dl, isc_o, jsc_o, isc_d, iec_d, jsc_d, jec_d, &
-                              isd_d, ied_d, jsd_d, jed_d)
-  real, dimension(:,:), intent(in) :: field_in !< Original field to be down sampled
-  real, dimension(:,:), pointer :: field_out   !< Down sampled field
+subroutine downsample_mask_2d(field_in, field_out, dl, isc_o, jsc_o, isd_o, jsd_o, &
+                              isc_d, iec_d, jsc_d, jec_d, isd_d, ied_d, jsd_d, jed_d)
+  integer, intent(in) :: isd_o !< Original data domain i-start index
+  integer, intent(in) :: jsd_o !< Original data domain j-start index
+  real, dimension(isd_o:,jsd_o:), intent(in) :: field_in !< Original field to be down sampled in arbitrary units [A]
+  real, dimension(:,:), pointer :: field_out   !< Down sampled field mask [nondim]
   integer, intent(in) :: dl    !< Level of down sampling
   integer, intent(in) :: isc_o !< Original i-start index
   integer, intent(in) :: jsc_o !< Original j-start index
@@ -4528,13 +4538,13 @@ subroutine downsample_mask_2d(field_in, field_out, dl, isc_o, jsc_o, isc_d, iec_
   integer, intent(in) :: iec_d !< Computational i-end index of down sampled data
   integer, intent(in) :: jsc_d !< Computational j-start index of down sampled data
   integer, intent(in) :: jec_d !< Computational j-end index of down sampled data
-  integer, intent(in) :: isd_d !< Computational i-start index of down sampled data
-  integer, intent(in) :: ied_d !< Computational i-end index of down sampled data
-  integer, intent(in) :: jsd_d !< Computational j-start index of down sampled data
-  integer, intent(in) :: jed_d !< Computational j-end index of down sampled data
+  integer, intent(in) :: isd_d !< Data domain i-start index of down sampled data
+  integer, intent(in) :: ied_d !< Data domain i-end index of down sampled data
+  integer, intent(in) :: jsd_d !< Data domain j-start index of down sampled data
+  integer, intent(in) :: jed_d !< Data domain j-end index of down sampled data
   ! Locals
   integer :: i,j,ii,jj,i0,j0
-  real    :: tot_non_zero
+  real    :: tot_non_zero  ! The sum of values in the down-scaled cell [A]
   ! down sampled mask = 0 unless the mask value of one of the down sampling cells is 1
   allocate(field_out(isd_d:ied_d,jsd_d:jed_d))
   field_out(:,:) = 0.0
@@ -4552,10 +4562,12 @@ end subroutine downsample_mask_2d
 !> Allocate and compute the 3d down sampled mask
 !! The masks are down sampled based on a minority rule, i.e., a coarse cell is open (1)
 !! if at least one of the sub-cells are open, otherwise it's closed (0)
-subroutine downsample_mask_3d(field_in, field_out, dl, isc_o, jsc_o, isc_d, iec_d, jsc_d, jec_d, &
-                              isd_d, ied_d, jsd_d, jed_d)
-  real, dimension(:,:,:), intent(in) :: field_in !< Original field to be down sampled
-  real, dimension(:,:,:), pointer :: field_out   !< down sampled field
+subroutine downsample_mask_3d(field_in, field_out, dl, isc_o, jsc_o, isd_o, jsd_o, &
+                              isc_d, iec_d, jsc_d, jec_d, isd_d, ied_d, jsd_d, jed_d)
+  integer, intent(in) :: isd_o !< Original data domain i-start index
+  integer, intent(in) :: jsd_o !< Original data domain j-start index
+  real, dimension(isd_o:,jsd_o:,:), intent(in) :: field_in !< Original field to be down sampled in arbitrary units [A]
+  real, dimension(:,:,:), pointer :: field_out   !< down sampled field mask [nondim]
   integer, intent(in) :: dl    !< Level of down sampling
   integer, intent(in) :: isc_o !< Original i-start index
   integer, intent(in) :: jsc_o !< Original j-start index
@@ -4569,7 +4581,7 @@ subroutine downsample_mask_3d(field_in, field_out, dl, isc_o, jsc_o, isc_d, iec_
   integer, intent(in) :: jed_d !< Computational j-end index of down sampled data
   ! Locals
   integer :: i,j,ii,jj,i0,j0,k,ks,ke
-  real    :: tot_non_zero
+  real    :: tot_non_zero  ! The sum of values in the down-scaled cell [A]
   ! down sampled mask = 0 unless the mask value of one of the down sampling cells is 1
   ks = lbound(field_in,3) ; ke = ubound(field_in,3)
   allocate(field_out(isd_d:ied_d,jsd_d:jed_d,ks:ke))

--- a/src/framework/MOM_diag_mediator.F90
+++ b/src/framework/MOM_diag_mediator.F90
@@ -1583,7 +1583,7 @@ subroutine post_data_3d(diag_field_id, field, diag_cs, is_static, mask, alt_h)
       if (id_clock_diag_remap>0) call cpu_clock_begin(id_clock_diag_remap)
       allocate(remapped_field(size(field,1), size(field,2), diag%axes%nz))
       call diag_remap_do_remap(diag_cs%diag_remap_cs(diag%axes%vertical_coordinate_number), &
-              diag_cs%G, diag_cs%GV, h_diag, staggered_in_x, staggered_in_y, &
+              diag_cs%G, diag_cs%GV, diag_cs%US, h_diag, staggered_in_x, staggered_in_y, &
               diag%axes%mask3d, field, remapped_field)
       if (id_clock_diag_remap>0) call cpu_clock_end(id_clock_diag_remap)
       if (associated(diag%axes%mask3d)) then
@@ -3207,7 +3207,7 @@ subroutine diag_mediator_init(G, GV, US, nz, param_file, diag_cs, doc_file_dir)
     allocate(diag_cs%diag_remap_cs(diag_cs%num_diag_coords))
     ! Initialize each diagnostic vertical coordinate
     do i=1, diag_cs%num_diag_coords
-      call diag_remap_init(diag_cs%diag_remap_cs(i), diag_coords(i), answer_date=remap_answer_date)
+      call diag_remap_init(diag_cs%diag_remap_cs(i), diag_coords(i), answer_date=remap_answer_date, GV=GV)
     enddo
     deallocate(diag_coords)
   endif

--- a/src/framework/MOM_diag_mediator.F90
+++ b/src/framework/MOM_diag_mediator.F90
@@ -14,6 +14,7 @@ use MOM_diag_manager_infra, only : diag_axis_init=>MOM_diag_axis_init, get_MOM_d
 use MOM_diag_manager_infra, only : send_data_infra, MOM_diag_field_add_attribute, EAST, NORTH
 use MOM_diag_manager_infra, only : register_diag_field_infra, register_static_field_infra
 use MOM_diag_manager_infra, only : get_MOM_diag_field_id, DIAG_FIELD_NOT_FOUND
+use MOM_diag_manager_infra, only : diag_send_complete_infra
 use MOM_diag_remap,       only : diag_remap_ctrl, diag_remap_update, diag_remap_calc_hmask
 use MOM_diag_remap,       only : diag_remap_init, diag_remap_end, diag_remap_do_remap
 use MOM_diag_remap,       only : vertically_reintegrate_diag_field, vertically_interpolate_diag_field
@@ -2078,6 +2079,7 @@ end subroutine enable_averages
 subroutine disable_averaging(diag_cs)
   type(diag_ctrl), intent(inout) :: diag_CS !< Structure used to regulate diagnostic output
 
+  call diag_send_complete_infra()
   diag_cs%time_int = 0.0
   diag_cs%ave_enabled = .false.
 

--- a/src/framework/MOM_diag_remap.F90
+++ b/src/framework/MOM_diag_remap.F90
@@ -183,7 +183,11 @@ subroutine diag_remap_configure_axes(remap_cs, GV, US, param_file)
   character(len=40)  :: mod  = "MOM_diag_remap" ! This module's name.
   character(len=8)   :: units
   character(len=34)  :: longname
-  real, allocatable, dimension(:) :: interfaces, layers
+  real, allocatable, dimension(:) :: &
+    interfaces, & ! Numerical values for interface vertical coordinates, in unscaled units
+                  ! that might be [m], [kg m-3] or [nondim], depending on the coordinate.
+    layers        ! Numerical values for layer vertical coordinates, in unscaled units
+                  ! that might be [m], [kg m-3] or [nondim], depending on the coordinate.
 
   call initialize_regridding(remap_cs%regrid_cs, GV, US, GV%max_depth, param_file, mod, &
            trim(remap_cs%vertical_coord_name), "DIAG_COORD", trim(remap_cs%diag_coord_name))

--- a/src/framework/MOM_diag_remap.F90
+++ b/src/framework/MOM_diag_remap.F90
@@ -658,8 +658,15 @@ subroutine horizontally_average_diag_field(G, GV, h, staggered_in_x, staggered_i
   logical, dimension(:), intent(inout) :: averaged_mask  !< Mask for horizontally averaged field [nondim]
 
   ! Local variables
-  real, dimension(G%isc:G%iec, G%jsc:G%jec, size(field,3)) :: volume, stuff
-  real, dimension(size(field, 3)) :: vol_sum, stuff_sum ! nz+1 is needed for interface averages
+  real :: volume(G%isc:G%iec, G%jsc:G%jec, size(field,3)) ! The area [m2], volume [m3] or mass [kg] of each cell.
+  real :: stuff(G%isc:G%iec, G%jsc:G%jec, size(field,3))  ! The area, volume or mass-weighted integral of the
+                                             ! field being averaged in each cell, in [m2 A], [m3 A] or [kg A],
+                                             ! depending on the weighting for the averages and whether the
+                                             ! model makes the Boussinesq approximation.
+  real, dimension(size(field, 3)) :: vol_sum   ! The global sum of the areas [m2], volumes [m3] or mass [kg]
+                                               ! in the cells that used in the weighted averages.
+  real, dimension(size(field, 3)) :: stuff_sum ! The global sum of the weighted field in all cells, in
+                                               ! [A m2], [A m3] or [A kg]
   type(EFP_type), dimension(2*size(field,3)) :: sums_EFP ! Sums of volume or stuff by layer
   real :: height  ! An average thickness attributed to an velocity point [H ~> m or kg m-2]
   integer :: i, j, k, nz
@@ -688,7 +695,7 @@ subroutine horizontally_average_diag_field(G, GV, h, staggered_in_x, staggered_i
             I1 = i - G%isdB + 1
             height = 0.5 * (h(i,j,k) + h(i+1,j,k))
             volume(I,j,k) = (G%US%L_to_m**2 * G%areaCu(I,j)) &
-                * (GV%H_to_m * height) * G%mask2dCu(I,j)
+                * (GV%H_to_MKS * height) * G%mask2dCu(I,j)
             stuff(I,j,k) = volume(I,j,k) * field(I1,j,k)
           enddo ; enddo
         endif
@@ -717,7 +724,7 @@ subroutine horizontally_average_diag_field(G, GV, h, staggered_in_x, staggered_i
             J1 = J - G%jsdB + 1
             height = 0.5 * (h(i,j,k) + h(i,j+1,k))
             volume(i,J,k) = (G%US%L_to_m**2 * G%areaCv(i,J)) &
-                * (GV%H_to_m * height) * G%mask2dCv(i,J)
+                * (GV%H_to_MKS * height) * G%mask2dCv(i,J)
             stuff(i,J,k) = volume(i,J,k) * field(i,J1,k)
           enddo ; enddo
         endif
@@ -748,7 +755,7 @@ subroutine horizontally_average_diag_field(G, GV, h, staggered_in_x, staggered_i
         else ! Intensive
           do j=G%jsc, G%jec ; do i=G%isc, G%iec
             volume(i,j,k) = (G%US%L_to_m**2 * G%areaT(i,j)) &
-                * (GV%H_to_m * h(i,j,k)) * G%mask2dT(i,j)
+                * (GV%H_to_MKS * h(i,j,k)) * G%mask2dT(i,j)
             stuff(i,j,k) = volume(i,j,k) * field(i,j,k)
           enddo ; enddo
         endif

--- a/src/framework/MOM_diag_remap.F90
+++ b/src/framework/MOM_diag_remap.F90
@@ -326,7 +326,7 @@ subroutine diag_remap_update(remap_cs, G, GV, US, h, T, S, eqn_of_state, h_targe
     elseif (remap_cs%vertical_coord == coordinateMode('RHO')) then
       call build_rho_column(get_rho_CS(remap_cs%regrid_cs), GV%ke, &
                             GV%Z_to_H*(G%bathyT(i,j)+G%Z_ref), h(i,j,:), T(i,j,:), S(i,j,:), &
-                            eqn_of_state, zInterfaces, h_neglect, h_neglect_edge)
+                            eqn_of_state, zInterfaces, h_neglect=h_neglect, h_neglect_edge=h_neglect_edge)
     elseif (remap_cs%vertical_coord == coordinateMode('HYCOM1')) then
 !     call build_hycom1_column(remap_cs%regrid_cs, nz, &
 !                           GV%Z_to_H*(G%bathyT(i,j)+G%Z_ref), sum(h(i,j,:)), zInterfaces)

--- a/src/framework/MOM_diag_remap.F90
+++ b/src/framework/MOM_diag_remap.F90
@@ -103,7 +103,7 @@ contains
 
 !> Initialize a diagnostic remapping type with the given vertical coordinate.
 subroutine diag_remap_init(remap_cs, coord_tuple, answer_date, GV)
-  type(diag_remap_ctrl), intent(inout) :: remap_cs !< Diag remapping control structure
+  type(diag_remap_ctrl), intent(inout) :: remap_cs    !< Diag remapping control structure
   character(len=*),      intent(in)    :: coord_tuple !< A string in form of
                                                       !! MODULE_SUFFIX PARAMETER_SUFFIX COORDINATE_NAME
   integer,               intent(in)    :: answer_date !< The vintage of the order of arithmetic and expressions
@@ -118,10 +118,11 @@ subroutine diag_remap_init(remap_cs, coord_tuple, answer_date, GV)
   remap_cs%vertical_coord_name = trim(extractWord(coord_tuple, 3))
   remap_cs%vertical_coord = coordinateMode(remap_cs%vertical_coord_name)
   remap_cs%Z_based_coord = .false.
-  ! if ( & ! (.not.(GV%Boussinesq .or. GV%semi_Boussinesq)) .and. &
-  !      ((remap_cs%vertical_coord == coordinateMode('ZSTAR')) .or. &
-  !      (remap_cs%vertical_coord == coordinateMode('SIGMA'))) ) &
-  !   remap_cs%Z_based_coord = .true.
+  if (.not.(GV%Boussinesq .or. GV%semi_Boussinesq) .and. &
+      ((remap_cs%vertical_coord == coordinateMode('ZSTAR')) .or. &
+       (remap_cs%vertical_coord == coordinateMode('SIGMA')) .or. &
+       (remap_cs%vertical_coord == coordinateMode('RHO'))) ) &
+    remap_cs%Z_based_coord = .true.
 
   remap_cs%configured = .false.
   remap_cs%initialized = .false.
@@ -295,7 +296,7 @@ subroutine diag_remap_update(remap_cs, G, GV, US, h, T, S, eqn_of_state, h_targe
     enddo ; enddo
   else
     h_neglect = set_h_neglect(GV, remap_cs%answer_date, h_neglect_edge)
-    Z_unit_scale = GV%Z_to_H
+    Z_unit_scale = GV%Z_to_H  ! This branch is not used in fully non-Boussinesq mode.
     do j=js-1,je+1 ; do i=is-1,ie+1
       bottom_depth(i,j) = GV%Z_to_H * (G%bathyT(i,j) + G%Z_ref)
     enddo ; enddo

--- a/src/framework/MOM_diag_remap.F90
+++ b/src/framework/MOM_diag_remap.F90
@@ -15,42 +15,14 @@
 !!    the diagnostic is written out.
 
 
-! NOTE: In the following functions, the fields are passed using 1-based
-! indexing, which requires special handling within the grid index loops.
+! NOTE: In the following functions, the fields are initially passed using 1-based
+! indexing, which are then passed to separate private internal routines that shift
+! the indexing to use the same indexing conventions used elsewhere in the MOM6 code.
 !
-!   * diag_remap_do_remap
-!   * vertically_reintegrate_diag_field
-!   * vertically_interpolate_diag_field
-!   * horizontally_average_diag_field
-!
-! Symmetric grids add an additional row of western and southern points to u-
-! and v-grids.  Non-symmetric grids are 1-based and symmetric grids are
-! zero-based, allowing the same expressions to be used when accessing the
-! fields.  But if u- or v-points become 1-indexed, as in these functions, then
-! the stencils must be re-assessed.
-!
-! For interpolation between h and u grids, we use the following relations:
-!
-!   h->u: f_u(ig) = 0.5 * (f_h( ig ) + f_h(ig+1))
-!         f_u(i1) = 0.5 * (f_h(i1-1) + f_h( i1 ))
-!
-!   u->h: f_h(ig) = 0.5 * (f_u(ig-1) + f_u( ig ))
-!         f_h(i1) = 0.5 * (f_u( i1 ) + f_u(i1+1))
-!
-! where ig is the grid index and i1 is the 1-based index.  That is, a 1-based
-! u-point is ahead of its matching h-point in non-symmetric mode, but behind
-! its matching h-point in non-symmetric mode.
-!
-! We can combine these expressions by applying to ig a -1 shift on u-grids and
-! a +1 shift on h-grids in symmetric mode.
-!
-! We do not adjust the h-point indices, since they are assumed to be 1-based.
-! This is only correct when global indexing is disabled.  If global indexing is
-! enabled, then all indices will need to be defined relative to the data
-! domain.
-!
-! Finally, note that the mask input fields are pointers to arrays which are
-! zero-indexed, and do not need any corrections over grid index loops.
+!   * diag_remap_do_remap, which calls do_remap
+!   * vertically_reintegrate_diag_field, which calls vertically_reintegrate_field
+!   * vertically_interpolate_diag_field, which calls vertically_interpolate_field
+!   * horizontally_average_diag_field, which calls horizontally_average_field
 
 
 module MOM_diag_remap
@@ -70,10 +42,9 @@ use MOM_verticalGrid,     only : verticalGrid_type
 use MOM_EOS,              only : EOS_type
 use MOM_remapping,        only : remapping_CS, initialize_remapping, remapping_core_h
 use MOM_remapping,        only : interpolate_column, reintegrate_column
-use MOM_regridding,       only : regridding_CS, initialize_regridding
-use MOM_regridding,       only : end_regridding
+use MOM_regridding,       only : regridding_CS, initialize_regridding, end_regridding
 use MOM_regridding,       only : set_regrid_params, get_regrid_size
-use MOM_regridding,       only : getCoordinateInterfaces
+use MOM_regridding,       only : getCoordinateInterfaces, set_h_neglect, set_dz_neglect
 use MOM_regridding,       only : get_zlike_CS, get_sigma_CS, get_rho_CS
 use regrid_consts,        only : coordinateMode
 use coord_zlike,          only : build_zstar_column
@@ -82,6 +53,8 @@ use coord_rho,            only : build_rho_column
 
 
 implicit none ; private
+
+#include "MOM_memory.h"
 
 public diag_remap_ctrl
 public diag_remap_init, diag_remap_end, diag_remap_update, diag_remap_do_remap
@@ -104,14 +77,19 @@ type :: diag_remap_ctrl
   logical :: used = .false.  !< Whether this coordinate actually gets used.
   integer :: vertical_coord = 0 !< The vertical coordinate that we remap to
   character(len=10) :: vertical_coord_name ='' !< The coordinate name as understood by ALE
+  logical :: Z_based_coord = .false.  !< If true, this coordinate is based on remapping of
+                                      !! geometric distances across layers (in [Z ~> m]) rather
+                                      !! than layer thicknesses (in [H ~> m or kg m-2]).  This
+                                      !! distinction only matters in non-Boussinesq mode.
   character(len=16) :: diag_coord_name = '' !< A name for the purpose of run-time parameters
   character(len=8) :: diag_module_suffix = '' !< The suffix for the module to appear in diag_table
   type(remapping_CS) :: remap_cs !< Remapping control structure use for this axes
   type(regridding_CS) :: regrid_cs !< Regridding control structure that defines the coordinates for this axes
   integer :: nz = 0 !< Number of vertical levels used for remapping
-  real, dimension(:,:,:), allocatable :: h !< Remap grid thicknesses [H ~> m or kg m-2]
-  real, dimension(:,:,:), allocatable :: h_extensive !< Remap grid thicknesses for extensive
-                                           !! variables [H ~> m or kg m-2]
+  real, dimension(:,:,:), allocatable :: h !< Remap grid thicknesses in [H ~> m or kg m-2] or
+                                      !! vertical extents in [Z ~> m], depending on the setting of Z_based_coord.
+  real, dimension(:,:,:), allocatable :: h_extensive !< Remap grid thicknesses in [H ~> m or kg m-2] or
+                                      !! vertical extents in [Z ~> m] for remapping extensive variables
   integer :: interface_axes_id = 0 !< Vertical axes id for remapping at interfaces
   integer :: layer_axes_id = 0 !< Vertical axes id for remapping on layers
   integer :: answer_date      !< The vintage of the order of arithmetic and expressions
@@ -124,7 +102,7 @@ end type diag_remap_ctrl
 contains
 
 !> Initialize a diagnostic remapping type with the given vertical coordinate.
-subroutine diag_remap_init(remap_cs, coord_tuple, answer_date)
+subroutine diag_remap_init(remap_cs, coord_tuple, answer_date, GV)
   type(diag_remap_ctrl), intent(inout) :: remap_cs !< Diag remapping control structure
   character(len=*),      intent(in)    :: coord_tuple !< A string in form of
                                                       !! MODULE_SUFFIX PARAMETER_SUFFIX COORDINATE_NAME
@@ -132,11 +110,19 @@ subroutine diag_remap_init(remap_cs, coord_tuple, answer_date)
                                                       !! to use for remapping.  Values below 20190101 recover
                                                       !! the answers from 2018, while higher values use more
                                                       !! robust forms of the same remapping expressions.
+  type(verticalGrid_type), intent(in)  :: GV          !< The ocean vertical grid structure, used here to evaluate
+                                                      !! whether the model is in non-Boussinesq mode.
 
   remap_cs%diag_module_suffix = trim(extractWord(coord_tuple, 1))
   remap_cs%diag_coord_name = trim(extractWord(coord_tuple, 2))
   remap_cs%vertical_coord_name = trim(extractWord(coord_tuple, 3))
   remap_cs%vertical_coord = coordinateMode(remap_cs%vertical_coord_name)
+  remap_cs%Z_based_coord = .false.
+  ! if ( & ! (.not.(GV%Boussinesq .or. GV%semi_Boussinesq)) .and. &
+  !      ((remap_cs%vertical_coord == coordinateMode('ZSTAR')) .or. &
+  !      (remap_cs%vertical_coord == coordinateMode('SIGMA'))) ) &
+  !   remap_cs%Z_based_coord = .true.
+
   remap_cs%configured = .false.
   remap_cs%initialized = .false.
   remap_cs%used = .false.
@@ -274,31 +260,46 @@ subroutine diag_remap_update(remap_cs, G, GV, US, h, T, S, eqn_of_state, h_targe
   type(ocean_grid_type),   pointer    :: G  !< The ocean's grid type
   type(verticalGrid_type), intent(in) :: GV !< ocean vertical grid structure
   type(unit_scale_type),   intent(in) :: US !< A dimensional unit scaling type
-  real, dimension(:,:,:),  intent(in) :: h  !< New thickness [H ~> m or kg m-2]
-  real, dimension(:,:,:),  intent(in) :: T  !< New temperatures [C ~> degC]
-  real, dimension(:,:,:),  intent(in) :: S  !< New salinities [S ~> ppt]
+  real, dimension(SZI_(G),SZJ_(G),SZK_(GV)), &
+                           intent(in) :: h  !< New thickness in [H ~> m or kg m-2] or [Z ~> m], depending
+                                            !! on the value of remap_cs%Z_based_coord
+  real, dimension(SZI_(G),SZJ_(G),SZK_(GV)), &
+                           intent(in) :: T  !< New temperatures [C ~> degC]
+  real, dimension(SZI_(G),SZJ_(G),SZK_(GV)), &
+                           intent(in) :: S  !< New salinities [S ~> ppt]
   type(EOS_type),          intent(in) :: eqn_of_state !< A pointer to the equation of state
-  real, dimension(:,:,:),  intent(inout) :: h_target  !< The new diagnostic thicknesses [H ~> m or kg m-2]
+  real, dimension(SZI_(G),SZJ_(G),remap_cs%nz), &
+                        intent(inout) :: h_target  !< The new diagnostic thicknesses in [H ~> m or kg m-2]
+                                            !! or [Z ~> m], depending on the value of remap_cs%Z_based_coord
 
   ! Local variables
-  real, dimension(remap_cs%nz + 1) :: zInterfaces ! Interface positions [H ~> m or kg m-2]
-  real :: h_neglect, h_neglect_edge ! Negligible thicknesses [H ~> m or kg m-2]
-  integer :: i, j, k, nz
+  real, dimension(remap_cs%nz + 1) :: zInterfaces ! Interface positions [H ~> m or kg m-2] or [Z ~> m]
+  real :: h_neglect, h_neglect_edge ! Negligible thicknesses [H ~> m or kg m-2] or [Z ~> m]
+  real :: bottom_depth(SZI_(G),SZJ_(G)) ! The depth of the bathymetry in [H ~> m or kg m-2] or [Z ~> m]
+  real :: h_tot(SZI_(G),SZJ_(G))        ! The total thickness of the water column [H ~> m or kg m-2] or [Z ~> m]
+  real :: Z_unit_scale   ! A conversion factor from Z-units the internal work units in this routine,
+                         ! in units of [H Z-1 ~> 1 or kg m-3] or [nondim], depending on remap_cs%Z_based_coord.
+  integer :: i, j, k, is, ie, js, je, nz
 
-  ! Note that coordinateMode('LAYER') is never 'configured' so will
-  ! always return here.
-  if (.not. remap_cs%configured) then
-    return
-  endif
+  ! Note that coordinateMode('LAYER') is never 'configured' so will always return here.
+  if (.not. remap_cs%configured) return
 
-  if (remap_cs%answer_date >= 20190101) then
-    h_neglect = GV%H_subroundoff ; h_neglect_edge = GV%H_subroundoff
-  elseif (GV%Boussinesq) then
-    h_neglect = GV%m_to_H*1.0e-30 ; h_neglect_edge = GV%m_to_H*1.0e-10
+  is = G%isc ; ie = G%iec ; js = G%jsc ; je = G%jec
+
+  ! Set the bottom depth and negligible thicknesses used in the coordinate remapping in the right units.
+  if (remap_cs%Z_based_coord) then
+    h_neglect = set_dz_neglect(GV, US, remap_cs%answer_date, h_neglect_edge)
+    Z_unit_scale = 1.0
+    do j=js-1,je+1 ; do i=is-1,ie+1
+      bottom_depth(i,j) = G%bathyT(i,j) + G%Z_ref
+    enddo ; enddo
   else
-    h_neglect = GV%kg_m2_to_H*1.0e-30 ; h_neglect_edge = GV%kg_m2_to_H*1.0e-10
+    h_neglect = set_h_neglect(GV, remap_cs%answer_date, h_neglect_edge)
+    Z_unit_scale = GV%Z_to_H
+    do j=js-1,je+1 ; do i=is-1,ie+1
+      bottom_depth(i,j) = GV%Z_to_H * (G%bathyT(i,j) + G%Z_ref)
+    enddo ; enddo
   endif
-  nz = remap_cs%nz
 
   if (.not. remap_cs%initialized) then
     ! Initialize remapping and regridding on the first call
@@ -307,145 +308,203 @@ subroutine diag_remap_update(remap_cs, G, GV, US, h, T, S, eqn_of_state, h_targe
     remap_cs%initialized = .true.
   endif
 
+  ! Calculate the total thickness of the water column, if it is needed,
+  if ((remap_cs%vertical_coord == coordinateMode('ZSTAR')) .or. &
+      (remap_cs%vertical_coord == coordinateMode('SIGMA'))) then
+    if (remap_CS%answer_date >= 20240201) then
+      ! Avoid using sum to have a specific order for the vertical sums.
+      ! For some compilers, the explicit expression gives the same answers as the sum function.
+      h_tot(:,:) = 0.0
+      do k=1,GV%ke ; do j=js-1,je+1 ; do i=is-1,ie+1
+        h_tot(i,j) = h_tot(i,j) + h(i,j,k)
+      enddo ; enddo ; enddo
+    else
+      do j=js-1,je+1 ; do i=is-1,ie+1
+        h_tot(i,j) = sum(h(i,j,:))
+      enddo ; enddo
+    endif
+  endif
+
   ! Calculate remapping thicknesses for different target grids based on
   ! nominal/target interface locations. This happens for every call on the
   ! assumption that h, T, S has changed.
-  do j=G%jsc-1, G%jec+1 ; do i=G%isc-1, G%iec+1
-    if (G%mask2dT(i,j)==0.) then
-      h_target(i,j,:) = 0.
-      cycle
-    endif
+  h_target(:,:,:) = 0.0
 
-    if (remap_cs%vertical_coord == coordinateMode('ZSTAR')) then
+  nz = remap_cs%nz
+  if (remap_cs%vertical_coord == coordinateMode('ZSTAR')) then
+    do j=js-1,je+1 ; do i=is-1,ie+1 ; if (G%mask2dT(i,j) > 0.0) then
+      ! This function call can work with the last 4 arguments all in units of [Z ~> m] or [H ~> kg m-2].
       call build_zstar_column(get_zlike_CS(remap_cs%regrid_cs), &
-                              GV%Z_to_H*(G%bathyT(i,j)+G%Z_ref), sum(h(i,j,:)), &
-                              zInterfaces, zScale=GV%Z_to_H)
-    elseif (remap_cs%vertical_coord == coordinateMode('SIGMA')) then
+                              bottom_depth(i,j), h_tot(i,j), zInterfaces, zScale=Z_unit_scale)
+      do k=1,nz ; h_target(i,j,k) = zInterfaces(K) - zInterfaces(K+1) ; enddo
+    endif ; enddo ; enddo
+  elseif (remap_cs%vertical_coord == coordinateMode('SIGMA')) then
+    do j=js-1, je+1 ; do i=is-1,ie+1 ; if (G%mask2dT(i,j) > 0.0) then
+      ! This function call can work with the last 3 arguments all in units of [Z ~> m] or [H ~> kg m-2].
       call build_sigma_column(get_sigma_CS(remap_cs%regrid_cs), &
-                              GV%Z_to_H*(G%bathyT(i,j)+G%Z_ref), sum(h(i,j,:)), zInterfaces)
-    elseif (remap_cs%vertical_coord == coordinateMode('RHO')) then
+                              bottom_depth(i,j), h_tot(i,j), zInterfaces)
+      do k=1,nz ; h_target(i,j,k) = zInterfaces(K) - zInterfaces(K+1) ; enddo
+    endif ; enddo ; enddo
+  elseif (remap_cs%vertical_coord == coordinateMode('RHO')) then
+    do j=js-1,je+1 ; do i=is-1,ie+1 ; if (G%mask2dT(i,j) > 0.0) then
+      ! This function call can work with 5 arguments in units of [Z ~> m] or [H ~> kg m-2].
       call build_rho_column(get_rho_CS(remap_cs%regrid_cs), GV%ke, &
-                            GV%Z_to_H*(G%bathyT(i,j)+G%Z_ref), h(i,j,:), T(i,j,:), S(i,j,:), &
+                            bottom_depth(i,j), h(i,j,:), T(i,j,:), S(i,j,:), &
                             eqn_of_state, zInterfaces, h_neglect=h_neglect, h_neglect_edge=h_neglect_edge)
-    elseif (remap_cs%vertical_coord == coordinateMode('HYCOM1')) then
-!     call build_hycom1_column(remap_cs%regrid_cs, nz, &
-!                           GV%Z_to_H*(G%bathyT(i,j)+G%Z_ref), sum(h(i,j,:)), zInterfaces)
-      call MOM_error(FATAL,"diag_remap_update: HYCOM1 coordinate not coded for diagnostics yet!")
-    endif
-    do k = 1,nz
-      h_target(i,j,k) = zInterfaces(k) - zInterfaces(k+1)
-    enddo
-  enddo ; enddo
+      do k=1,nz ; h_target(i,j,k) = zInterfaces(K) - zInterfaces(K+1) ; enddo
+    endif ; enddo ; enddo
+  elseif (remap_cs%vertical_coord == coordinateMode('HYCOM1')) then
+    call MOM_error(FATAL,"diag_remap_update: HYCOM1 coordinate not coded for diagnostics yet!")
+!    do j=js-1,je+1 ; do i=is-1,ie+1 ; if (G%mask2dT(i,j) > 0.0) then
+!      call build_hycom1_column(remap_cs%regrid_cs, nz, &
+!                           bottom_depth(i,j), h_tot(i,j), zInterfaces)
+!      do k=1,nz ; h_target(i,j,k) = zInterfaces(K) - zInterfaces(K+1) ; enddo
+!    endif ; enddo ; enddo
+  endif
 
 end subroutine diag_remap_update
 
 !> Remap diagnostic field to alternative vertical grid.
-subroutine diag_remap_do_remap(remap_cs, G, GV, h, staggered_in_x, staggered_in_y, &
+subroutine diag_remap_do_remap(remap_cs, G, GV, US, h, staggered_in_x, staggered_in_y, &
                                mask, field, remapped_field)
-  type(diag_remap_ctrl),   intent(in) :: remap_cs !< Diagnostic coodinate control structure
-  type(ocean_grid_type),   intent(in) :: G  !< Ocean grid structure
-  type(verticalGrid_type), intent(in) :: GV !< ocean vertical grid structure
-  real, dimension(:,:,:),  intent(in) :: h  !< The current thicknesses [H ~> m or kg m-2]
-  logical,                 intent(in) :: staggered_in_x !< True is the x-axis location is at u or q points
-  logical,                 intent(in) :: staggered_in_y !< True is the y-axis location is at v or q points
-  real, dimension(:,:,:),  pointer    :: mask !< A mask for the field [nondim]
-  real, dimension(:,:,:),  intent(in) :: field(:,:,:) !< The diagnostic field to be remapped [A]
-  real, dimension(:,:,:),  intent(inout) :: remapped_field !< Field remapped to new coordinate [A]
+  type(diag_remap_ctrl),   intent(in)  :: remap_cs !< Diagnostic coordinate control structure
+  type(ocean_grid_type),   intent(in)  :: G  !< Ocean grid structure
+  type(verticalGrid_type), intent(in)  :: GV !< ocean vertical grid structure
+  type(unit_scale_type),   intent(in)  :: US !< A dimensional unit scaling type
+  real, dimension(:,:,:),  intent(in)  :: h  !< The current thicknesses [H ~> m or kg m-2] or [Z ~> m],
+                                             !! depending on the value of remap_CS%Z_based_coord
+  logical,                 intent(in)  :: staggered_in_x !< True is the x-axis location is at u or q points
+  logical,                 intent(in)  :: staggered_in_y !< True is the y-axis location is at v or q points
+  real, dimension(:,:,:),  pointer     :: mask !< A mask for the field [nondim].
+  real, dimension(:,:,:),  intent(in)  :: field(:,:,:) !< The diagnostic field to be remapped [A]
+  real, dimension(:,:,:),  intent(out) :: remapped_field !< Field remapped to new coordinate [A]
+
   ! Local variables
-  real, dimension(remap_cs%nz) :: h_dest ! Destination thicknesses [H ~> m or kg m-2]
-  real, dimension(size(h,3)) :: h_src    ! A column of source thicknesses [H ~> m or kg m-2]
-  real :: h_neglect, h_neglect_edge ! Negligible thicknesses [H ~> m or kg m-2]
-  integer :: nz_src, nz_dest
-  integer :: i, j                   !< Grid index
-  integer :: i1, j1                 !< 1-based index
-  integer :: i_lo, i_hi, j_lo, j_hi !< (uv->h) interpolation indices
-  integer :: shift                  !< Symmetric offset for 1-based indexing
+  integer :: isdf, jsdf !< The starting i- and j-indices in memory for field
 
   call assert(remap_cs%initialized, 'diag_remap_do_remap: remap_cs not initialized.')
   call assert(size(field, 3) == size(h, 3), &
               'diag_remap_do_remap: Remap field and thickness z-axes do not match.')
 
-  if (remap_cs%answer_date >= 20190101) then
-    h_neglect = GV%H_subroundoff ; h_neglect_edge = GV%H_subroundoff
-  elseif (GV%Boussinesq) then
-    h_neglect = GV%m_to_H*1.0e-30 ; h_neglect_edge = GV%m_to_H*1.0e-10
+  isdf = G%isd ; if (staggered_in_x) Isdf = G%IsdB
+  jsdf = G%jsd ; if (staggered_in_y) Jsdf = G%JsdB
+
+  if (associated(mask)) then
+    call do_remap(remap_cs, G, GV, US, isdf, jsdf, h, staggered_in_x, staggered_in_y, &
+                  field, remapped_field, mask(:,:,1))
   else
-    h_neglect = GV%kg_m2_to_H*1.0e-30 ; h_neglect_edge = GV%kg_m2_to_H*1.0e-10
+    call do_remap(remap_cs, G, GV, US, isdf, jsdf, h, staggered_in_x, staggered_in_y, &
+                  field, remapped_field)
+  endif
+
+end subroutine diag_remap_do_remap
+
+!> The internal routine to remap a diagnostic field to an alternative vertical grid.
+subroutine do_remap(remap_cs, G, GV, US, isdf, jsdf, h, staggered_in_x, staggered_in_y, &
+                    field, remapped_field, mask)
+  type(diag_remap_ctrl),   intent(in)  :: remap_cs !< Diagnostic coordinate control structure
+  type(ocean_grid_type),   intent(in)  :: G  !< Ocean grid structure
+  type(verticalGrid_type), intent(in)  :: GV !< ocean vertical grid structure
+  type(unit_scale_type),   intent(in)  :: US !< A dimensional unit scaling type
+  integer,                 intent(in)  :: isdf !< The starting i-index in memory for field
+  integer,                 intent(in)  :: jsdf !< The starting j-index in memory for field
+  real, dimension(G%isd:,G%jsd:,:), &
+                           intent(in)  :: h  !< The current thicknesses [H ~> m or kg m-2] or [Z ~> m],
+                                             !! depending on the value of remap_CS%Z_based_coord
+  logical,                 intent(in)  :: staggered_in_x !< True is the x-axis location is at u or q points
+  logical,                 intent(in)  :: staggered_in_y !< True is the y-axis location is at v or q points
+  real, dimension(isdf:,jsdf:,:), &
+                           intent(in)  :: field !< The diagnostic field to be remapped [A]
+  real, dimension(isdf:,jsdf:,:), &
+                           intent(out) :: remapped_field !< Field remapped to new coordinate [A]
+  real, dimension(isdf:,jsdf:), &
+                 optional, intent(in)  :: mask !< A mask for the field [nondim]
+
+  ! Local variables
+  real, dimension(remap_cs%nz) :: h_dest ! Destination thicknesses [H ~> m or kg m-2] or [Z ~> m]
+  real, dimension(size(h,3)) :: h_src    ! A column of source thicknesses [H ~> m or kg m-2] or [Z ~> m]
+  real :: h_neglect, h_neglect_edge ! Negligible thicknesses [H ~> m or kg m-2] or [Z ~> m]
+  integer :: nz_src, nz_dest        ! The number of layers on the native and remapped grids
+  integer :: i, j                   ! Grid index
+
+  if (remap_cs%Z_based_coord) then
+    h_neglect = set_dz_neglect(GV, US, remap_cs%answer_date, h_neglect_edge)
+  else
+    h_neglect = set_h_neglect(GV, remap_cs%answer_date, h_neglect_edge)
   endif
 
   nz_src = size(field,3)
   nz_dest = remap_cs%nz
   remapped_field(:,:,:) = 0.
 
-  ! Symmetric grid offset under 1-based indexing; see header for details.
-  shift = 0 ; if (G%symmetric) shift = 1
-
   if (staggered_in_x .and. .not. staggered_in_y) then
     ! U-points
-    do j=G%jsc, G%jec
-      do I=G%iscB, G%iecB
-        I1 = I - G%isdB + 1
-        i_lo = I1 - shift; i_hi = i_lo + 1
-        if (associated(mask)) then
-          if (mask(I,j,1) == 0.) cycle
-        endif
-        h_src(:) = 0.5 * (h(i_lo,j,:) + h(i_hi,j,:))
-        h_dest(:) = 0.5 * (remap_cs%h(i_lo,j,:) + remap_cs%h(i_hi,j,:))
-        call remapping_core_h(remap_cs%remap_cs, &
-                              nz_src, h_src(:), field(I1,j,:), &
-                              nz_dest, h_dest(:), remapped_field(I1,j,:), &
-                              h_neglect, h_neglect_edge)
-      enddo
-    enddo
+    if (present(mask)) then
+      do j=G%jsc,G%jec ; do I=G%IscB,G%IecB ; if (mask(I,j) > 0.) then
+        h_src(:) = 0.5 * (h(i,j,:) + h(i+1,j,:))
+        h_dest(:) = 0.5 * (remap_cs%h(i,j,:) + remap_cs%h(i+1,j,:))
+        call remapping_core_h(remap_cs%remap_cs, nz_src, h_src(:), field(I,j,:), &
+                              nz_dest, h_dest(:), remapped_field(I,j,:), h_neglect, h_neglect_edge)
+      endif ; enddo ; enddo
+    else
+      do j=G%jsc,G%jec ; do I=G%IscB,G%IecB
+        h_src(:) = 0.5 * (h(i,j,:) + h(i+1,j,:))
+        h_dest(:) = 0.5 * (remap_cs%h(i,j,:) + remap_cs%h(i+1,j,:))
+        call remapping_core_h(remap_cs%remap_cs, nz_src, h_src(:), field(I,j,:), &
+                              nz_dest, h_dest(:), remapped_field(I,j,:), h_neglect, h_neglect_edge)
+      enddo ; enddo
+    endif
   elseif (staggered_in_y .and. .not. staggered_in_x) then
     ! V-points
-    do J=G%jscB, G%jecB
-      J1 = J - G%jsdB + 1
-      j_lo = J1 - shift; j_hi = j_lo + 1
-      do i=G%isc, G%iec
-        if (associated(mask)) then
-          if (mask(i,J,1) == 0.) cycle
-        endif
-        h_src(:) = 0.5 * (h(i,j_lo,:) + h(i,j_hi,:))
-        h_dest(:) = 0.5 * (remap_cs%h(i,j_lo,:) + remap_cs%h(i,j_hi,:))
-        call remapping_core_h(remap_cs%remap_cs, &
-                              nz_src, h_src(:), field(i,J1,:), &
-                              nz_dest, h_dest(:), remapped_field(i,J1,:), &
-                              h_neglect, h_neglect_edge)
-      enddo
-    enddo
+    if (present(mask)) then
+      do J=G%jscB,G%jecB ; do i=G%isc,G%iec ; if (mask(i,j) > 0.) then
+        h_src(:) = 0.5 * (h(i,j,:) + h(i,j+1,:))
+        h_dest(:) = 0.5 * (remap_cs%h(i,j,:) + remap_cs%h(i,j+1,:))
+        call remapping_core_h(remap_cs%remap_cs, nz_src, h_src(:), field(i,J,:), &
+                              nz_dest, h_dest(:), remapped_field(i,J,:), h_neglect, h_neglect_edge)
+      endif ; enddo ; enddo
+    else
+      do J=G%jscB,G%jecB ; do i=G%isc,G%iec
+        h_src(:) = 0.5 * (h(i,j,:) + h(i,j+1,:))
+        h_dest(:) = 0.5 * (remap_cs%h(i,j,:) + remap_cs%h(i,j+1,:))
+        call remapping_core_h(remap_cs%remap_cs, nz_src, h_src(:), field(i,J,:), &
+                              nz_dest, h_dest(:), remapped_field(i,J,:), h_neglect, h_neglect_edge)
+      enddo ; enddo
+    endif
   elseif ((.not. staggered_in_x) .and. (.not. staggered_in_y)) then
     ! H-points
-    do j=G%jsc, G%jec
-      do i=G%isc, G%iec
-        if (associated(mask)) then
-          if (mask(i,j,1) == 0.) cycle
-        endif
-        h_src(:) = h(i,j,:)
-        h_dest(:) = remap_cs%h(i,j,:)
-        call remapping_core_h(remap_cs%remap_cs, &
-                              nz_src, h_src(:), field(i,j,:), &
-                              nz_dest, h_dest(:), remapped_field(i,j,:), &
+    if (present(mask)) then
+      do j=G%jsc,G%jec ; do i=G%isc,G%iec ; if (mask(i,j) > 0.) then
+        call remapping_core_h(remap_cs%remap_cs, nz_src, h(i,j,:), field(i,j,:), &
+                              nz_dest, remap_cs%h(i,j,:), remapped_field(i,j,:), &
                               h_neglect, h_neglect_edge)
-      enddo
-    enddo
+      endif ; enddo ; enddo
+    else
+      do j=G%jsc,G%jec ; do i=G%isc,G%iec
+        call remapping_core_h(remap_cs%remap_cs, nz_src, h(i,j,:), field(i,j,:), &
+                              nz_dest, remap_cs%h(i,j,:), remapped_field(i,j,:), &
+                              h_neglect, h_neglect_edge)
+      enddo ; enddo
+    endif
   else
     call assert(.false., 'diag_remap_do_remap: Unsupported axis combination')
   endif
 
-end subroutine diag_remap_do_remap
+end subroutine do_remap
 
 !> Calculate masks for target grid
 subroutine diag_remap_calc_hmask(remap_cs, G, mask)
-  type(diag_remap_ctrl),  intent(in)  :: remap_cs !< Diagnostic coodinate control structure
+  type(diag_remap_ctrl),  intent(in)  :: remap_cs !< Diagnostic coordinate control structure
   type(ocean_grid_type),  intent(in)  :: G    !< Ocean grid structure
-  real, dimension(:,:,:), intent(out) :: mask !< h-point mask for target grid [nondim]
+  real, dimension(G%isd:,G%jsd:,:), &
+                          intent(out) :: mask !< h-point mask for target grid [nondim]
+
   ! Local variables
-  real, dimension(remap_cs%nz) :: h_dest ! Destination thicknesses [H ~> m or kg m-2]
+  real, dimension(remap_cs%nz) :: h_dest ! Destination thicknesses [H ~> m or kg m-2] or [Z ~> m]
   integer :: i, j, k
   logical :: mask_vanished_layers
-  real :: h_tot      ! Sum of all thicknesses [H ~> m or kg m-2]
-  real :: h_err      ! An estimate of a negligible thickness [H ~> m or kg m-2]
+  real :: h_tot      ! Sum of all thicknesses [H ~> m or kg m-2] or [Z ~> m]
+  real :: h_err      ! An estimate of a negligible thickness [H ~> m or kg m-2] or [Z ~> m]
 
   call assert(remap_cs%initialized, 'diag_remap_calc_hmask: remap_cs not initialized.')
 
@@ -453,7 +512,7 @@ subroutine diag_remap_calc_hmask(remap_cs, G, mask)
   mask_vanished_layers = (remap_cs%vertical_coord == coordinateMode('ZSTAR'))
   mask(:,:,:) = 0.
 
-  do j=G%jsc-1, G%jec+1 ; do i=G%isc-1, G%iec+1
+  do j=G%jsc-1,G%jec+1 ; do i=G%isc-1,G%iec+1
     if (G%mask2dT(i,j)>0.) then
       if (mask_vanished_layers) then
         h_dest(:) = remap_cs%h(i,j,:)
@@ -482,166 +541,239 @@ end subroutine diag_remap_calc_hmask
 !> Vertically re-grid an already vertically-integrated diagnostic field to alternative vertical grid.
 subroutine vertically_reintegrate_diag_field(remap_cs, G, h, h_target, staggered_in_x, staggered_in_y, &
                                              mask, field, reintegrated_field)
-  type(diag_remap_ctrl),  intent(in) :: remap_cs !< Diagnostic coodinate control structure
-  type(ocean_grid_type),  intent(in) :: G        !< Ocean grid structure
-  real, dimension(:,:,:), intent(in) :: h        !< The thicknesses of the source grid [H ~> m or kg m-2]
-  real, dimension(:,:,:), intent(in) :: h_target !< The thicknesses of the target grid [H ~> m or kg m-2]
-  logical,                intent(in) :: staggered_in_x !< True is the x-axis location is at u or q points
-  logical,                intent(in) :: staggered_in_y !< True is the y-axis location is at v or q points
-  real, dimension(:,:,:), pointer    :: mask     !< A mask for the field [nondim]
-  real, dimension(:,:,:), intent(in) :: field    !<  The diagnostic field to be remapped [A]
-  real, dimension(:,:,:), intent(inout) :: reintegrated_field !< Field argument remapped to alternative coordinate [A]
+  type(diag_remap_ctrl),  intent(in)  :: remap_cs !< Diagnostic coordinate control structure
+  type(ocean_grid_type),  intent(in)  :: G        !< Ocean grid structure
+  real, dimension(:,:,:), intent(in)  :: h        !< The thicknesses of the source grid [H ~> m or kg m-2] or [Z ~> m]
+  real, dimension(:,:,:), intent(in)  :: h_target !< The thicknesses of the target grid [H ~> m or kg m-2] or [Z ~> m]
+  logical,                intent(in)  :: staggered_in_x !< True is the x-axis location is at u or q points
+  logical,                intent(in)  :: staggered_in_y !< True is the y-axis location is at v or q points
+  real, dimension(:,:,:), pointer     :: mask     !< A mask for the field [nondim].  Note that because this
+                                                  !! is a pointer it retains its declared indexing conventions.
+  real, dimension(:,:,:), intent(in)  :: field    !<  The diagnostic field to be remapped [A]
+  real, dimension(:,:,:), intent(out) :: reintegrated_field !< Field argument remapped to alternative coordinate [A]
+
   ! Local variables
-  real, dimension(remap_cs%nz) :: h_dest ! Destination thicknesses [H ~> m or kg m-2]
-  real, dimension(size(h,3)) :: h_src    ! A column of source thicknesses [H ~> m or kg m-2]
-  integer :: nz_src, nz_dest
-  integer :: i, j                   !< Grid index
-  integer :: i1, j1                 !< 1-based index
-  integer :: i_lo, i_hi, j_lo, j_hi !< (uv->h) interpolation indices
-  integer :: shift                  !< Symmetric offset for 1-based indexing
+  integer :: isdf, jsdf !< The starting i- and j-indices in memory for field
 
   call assert(remap_cs%initialized, 'vertically_reintegrate_diag_field: remap_cs not initialized.')
   call assert(size(field, 3) == size(h, 3), &
               'vertically_reintegrate_diag_field: Remap field and thickness z-axes do not match.')
 
-  nz_src = size(field,3)
-  nz_dest = remap_cs%nz
-  reintegrated_field(:,:,:) = 0.
+  isdf = G%isd ; if (staggered_in_x) Isdf = G%IsdB
+  jsdf = G%jsd ; if (staggered_in_y) Jsdf = G%JsdB
 
-  ! Symmetric grid offset under 1-based indexing; see header for details.
-  shift = 0 ; if (G%symmetric) shift = 1
-
-  if (staggered_in_x .and. .not. staggered_in_y) then
-    ! U-points
-    do j=G%jsc, G%jec
-      do I=G%iscB, G%iecB
-        I1 = I - G%isdB + 1
-        i_lo = I1 - shift; i_hi = i_lo + 1
-        if (associated(mask)) then
-          if (mask(I,j,1) == 0.) cycle
-        endif
-        h_src(:) = 0.5 * (h(i_lo,j,:) + h(i_hi,j,:))
-        h_dest(:) = 0.5 * (h_target(i_lo,j,:) + h_target(i_hi,j,:))
-        call reintegrate_column(nz_src, h_src, field(I1,j,:), &
-                                nz_dest, h_dest, reintegrated_field(I1,j,:))
-      enddo
-    enddo
-  elseif (staggered_in_y .and. .not. staggered_in_x) then
-    ! V-points
-    do J=G%jscB, G%jecB
-      J1 = J - G%jsdB + 1
-      j_lo = J1 - shift; j_hi = j_lo + 1
-      do i=G%isc, G%iec
-        if (associated(mask)) then
-          if (mask(i,J,1) == 0.) cycle
-        endif
-        h_src(:) = 0.5 * (h(i,j_lo,:) + h(i,j_hi,:))
-        h_dest(:) = 0.5 * (h_target(i,j_lo,:) + h_target(i,j_hi,:))
-        call reintegrate_column(nz_src, h_src, field(i,J1,:), &
-                                nz_dest, h_dest, reintegrated_field(i,J1,:))
-      enddo
-    enddo
-  elseif ((.not. staggered_in_x) .and. (.not. staggered_in_y)) then
-    ! H-points
-    do j=G%jsc, G%jec
-      do i=G%isc, G%iec
-        if (associated(mask)) then
-          if (mask(i,j,1) == 0.) cycle
-        endif
-        h_src(:) = h(i,j,:)
-        h_dest(:) = h_target(i,j,:)
-        call reintegrate_column(nz_src, h_src, field(i,j,:), &
-                                nz_dest, h_dest, reintegrated_field(i,j,:))
-      enddo
-    enddo
+  if (associated(mask)) then
+    call vertically_reintegrate_field(remap_cs, G, isdf, jsdf, h, h_target, staggered_in_x, staggered_in_y, &
+                                      field, reintegrated_field, mask(:,:,1))
   else
-    call assert(.false., 'vertically_reintegrate_diag_field: Q point remapping is not coded yet.')
+    call vertically_reintegrate_field(remap_cs, G, isdf, jsdf, h, h_target, staggered_in_x, staggered_in_y, &
+                                      field, reintegrated_field)
   endif
 
 end subroutine vertically_reintegrate_diag_field
 
+!> The internal routine to vertically re-grid an already vertically-integrated diagnostic field to
+!! an alternative vertical grid.
+subroutine vertically_reintegrate_field(remap_cs, G, isdf, jsdf, h, h_target, staggered_in_x, staggered_in_y, &
+                                        field, reintegrated_field, mask)
+  type(diag_remap_ctrl),  intent(in)  :: remap_cs !< Diagnostic coordinate control structure
+  type(ocean_grid_type),  intent(in)  :: G        !< Ocean grid structure
+  integer,                intent(in)  :: isdf     !< The starting i-index in memory for field
+  integer,                intent(in)  :: jsdf     !< The starting j-index in memory for field
+  real, dimension(G%isd:,G%jsd:,:), &
+                          intent(in)  :: h        !< The thicknesses of the source grid [H ~> m or kg m-2] or [Z ~> m]
+  real, dimension(G%isd:,G%jsd:,:), &
+                          intent(in)  :: h_target !< The thicknesses of the target grid [H ~> m or kg m-2] or [Z ~> m]
+  logical,                intent(in)  :: staggered_in_x !< True is the x-axis location is at u or q points
+  logical,                intent(in)  :: staggered_in_y !< True is the y-axis location is at v or q points
+  real, dimension(isdf:,jsdf:,:), &
+                          intent(in)  :: field   !< The diagnostic field to be remapped [A]
+  real, dimension(isdf:,jsdf:,:), &
+                          intent(out) :: reintegrated_field !< Field argument remapped to alternative coordinate [A]
+  real, dimension(isdf:,jsdf:), &
+                optional, intent(in)  :: mask !< A mask for the field [nondim]
+
+  ! Local variables
+  real, dimension(remap_cs%nz) :: h_dest ! Destination thicknesses [H ~> m or kg m-2] or [Z ~> m]
+  real, dimension(size(h,3)) :: h_src    ! A column of source thicknesses [H ~> m or kg m-2] or [Z ~> m]
+  integer :: nz_src, nz_dest        ! The number of layers on the native and remapped grids
+  integer :: i, j                   ! Grid index
+
+  nz_src = size(field,3)
+  nz_dest = remap_cs%nz
+  reintegrated_field(:,:,:) = 0.
+
+  if (staggered_in_x .and. .not. staggered_in_y) then
+    ! U-points
+    if (present(mask)) then
+      do j=G%jsc,G%jec ; do I=G%IscB,G%IecB ; if (mask(I,j) > 0.0) then
+        h_src(:) = 0.5 * (h(i,j,:) + h(i+1,j,:))
+        h_dest(:) = 0.5 * (h_target(i,j,:) + h_target(i+1,j,:))
+        call reintegrate_column(nz_src, h_src, field(I,j,:), &
+                                nz_dest, h_dest, reintegrated_field(I,j,:))
+      endif ; enddo ; enddo
+    else
+      do j=G%jsc,G%jec ; do I=G%IscB,G%IecB
+        h_src(:) = 0.5 * (h(i,j,:) + h(i+1,j,:))
+        h_dest(:) = 0.5 * (h_target(i,j,:) + h_target(i+1,j,:))
+        call reintegrate_column(nz_src, h_src, field(I,j,:), &
+                                nz_dest, h_dest, reintegrated_field(I,j,:))
+      enddo ; enddo
+    endif
+  elseif (staggered_in_y .and. .not. staggered_in_x) then
+    ! V-points
+    if (present(mask)) then
+      do J=G%jscB,G%jecB ; do i=G%isc,G%iec ; if (mask(i,J) > 0.0) then
+        h_src(:) = 0.5 * (h(i,j,:) + h(i,j+1,:))
+        h_dest(:) = 0.5 * (h_target(i,j,:) + h_target(i,j+1,:))
+        call reintegrate_column(nz_src, h_src, field(i,J,:), &
+                                nz_dest, h_dest, reintegrated_field(i,J,:))
+      endif ; enddo ; enddo
+    else
+      do J=G%jscB,G%jecB ; do i=G%isc,G%iec
+        h_src(:) = 0.5 * (h(i,j,:) + h(i,j+1,:))
+        h_dest(:) = 0.5 * (h_target(i,j,:) + h_target(i,j+1,:))
+        call reintegrate_column(nz_src, h_src, field(i,J,:), &
+                                nz_dest, h_dest, reintegrated_field(i,J,:))
+      enddo ; enddo
+    endif
+  elseif ((.not. staggered_in_x) .and. (.not. staggered_in_y)) then
+    ! H-points
+    if (present(mask)) then
+      do j=G%jsc,G%jec ; do i=G%isc,G%iec ; if (mask(i,J) > 0.0) then
+        call reintegrate_column(nz_src, h(i,j,:), field(i,j,:), &
+                                nz_dest, h_target(i,j,:), reintegrated_field(i,j,:))
+      endif ; enddo ; enddo
+    else
+      do j=G%jsc,G%jec ; do i=G%isc,G%iec
+        call reintegrate_column(nz_src, h(i,j,:), field(i,j,:), &
+                                nz_dest, h_target(i,j,:), reintegrated_field(i,j,:))
+      enddo ; enddo
+    endif
+  else
+    call assert(.false., 'vertically_reintegrate_diag_field: Q point remapping is not coded yet.')
+  endif
+
+end subroutine vertically_reintegrate_field
+
 !> Vertically interpolate diagnostic field to alternative vertical grid.
 subroutine vertically_interpolate_diag_field(remap_cs, G, h, staggered_in_x, staggered_in_y, &
                                              mask, field, interpolated_field)
-  type(diag_remap_ctrl),  intent(in) :: remap_cs !< Diagnostic coodinate control structure
+  type(diag_remap_ctrl),  intent(in) :: remap_cs !< Diagnostic coordinate control structure
   type(ocean_grid_type),  intent(in) :: G   !< Ocean grid structure
-  real, dimension(:,:,:), intent(in) :: h   !< The current thicknesses [H ~> m or kg m-2]
+  real, dimension(:,:,:), intent(in) :: h   !< The current thicknesses [H ~> m or kg m-2] or [Z ~> m],
+                                            !! depending on the value of remap_cs%Z_based_coord
   logical,                intent(in) :: staggered_in_x !< True is the x-axis location is at u or q points
   logical,                intent(in) :: staggered_in_y !< True is the y-axis location is at v or q points
-  real, dimension(:,:,:), pointer    :: mask !< A mask for the field [nondim]
+  real, dimension(:,:,:), pointer    :: mask !< A mask for the field [nondim].  Note that because this
+                                             !! is a pointer it retains its declared indexing conventions.
   real, dimension(:,:,:), intent(in) :: field !<  The diagnostic field to be remapped [A]
   real, dimension(:,:,:), intent(inout) :: interpolated_field !< Field argument remapped to alternative coordinate [A]
+
   ! Local variables
-  real, dimension(remap_cs%nz) :: h_dest ! Destination thicknesses [H ~> m or kg m-2]
-  real, dimension(size(h,3)) :: h_src    ! A column of source thicknesses [H ~> m or kg m-2]
-  integer :: nz_src, nz_dest
-  integer :: i, j                   !< Grid index
-  integer :: i1, j1                 !< 1-based index
-  integer :: i_lo, i_hi, j_lo, j_hi !< (uv->h) interpolation indices
-  integer :: shift                  !< Symmetric offset for 1-based indexing
+  integer :: isdf, jsdf !< The starting i- and j-indices in memory for field
 
   call assert(remap_cs%initialized, 'vertically_interpolate_diag_field: remap_cs not initialized.')
   call assert(size(field, 3) == size(h, 3)+1, &
               'vertically_interpolate_diag_field: Remap field and thickness z-axes do not match.')
+
+  isdf = G%isd ; if (staggered_in_x) Isdf = G%IsdB
+  jsdf = G%jsd ; if (staggered_in_y) Jsdf = G%JsdB
+
+  if (associated(mask)) then
+    call vertically_interpolate_field(remap_cs, G, isdf, jsdf, h, staggered_in_x, staggered_in_y, &
+                                      field, interpolated_field, mask(:,:,1))
+  else
+    call vertically_interpolate_field(remap_cs, G, isdf, jsdf, h, staggered_in_x, staggered_in_y, &
+                                      field, interpolated_field)
+  endif
+
+end subroutine vertically_interpolate_diag_field
+
+!> Internal routine to vertically interpolate a diagnostic field to an alternative vertical grid.
+subroutine vertically_interpolate_field(remap_cs, G, isdf, jsdf, h, staggered_in_x, staggered_in_y, &
+                                        field, interpolated_field, mask)
+  type(diag_remap_ctrl),  intent(in)  :: remap_cs !< Diagnostic coordinate control structure
+  type(ocean_grid_type),  intent(in)  :: G    !< Ocean grid structure
+  integer,                intent(in)  :: isdf !< The starting i-index in memory for field
+  integer,                intent(in)  :: jsdf !< The starting j-index in memory for field
+  real, dimension(G%isd:,G%jsd:,:), &
+                          intent(in)  :: h    !< The current thicknesses [H ~> m or kg m-2] or [Z ~> m],
+                                              !! depending on the value of remap_cs%Z_based_coord
+  logical,                intent(in)  :: staggered_in_x !< True is the x-axis location is at u or q points
+  logical,                intent(in)  :: staggered_in_y !< True is the y-axis location is at v or q points
+  real, dimension(isdf:,jsdf:,:), &
+                          intent(in)  :: field !< The diagnostic field to be remapped [A]
+  real, dimension(isdf:,jsdf:,:), &
+                          intent(out) :: interpolated_field !< Field argument remapped to alternative coordinate [A]
+  real, dimension(isdf:,jsdf:), &
+                optional, intent(in)  :: mask !< A mask for the field [nondim]
+
+  ! Local variables
+  real, dimension(remap_cs%nz) :: h_dest ! Destination thicknesses [H ~> m or kg m-2] or [Z ~> m]
+  real, dimension(size(h,3)) :: h_src    ! A column of source thicknesses [H ~> m or kg m-2] or [Z ~> m]
+  integer :: nz_src, nz_dest        ! The number of layers on the native and remapped grids
+  integer :: i, j                   !< Grid index
 
   interpolated_field(:,:,:) = 0.
 
   nz_src = size(h,3)
   nz_dest = remap_cs%nz
 
-  ! Symmetric grid offset under 1-based indexing; see header for details.
-  shift = 0 ; if (G%symmetric) shift = 1
-
   if (staggered_in_x .and. .not. staggered_in_y) then
     ! U-points
-    do j=G%jsc, G%jec
-      do I=G%iscB, G%iecB
-        I1 = I - G%isdB + 1
-        i_lo = I1 - shift; i_hi = i_lo + 1
-        if (associated(mask)) then
-          if (mask(I,j,1) == 0.) cycle
-        endif
-        h_src(:) = 0.5 * (h(i_lo,j,:) + h(i_hi,j,:))
-        h_dest(:) = 0.5 * (remap_cs%h(i_lo,j,:) + remap_cs%h(i_hi,j,:))
-        call interpolate_column(nz_src, h_src, field(I1,j,:), &
-                                nz_dest, h_dest, interpolated_field(I1,j,:), .true.)
-      enddo
-    enddo
+    if (present(mask)) then
+      do j=G%jsc,G%jec ; do I=G%IscB,G%IecB ; if (mask(I,j) > 0.0) then
+        h_src(:) = 0.5 * (h(i,j,:) + h(i+1,j,:))
+        h_dest(:) = 0.5 * (remap_cs%h(i,j,:) + remap_cs%h(i+1,j,:))
+        call interpolate_column(nz_src, h_src, field(I,j,:), &
+                                nz_dest, h_dest, interpolated_field(I,j,:), .true.)
+      endif ; enddo ; enddo
+    else
+      do j=G%jsc,G%jec ; do I=G%IscB,G%IecB
+        h_src(:) = 0.5 * (h(i,j,:) + h(i+1,j,:))
+        h_dest(:) = 0.5 * (remap_cs%h(i,j,:) + remap_cs%h(i+1,j,:))
+        call interpolate_column(nz_src, h_src, field(I,j,:), &
+                                nz_dest, h_dest, interpolated_field(I,j,:), .true.)
+      enddo ; enddo
+    endif
   elseif (staggered_in_y .and. .not. staggered_in_x) then
     ! V-points
-    do J=G%jscB, G%jecB
-      J1 = J - G%jsdB + 1
-      j_lo = J1 - shift; j_hi = j_lo + 1
-      do i=G%isc, G%iec
-        if (associated(mask)) then
-          if (mask(i,J,1) == 0.) cycle
-        endif
-        h_src(:) = 0.5 * (h(i,j_lo,:) + h(i,j_hi,:))
-        h_dest(:) = 0.5 * (remap_cs%h(i,j_lo,:) + remap_cs%h(i,j_hi,:))
-        call interpolate_column(nz_src, h_src, field(i,J1,:), &
-                                nz_dest, h_dest, interpolated_field(i,J1,:), .true.)
-      enddo
-    enddo
+    if (present(mask)) then
+      do J=G%jscB,G%jecB ; do i=G%isc,G%iec ; if (mask(I,j) > 0.0) then
+        h_src(:) = 0.5 * (h(i,j,:) + h(i,j+1,:))
+        h_dest(:) = 0.5 * (remap_cs%h(i,j,:) + remap_cs%h(i,j+1,:))
+        call interpolate_column(nz_src, h_src, field(i,J,:), &
+                                nz_dest, h_dest, interpolated_field(i,J,:), .true.)
+      endif ; enddo ; enddo
+    else
+      do J=G%jscB,G%jecB ; do i=G%isc,G%iec
+        h_src(:) = 0.5 * (h(i,j,:) + h(i,j+1,:))
+        h_dest(:) = 0.5 * (remap_cs%h(i,j,:) + remap_cs%h(i,j+1,:))
+        call interpolate_column(nz_src, h_src, field(i,J,:), &
+                                nz_dest, h_dest, interpolated_field(i,J,:), .true.)
+      enddo ; enddo
+    endif
   elseif ((.not. staggered_in_x) .and. (.not. staggered_in_y)) then
     ! H-points
-    do j=G%jsc, G%jec
-      do i=G%isc, G%iec
-        if (associated(mask)) then
-          if (mask(i,j,1) == 0.) cycle
-        endif
-        h_src(:) = h(i,j,:)
-        h_dest(:) = remap_cs%h(i,j,:)
-        call interpolate_column(nz_src, h_src, field(i,j,:), &
-                                nz_dest, h_dest, interpolated_field(i,j,:), .true.)
-      enddo
-    enddo
+    if (present(mask)) then
+      do j=G%jsc,G%jec ; do i=G%isc,G%iec ; if (mask(i,j) > 0.0) then
+        call interpolate_column(nz_src, h(i,j,:), field(i,j,:), &
+                                nz_dest, remap_cs%h(i,j,:), interpolated_field(i,j,:), .true.)
+      endif ; enddo ; enddo
+    else
+      do j=G%jsc,G%jec ; do i=G%isc,G%iec
+        call interpolate_column(nz_src, h(i,j,:), field(i,j,:), &
+                                nz_dest, remap_cs%h(i,j,:), interpolated_field(i,j,:), .true.)
+      enddo ; enddo
+    endif
   else
     call assert(.false., 'vertically_interpolate_diag_field: Q point remapping is not coded yet.')
   endif
 
-end subroutine vertically_interpolate_diag_field
+end subroutine vertically_interpolate_field
 
-!> Horizontally average field
+!> Horizontally average a diagnostic field
 subroutine horizontally_average_diag_field(G, GV, h, staggered_in_x, staggered_in_y, &
                                            is_layer, is_extensive, &
                                            field, averaged_field, &
@@ -654,8 +786,37 @@ subroutine horizontally_average_diag_field(G, GV, h, staggered_in_x, staggered_i
   logical,                intent(in) :: is_layer !< True if the z-axis location is at h points
   logical,                intent(in) :: is_extensive !< True if the z-direction is spatially integrated (over layers)
   real, dimension(:,:,:), intent(in) :: field !<  The diagnostic field to be remapped [A]
-  real, dimension(:),  intent(inout) :: averaged_field !< Field argument horizontally averaged [A]
-  logical, dimension(:), intent(inout) :: averaged_mask  !< Mask for horizontally averaged field [nondim]
+  real, dimension(:),    intent(out) :: averaged_field !< Field argument horizontally averaged [A]
+  logical, dimension(:), intent(out) :: averaged_mask  !< Mask for horizontally averaged field [nondim]
+
+  ! Local variables
+  integer :: isdf, jsdf !< The starting i- and j-indices in memory for field
+
+  isdf = G%isd ; if (staggered_in_x) Isdf = G%IsdB
+  jsdf = G%jsd ; if (staggered_in_y) Jsdf = G%JsdB
+
+  call horizontally_average_field(G, GV, isdf, jsdf, h, staggered_in_x, staggered_in_y, &
+                                  is_layer, is_extensive, field, averaged_field, averaged_mask)
+
+end subroutine horizontally_average_diag_field
+
+!> Horizontally average a diagnostic field
+subroutine horizontally_average_field(G, GV, isdf, jsdf, h, staggered_in_x, staggered_in_y, &
+                                      is_layer, is_extensive, field, averaged_field, averaged_mask)
+  type(ocean_grid_type),   intent(in)  :: G  !< Ocean grid structure
+  type(verticalGrid_type), intent(in)  :: GV !< The ocean vertical grid structure
+  integer,                 intent(in)  :: isdf !< The starting i-index in memory for field
+  integer,                 intent(in)  :: jsdf !< The starting j-index in memory for field
+  real, dimension(G%isd:,G%jsd:,:), &
+                           intent(in)  :: h  !< The current thicknesses [H ~> m or kg m-2]
+  logical,                 intent(in)  :: staggered_in_x !< True if the x-axis location is at u or q points
+  logical,                 intent(in)  :: staggered_in_y !< True if the y-axis location is at v or q points
+  logical,                 intent(in)  :: is_layer !< True if the z-axis location is at h points
+  logical,                 intent(in)  :: is_extensive !< True if the z-direction is spatially integrated (over layers)
+  real, dimension(isdf:,jsdf:,:), &
+                           intent(in)  :: field !<  The diagnostic field to be remapped [A]
+  real, dimension(:),      intent(out) :: averaged_field !< Field argument horizontally averaged [A]
+  logical, dimension(:),   intent(out) :: averaged_mask  !< Mask for horizontally averaged field [nondim]
 
   ! Local variables
   real :: volume(G%isc:G%iec, G%jsc:G%jec, size(field,3)) ! The area [m2], volume [m3] or mass [kg] of each cell.
@@ -670,7 +831,6 @@ subroutine horizontally_average_diag_field(G, GV, h, staggered_in_x, staggered_i
   type(EFP_type), dimension(2*size(field,3)) :: sums_EFP ! Sums of volume or stuff by layer
   real :: height  ! An average thickness attributed to an velocity point [H ~> m or kg m-2]
   integer :: i, j, k, nz
-  integer :: i1, j1                 !< 1-based index
 
   nz = size(field, 3)
 
@@ -686,26 +846,23 @@ subroutine horizontally_average_diag_field(G, GV, h, staggered_in_x, staggered_i
         stuff_sum(k) = 0.
         if (is_extensive) then
           do j=G%jsc, G%jec ; do I=G%isc, G%iec
-            I1 = I - G%isdB + 1
             volume(I,j,k) = (G%US%L_to_m**2 * G%areaCu(I,j)) * G%mask2dCu(I,j)
-            stuff(I,j,k) = volume(I,j,k) * field(I1,j,k)
+            stuff(I,j,k) = volume(I,j,k) * field(I,j,k)
           enddo ; enddo
         else ! Intensive
           do j=G%jsc, G%jec ; do I=G%isc, G%iec
-            I1 = i - G%isdB + 1
             height = 0.5 * (h(i,j,k) + h(i+1,j,k))
             volume(I,j,k) = (G%US%L_to_m**2 * G%areaCu(I,j)) &
                 * (GV%H_to_MKS * height) * G%mask2dCu(I,j)
-            stuff(I,j,k) = volume(I,j,k) * field(I1,j,k)
+            stuff(I,j,k) = volume(I,j,k) * field(I,j,k)
           enddo ; enddo
         endif
       enddo
     else ! Interface
       do k=1,nz
         do j=G%jsc, G%jec ; do I=G%isc, G%iec
-          I1 = I - G%isdB + 1
           volume(I,j,k) = (G%US%L_to_m**2 * G%areaCu(I,j)) * G%mask2dCu(I,j)
-          stuff(I,j,k) = volume(I,j,k) * field(I1,j,k)
+          stuff(I,j,k) = volume(I,j,k) * field(I,j,k)
         enddo ; enddo
       enddo
     endif
@@ -715,26 +872,23 @@ subroutine horizontally_average_diag_field(G, GV, h, staggered_in_x, staggered_i
       do k=1,nz
         if (is_extensive) then
           do J=G%jsc, G%jec ; do i=G%isc, G%iec
-            J1 = J - G%jsdB + 1
             volume(i,J,k) = (G%US%L_to_m**2 * G%areaCv(i,J)) * G%mask2dCv(i,J)
-            stuff(i,J,k) = volume(i,J,k) * field(i,J1,k)
+            stuff(i,J,k) = volume(i,J,k) * field(i,J,k)
           enddo ; enddo
         else ! Intensive
           do J=G%jsc, G%jec ; do i=G%isc, G%iec
-            J1 = J - G%jsdB + 1
             height = 0.5 * (h(i,j,k) + h(i,j+1,k))
             volume(i,J,k) = (G%US%L_to_m**2 * G%areaCv(i,J)) &
                 * (GV%H_to_MKS * height) * G%mask2dCv(i,J)
-            stuff(i,J,k) = volume(i,J,k) * field(i,J1,k)
+            stuff(i,J,k) = volume(i,J,k) * field(i,J,k)
           enddo ; enddo
         endif
       enddo
     else ! Interface
       do k=1,nz
         do J=G%jsc, G%jec ; do i=G%isc, G%iec
-          J1 = J - G%jsdB + 1
           volume(i,J,k) = (G%US%L_to_m**2 * G%areaCv(i,J)) * G%mask2dCv(i,J)
-          stuff(i,J,k) = volume(i,J,k) * field(i,J1,k)
+          stuff(i,J,k) = volume(i,J,k) * field(i,J,k)
         enddo ; enddo
       enddo
     endif
@@ -794,6 +948,6 @@ subroutine horizontally_average_diag_field(G, GV, h, staggered_in_x, staggered_i
     endif
   enddo
 
-end subroutine horizontally_average_diag_field
+end subroutine horizontally_average_field
 
 end module MOM_diag_remap

--- a/src/framework/MOM_dyn_horgrid.F90
+++ b/src/framework/MOM_dyn_horgrid.F90
@@ -133,16 +133,20 @@ type, public :: dyn_horgrid_type
     IareaBu      !< IareaBu = 1/areaBu [L-2 ~> m-2].
 
   real, pointer, dimension(:) :: gridLatT => NULL()
-        !< The latitude of T points for the purpose of labeling the output axes.
+        !< The latitude of T points for the purpose of labeling the output axes,
+        !! often in units of [degrees_N] or [km] or [m] or [gridpoints].
         !! On many grids this is the same as geoLatT.
   real, pointer, dimension(:) :: gridLatB => NULL()
-        !< The latitude of B points for the purpose of labeling the output axes.
+        !< The latitude of B points for the purpose of labeling the output axes,
+        !! often in units of [degrees_N] or [km] or [m] or [gridpoints].
         !! On many grids this is the same as geoLatBu.
   real, pointer, dimension(:) :: gridLonT => NULL()
-        !< The longitude of T points for the purpose of labeling the output axes.
+        !< The longitude of T points for the purpose of labeling the output axes,
+        !! often in units of [degrees_E] or [km] or [m] or [gridpoints].
         !! On many grids this is the same as geoLonT.
   real, pointer, dimension(:) :: gridLonB => NULL()
-        !< The longitude of B points for the purpose of labeling the output axes.
+        !< The longitude of B points for the purpose of labeling the output axes,
+        !! often in units of [degrees_E] or [km] or [m] or [gridpoints].
         !! On many grids this is the same as geoLonBu.
   character(len=40) :: &
     ! Except on a Cartesian grid, these are usually some variant of "degrees".
@@ -176,10 +180,10 @@ type, public :: dyn_horgrid_type
 
   ! These parameters are run-time parameters that are used during some
   ! initialization routines (but not all)
-  real :: south_lat     !< The latitude (or y-coordinate) of the first v-line
-  real :: west_lon      !< The longitude (or x-coordinate) of the first u-line
-  real :: len_lat       !< The latitudinal (or y-coord) extent of physical domain
-  real :: len_lon       !< The longitudinal (or x-coord) extent of physical domain
+  real :: south_lat     !< The latitude (or y-coordinate) of the first v-line [degrees_N] or [km] or [m]
+  real :: west_lon      !< The longitude (or x-coordinate) of the first u-line [degrees_E] or [km] or [m]
+  real :: len_lat       !< The latitudinal (or y-coord) extent of physical domain [degrees_N] or [km] or [m]
+  real :: len_lon       !< The longitudinal (or x-coord) extent of physical domain [degrees_E] or [km] or [m]
   real :: Rad_Earth     !< The radius of the planet [m]
   real :: Rad_Earth_L   !< The radius of the planet in rescaled units [L ~> m]
   real :: max_depth     !< The maximum depth of the ocean [Z ~> m]
@@ -407,10 +411,10 @@ end subroutine rotate_dyn_horgrid
 !! grid, both rescaling the depths and recording the new internal depth units.
 subroutine rescale_dyn_horgrid_bathymetry(G, m_in_new_units)
   type(dyn_horgrid_type), intent(inout) :: G !< The dynamic horizontal grid type
-  real,                   intent(in)    :: m_in_new_units !< The new internal representation of 1 m depth.
+  real,                   intent(in)    :: m_in_new_units !< The new internal representation of 1 m depth [m Z-1 ~> 1]
 
   ! Local variables
-  real :: rescale
+  real :: rescale ! The inverse of m_in_new_units, used in rescaling bathymetry [Z m-1 ~> 1]
   integer :: i, j, isd, ied, jsd, jed, IsdB, IedB, JsdB, JedB
 
   isd = G%isd ; ied = G%ied ; jsd = G%jsd ; jed = G%jed
@@ -485,8 +489,8 @@ end subroutine set_derived_dyn_horgrid
 
 !> Adcroft_reciprocal(x) = 1/x for |x|>0 or 0 for x=0.
 function Adcroft_reciprocal(val) result(I_val)
-  real, intent(in) :: val  !< The value being inverted.
-  real :: I_val            !< The Adcroft reciprocal of val.
+  real, intent(in) :: val  !< The value being inverted in abitrary units [A ~> a]
+  real :: I_val            !< The Adcroft reciprocal of val [A-1 ~> a-1].
 
   I_val = 0.0 ; if (val /= 0.0) I_val = 1.0/val
 end function Adcroft_reciprocal

--- a/src/framework/MOM_horizontal_regridding.F90
+++ b/src/framework/MOM_horizontal_regridding.F90
@@ -44,26 +44,31 @@ end interface
 contains
 
 !> Write to the terminal some basic statistics about the k-th level of an array
-subroutine myStats(array, missing, is, ie, js, je, k, mesg, scale)
-  real, dimension(:,:), intent(in) :: array !< input array in arbitrary units [A ~> a]
-  real,             intent(in) :: missing !< missing value in arbitrary units [A ~> a]
-  integer,          intent(in) :: is   !< Start index in i
-  integer,          intent(in) :: ie   !< End index in i
-  integer,          intent(in) :: js   !< Start index in j
-  integer,          intent(in) :: je   !< End index in j
-  integer,          intent(in) :: k    !< Level to calculate statistics for
-  character(len=*), intent(in) :: mesg !< Label to use in message
-  real,   optional, intent(in) :: scale !< A scaling factor for output [a A-1 ~> 1]
+subroutine myStats(array, missing, G, k, mesg, scale, full_halo)
+  type(ocean_grid_type), intent(in) :: G     !< Ocean grid type
+  real, dimension(SZI_(G),SZJ_(G)), &
+                         intent(in) :: array !< input array in arbitrary units [A ~> a]
+  real,                  intent(in) :: missing !< missing value in arbitrary units [A ~> a]
+  integer,               intent(in) :: k     !< Level to calculate statistics for
+  character(len=*),      intent(in) :: mesg  !< Label to use in message
+  real,        optional, intent(in) :: scale !< A scaling factor for output [a A-1 ~> 1]
+  logical,     optional, intent(in) :: full_halo !< If present and true, test values on the whole
+                                             !! array rather than just the computational domain.
   ! Local variables
   real :: minA ! Minimum value in the array in the arbitrary units of the input array [A ~> a]
   real :: maxA ! Maximum value in the array in the arbitrary units of the input array [A ~> a]
   real :: scl  ! A factor for undoing any scaling of the array statistics for output [a A-1 ~> 1]
-  integer :: i,j
+  integer :: i, j, is, ie, js, je
   logical :: found
   character(len=120) :: lMesg
 
   scl = 1.0 ; if (present(scale)) scl = scale
   minA = 9.E24 / scl ; maxA = -9.E24 / scl ; found = .false.
+
+  is = G%isc ; ie = G%iec ; js = G%jsc ; je = G%jec
+  if (present(full_halo)) then ; if (full_halo) then
+    is = G%isd ; ie = G%ied ; js = G%jsd ; je = G%jed
+  endif ; endif
 
   do j=js,je ; do i=is,ie
     if (array(i,j) /= array(i,j)) stop 'Nan!'
@@ -309,7 +314,7 @@ subroutine horiz_interp_and_extrap_tracer_record(filename, varnam, recnum, G, tr
   real, dimension(:,:),  allocatable   :: tr_in      !< A 2-d array for holding input data on its
                                                      !! native horizontal grid, with units that change
                                                      !! as the input data is interpreted [a] then [A ~> a]
-  real, dimension(:,:,:),  allocatable   :: tr_in_full  !< A 3-d array for holding input data on the
+  real, dimension(:,:,:), allocatable  :: tr_in_full  !< A 3-d array for holding input data on the
                                                      !! model horizontal grid, with units that change
                                                      !! as the input data is interpreted [a] then [A ~> a]
   real, dimension(:,:),  allocatable   :: tr_inp     !< Native horizontal grid data extended to the poles
@@ -332,7 +337,7 @@ subroutine horiz_interp_and_extrap_tracer_record(filename, varnam, recnum, G, tr
   real :: npole     ! The number of points contributing to the pole value [nondim]
   real :: missing_val_in ! The missing value in the input field [a]
   real :: roundoff  ! The magnitude of roundoff, usually ~2e-16 [nondim]
-  real :: add_offset, scale_factor  ! File-specific conversion factors.
+  real :: add_offset, scale_factor  ! File-specific conversion factors [a] or [nondim]
   integer :: ans_date           ! The vintage of the expressions and order of arithmetic to use
   logical :: found_attr
   logical :: add_np
@@ -545,7 +550,7 @@ subroutine horiz_interp_and_extrap_tracer_record(filename, varnam, recnum, G, tr
       endif
 
       if (debug) then
-        call myStats(tr_inp, missing_value, 1, id, 1, jd, k, 'Tracer from file', scale=I_scale)
+        call myStats(tr_inp, missing_value, G, k, 'Tracer from file', scale=I_scale, full_halo=.true.)
       endif
 
       call run_horiz_interp(Interp, tr_inp, tr_out(is:ie,js:je), missing_value=missing_value)
@@ -568,11 +573,12 @@ subroutine horiz_interp_and_extrap_tracer_record(filename, varnam, recnum, G, tr
           (mask_out(i,j) < 1.0)) &
         fill(i,j) = 1.0
     enddo ; enddo
+
     call pass_var(fill, G%Domain)
     call pass_var(good, G%Domain)
 
     if (debug) then
-      call myStats(tr_out, missing_value, is, ie, js, je, k, 'variable from horiz_interp()', scale=I_scale)
+      call myStats(tr_out, missing_value, G, k, 'variable from horiz_interp()', scale=I_scale)
     endif
 
     ! Horizontally homogenize data to produce perfectly "flat" initial conditions
@@ -589,7 +595,7 @@ subroutine horiz_interp_and_extrap_tracer_record(filename, varnam, recnum, G, tr
 
     call fill_miss_2d(tr_outf, good2, fill2, tr_prev, G, dtr_iter_stop, answer_date=ans_date)
     if (debug) then
-      call myStats(tr_outf, missing_value, is, ie, js, je, k, 'field from fill_miss_2d()', scale=I_scale)
+      call myStats(tr_outf, missing_value, G, k, 'field from fill_miss_2d()', scale=I_scale)
     endif
 
     tr_z(:,:,k) = tr_outf(:,:) * G%mask2dT(:,:)
@@ -850,7 +856,7 @@ subroutine horiz_interp_and_extrap_tracer_fms_id(field, Time, G, tr_z, mask_z, &
       endif
 
       if (debug) then
-        call myStats(tr_inp, missing_value, 1, id, 1, jd, k, 'Tracer from file', scale=I_scale)
+        call myStats(tr_inp, missing_value, G, k, 'Tracer from file', scale=I_scale, full_halo=.true.)
       endif
 
       tr_out(:,:) = 0.0
@@ -878,7 +884,7 @@ subroutine horiz_interp_and_extrap_tracer_fms_id(field, Time, G, tr_z, mask_z, &
       call pass_var(good, G%Domain)
 
       if (debug) then
-        call myStats(tr_out, missing_value, is, ie, js, je, k, 'variable from horiz_interp()', scale=I_scale)
+        call myStats(tr_out, missing_value, G, k, 'variable from horiz_interp()', scale=I_scale)
       endif
 
       ! Horizontally homogenize data to produce perfectly "flat" initial conditions
@@ -897,7 +903,7 @@ subroutine horiz_interp_and_extrap_tracer_fms_id(field, Time, G, tr_z, mask_z, &
 
 !     if (debug) then
 !       call hchksum(tr_outf, 'field from fill_miss_2d ', G%HI, scale=I_scale)
-!       call myStats(tr_outf, missing_value, is, ie, js, je, k, 'field from fill_miss_2d()', scale=I_scale)
+!       call myStats(tr_outf, missing_value, G, k, 'field from fill_miss_2d()', scale=I_scale)
 !     endif
 
       tr_z(:,:,k) = tr_outf(:,:) * G%mask2dT(:,:)

--- a/src/framework/MOM_horizontal_regridding.F90
+++ b/src/framework/MOM_horizontal_regridding.F90
@@ -322,7 +322,7 @@ subroutine horiz_interp_and_extrap_tracer_record(filename, varnam, recnum, G, tr
                                                      !! interpreted [a] then [A ~> a]
   real, dimension(:,:),  allocatable   :: mask_in    ! A 2-d mask for extended input grid [nondim]
 
-  real :: PI_180  ! A conversion factor from degrees to radians
+  real :: PI_180  ! A conversion factor from degrees to radians [radians degree-1]
   integer :: id, jd, kd, jdp ! Input dataset data sizes
   integer :: i, j, k
   integer, dimension(4) :: start, count
@@ -670,7 +670,7 @@ subroutine horiz_interp_and_extrap_tracer_fms_id(field, Time, G, tr_z, mask_z, &
                                                      !! on the original grid [a]
   real, dimension(:,:),  allocatable   :: mask_in    !< A 2-d mask for extended input grid [nondim]
 
-  real :: PI_180  ! A conversion factor from degrees to radians
+  real :: PI_180  ! A conversion factor from degrees to radians [radians degree-1]
   integer :: id, jd, kd, jdp ! Input dataset data sizes
   integer :: i, j, k
   real, dimension(:,:), allocatable :: x_in ! Input file longitudes [radians]

--- a/src/framework/MOM_interpolate.F90
+++ b/src/framework/MOM_interpolate.F90
@@ -31,12 +31,12 @@ contains
 subroutine time_interp_external_0d(field, time, data_in, verbose, scale)
   type(external_field), intent(in) :: field    !< Handle for time interpolated field
   type(time_type),   intent(in)    :: time     !< The target time for the data
-  real,              intent(inout) :: data_in  !< The interpolated value
+  real,              intent(inout) :: data_in  !< The interpolated value in arbitrary units [A ~> a]
   logical, optional, intent(in)    :: verbose  !< If true, write verbose output for debugging
-  real,     optional, intent(in)    :: scale   !< A scaling factor that new values of data_in are
-                                               !! multiplied by before it is returned
-  real :: data_in_pre_scale ! The input data before rescaling
-  real :: I_scale ! The inverse of scale
+  real,    optional, intent(in)    :: scale    !< A scaling factor that new values of data_in are
+                                               !! multiplied by before it is returned [A a-1 ~> 1]
+  real :: data_in_pre_scale ! The input data before rescaling [a]
+  real :: I_scale ! The inverse of scale [a A-1 ~> 1]
 
   ! Store the input value in case the scaling factor is perfectly invertable.
   data_in_pre_scale = data_in
@@ -68,7 +68,8 @@ subroutine time_interp_external_2d(field, time, data_in, interp, &
                                    verbose, horz_interp, mask_out, turns, scale)
   type(external_field), intent(in)    :: field    !< Handle for time interpolated field
   type(time_type),      intent(in)    :: time     !< The target time for the data
-  real, dimension(:,:), intent(inout) :: data_in  !< The array in which to store the interpolated values
+  real, dimension(:,:), intent(inout) :: data_in  !< The array in which to store the interpolated
+                                                  !! values in arbitrary units [A ~> a]
   integer,    optional, intent(in)    :: interp   !< A flag indicating the temporal interpolation method
   logical,    optional, intent(in)    :: verbose  !< If true, write verbose output for debugging
   type(horiz_interp_type), &
@@ -77,11 +78,11 @@ subroutine time_interp_external_2d(field, time, data_in, interp, &
               optional, intent(out)   :: mask_out !< An array that is true where there is valid data
   integer,    optional, intent(in)    :: turns    !< Number of quarter turns to rotate the data
   real,       optional, intent(in)    :: scale    !< A scaling factor that new values of data_in are
-                                                  !! multiplied by before it is returned
+                                                  !! multiplied by before it is returned [A a-1 ~> 1]
 
-  real, allocatable :: data_in_pre_scale(:,:) ! The input data before rescaling
-  real, allocatable :: data_pre_rot(:,:)      ! The unscaled input data before rotation
-  real    :: I_scale ! The inverse of scale
+  real, allocatable :: data_in_pre_scale(:,:) ! The input data before rescaling [a]
+  real, allocatable :: data_pre_rot(:,:)      ! The unscaled input data before rotation [a]
+  real    :: I_scale ! The inverse of scale [a A-1 ~> 1]
   integer :: qturns ! The number of quarter turns to rotate the data
   integer :: i, j
 
@@ -140,7 +141,8 @@ subroutine time_interp_external_3d(field, time, data_in, interp, &
                                    verbose, horz_interp, mask_out, turns, scale)
   type(external_field), intent(in)      :: field    !< Handle for time interpolated field
   type(time_type),        intent(in)    :: time     !< The target time for the data
-  real, dimension(:,:,:), intent(inout) :: data_in  !< The array in which to store the interpolated values
+  real, dimension(:,:,:), intent(inout) :: data_in  !< The array in which to store the interpolated
+                                                    !! values in arbitrary units [A ~> a]
   integer,      optional, intent(in)    :: interp   !< A flag indicating the temporal interpolation method
   logical,      optional, intent(in)    :: verbose  !< If true, write verbose output for debugging
   type(horiz_interp_type), &
@@ -149,11 +151,11 @@ subroutine time_interp_external_3d(field, time, data_in, interp, &
                 optional, intent(out)   :: mask_out !< An array that is true where there is valid data
   integer,      optional, intent(in)    :: turns    !< Number of quarter turns to rotate the data
   real,         optional, intent(in)    :: scale    !< A scaling factor that new values of data_in are
-                                                    !! multiplied by before it is returned
+                                                    !! multiplied by before it is returned [A a-1 ~> 1]
 
-  real, allocatable :: data_in_pre_scale(:,:,:) ! The input data before rescaling
-  real, allocatable :: data_pre_rot(:,:,:)      ! The unscaled input data before rotation
-  real    :: I_scale ! The inverse of scale
+  real, allocatable :: data_in_pre_scale(:,:,:) ! The input data before rescaling [a]
+  real, allocatable :: data_pre_rot(:,:,:)      ! The unscaled input data before rotation [a]
+  real    :: I_scale ! The inverse of scale [a A-1 ~> 1]
   integer :: qturns  ! The number of quarter turns to rotate the data
   integer :: i, j, k
 

--- a/src/framework/MOM_intrinsic_functions.F90
+++ b/src/framework/MOM_intrinsic_functions.F90
@@ -64,8 +64,11 @@ elemental function cuberoot(x) result(root)
     ! and it is therefore more computationally efficient.
 
     ! This first estimate gives the same magnitude of errors for 0.125 and 1.0 after two iterations.
-    num = 0.707106 ; den = 1.0
-    do itt=1,3
+    ! The first iteration is applied explicitly.
+    num = 0.707106 * (0.707106**3 + 2.0 * asx)
+    den = 2.0 * (0.707106**3) + asx
+
+    do itt=1,2
       ! Halley's method iterates estimates as Root = Root * (Root**3 + 2.*asx) / (2.*Root**3 + asx).
       num_prev = num ; den_prev = den
       num = num_prev * (num_prev**3 + 2.0 * asx * (den_prev**3))

--- a/src/framework/MOM_intrinsic_functions.F90
+++ b/src/framework/MOM_intrinsic_functions.F90
@@ -222,7 +222,7 @@ logical function Test_cuberoot(verbose, val)
   logical, intent(in) :: verbose !< If true, write results to stdout
   real, intent(in) :: val  !< The real value to test, in arbitrary units [A]
   ! Local variables
-  real :: diff ! The difference between val and the cube root of its cube.
+  real :: diff ! The difference between val and the cube root of its cube [A].
 
   diff = val - cuberoot(val)**3
   Test_cuberoot = (abs(diff) > 2.0e-15*abs(val))

--- a/src/framework/MOM_intrinsic_functions.F90
+++ b/src/framework/MOM_intrinsic_functions.F90
@@ -4,9 +4,12 @@ module MOM_intrinsic_functions
 
 ! This file is part of MOM6. See LICENSE.md for the license.
 
+use iso_fortran_env, only : stdout => output_unit, stderr => error_unit
+
 implicit none ; private
 
-public :: invcosh
+public :: invcosh, cuberoot
+public :: intrinsic_functions_unit_tests
 
 contains
 
@@ -24,5 +27,132 @@ function invcosh(x)
 #endif
 
 end function invcosh
+
+!> Returns the cube root of a real argument at roundoff accuracy, in a form that works properly with
+!! rescaling of the argument by integer powers of 8.  If the argument is a NaN, a NaN is returned.
+elemental function cuberoot(x) result(root)
+  real, intent(in) :: x !< The argument of cuberoot in arbitrary units cubed [A3]
+  real :: root !< The real cube root of x in arbitrary units [A]
+
+  real :: asx ! The absolute value of x rescaled by an integer power of 8 to put it into
+              ! the range from 0.125 < asx <= 1.0, in ambiguous units cubed [B3]
+  real :: root_asx ! The cube root of asx [B]
+  real :: num ! The numerator of an expression for the evolving estimate of the cube root of asx
+              ! in arbitrary units that can grow or shrink with each iteration [B C]
+  real :: den ! The denominator of an expression for the evolving estimate of the cube root of asx
+              ! in arbitrary units that can grow or shrink with each iteration [C]
+  real :: num_prev ! The numerator of an expression for the previous iteration of the evolving estimate
+              ! of the cube root of asx in arbitrary units that can grow or shrink with each iteration [B D]
+  real :: den_prev ! The denominator of an expression for the previous iteration of the evolving estimate of
+              ! the cube root of asx in arbitrary units that can grow or shrink with each iteration [D]
+  real, parameter :: den_min = 2.**(minexponent(1.) / 4 + 4)  ! A value of den that triggers rescaling [C]
+  real, parameter :: den_max = 2.**(maxexponent(1.) / 4 - 2)  ! A value of den that triggers rescaling [C]
+  integer :: ex_3 ! One third of the exponent part of x, used to rescale x to get a.
+  integer :: itt
+
+  if ((x >= 0.0) .eqv. (x <= 0.0)) then
+    ! Return 0 for an input of 0, or NaN for a NaN input.
+    root = x
+  else
+    ex_3 = ceiling(exponent(x) / 3.)
+    ! Here asx is in the range of 0.125 <= asx < 1.0
+    asx = scale(abs(x), -3*ex_3)
+
+    ! This first estimate is one iteration of Newton's method with a starting guess of 1.  It is
+    ! always an over-estimate of the true solution, but it is a good approximation for asx near 1.
+    num = 2.0 + asx
+    den = 3.0
+    ! Iteratively determine Root = asx**1/3 using Newton's method, noting that in this case Newton's
+    ! method converges monotonically from above and needs no bounding.  For the range of asx from
+    ! 0.125 to 1.0 with the first guess used above, 6 iterations suffice to converge to roundoff.
+    do itt=1,9
+      ! Newton's method iterates estimates as Root = Root - (Root**3 - asx) / (3.0 * Root**2), or
+      ! equivalently as Root = (2.0*Root**2 + asx) / (3.0 * Root**2).
+      ! Keeping the estimates in a fractional form Root = num / den allows this calculation with
+      ! fewer (or no) real divisions during the iterations before doing a single real division
+      ! at the end, and it is therefore more computationally efficient.
+
+      num_prev = num ; den_prev = den
+      num = 2.0 * num_prev**3 + asx * den_prev**3
+      den = 3.0 * (den_prev * num_prev**2)
+
+      if ((num * den_prev == num_prev * den) .or. (itt == 9)) then
+        !   If successive estimates of root are identical, this is a converged solution.
+        root_asx = num / den
+        exit
+      elseif (num * den_prev > num_prev * den) then
+        !   If the estimates are increasing, this also indicates convergence, but for a more subtle
+        ! reason.  Because Newton's method converges monotonically from above (at least for infinite
+        ! precision math), the only reason why this estimate could increase is if the iterations
+        ! have converged to a roundoff-level limit cycle around an irrational or otherwise
+        ! unrepresentable solution, with values only changing in the last bit or two.  If so, we
+        ! should stop iterating and accept the one of the current or previous solutions, both of
+        ! which will be within numerical roundoff of the true solution.
+        root_asx = num / den
+        ! Pick the more accurate of the last two iterations.
+        ! Given that both of the two previous iterations are within roundoff of the true
+        ! solution, this next step might be overkill.
+        if ( abs(den_prev**3*root_asx**3 - den_prev**3*asx) > abs(num_prev**3 - den_prev**3*asx) ) then
+          ! The previous iteration was slightly more accurate, so use that for root_asx.
+          root_asx = num_prev / den_prev
+        endif
+        exit
+      endif
+
+      ! Because successive estimates of the numerator and denominator tend to be the cube of their
+      ! predecessors, the numerator and denominator need to be rescaled by division when they get
+      ! too large or small to avoid overflow or underflow in the convergence test below.
+      if ((den > den_max) .or. (den < den_min)) then
+        num = scale(num, -exponent(den))
+        den = scale(den, -exponent(den))
+      endif
+
+    enddo
+
+    root = sign(scale(root_asx, ex_3), x)
+  endif
+
+end function cuberoot
+
+!> Returns true if any unit test of intrinsic_functions fails, or false if they all pass.
+logical function intrinsic_functions_unit_tests(verbose)
+  logical, intent(in) :: verbose !< If true, write results to stdout
+
+  ! Local variables
+  real :: testval  ! A test value for self-consistency testing [nondim]
+  logical :: fail, v
+
+  fail = .false.
+  v = verbose
+  write(stdout,*) '==== MOM_intrinsic_functions: intrinsic_functions_unit_tests ==='
+
+  fail = fail .or. Test_cuberoot(v, 1.2345678901234e9)
+  fail = fail .or. Test_cuberoot(v, -9.8765432109876e-21)
+  fail = fail .or. Test_cuberoot(v, 64.0)
+  fail = fail .or. Test_cuberoot(v, -0.5000000000001)
+  fail = fail .or. Test_cuberoot(v, 0.0)
+  fail = fail .or. Test_cuberoot(v, 1.0)
+  fail = fail .or. Test_cuberoot(v, 0.125)
+  fail = fail .or. Test_cuberoot(v, 0.965)
+
+end function intrinsic_functions_unit_tests
+
+!> True if the cube of cuberoot(val) does not closely match val. False otherwise.
+logical function Test_cuberoot(verbose, val)
+  logical, intent(in) :: verbose !< If true, write results to stdout
+  real, intent(in) :: val  !< The real value to test, in arbitrary units [A]
+  ! Local variables
+  real :: diff ! The difference between val and the cube root of its cube.
+
+  diff = val - cuberoot(val**3)
+  Test_cuberoot = (abs(diff) > 2.0e-15*abs(val))
+
+  if (Test_cuberoot) then
+    write(stdout, '("For val = ",ES22.15,", (val - cuberoot(val**3))) = ",ES9.2," <-- FAIL")') val, diff
+  elseif (verbose) then
+    write(stdout, '("For val = ",ES22.15,", (val - cuberoot(val**3))) = ",ES9.2)') val, diff
+
+  endif
+end function Test_cuberoot
 
 end module MOM_intrinsic_functions

--- a/src/framework/MOM_io_file.F90
+++ b/src/framework/MOM_io_file.F90
@@ -1326,7 +1326,13 @@ subroutine open_file_nc(handle, filename, action, MOM_domain, threading, fileset
 
   if (present(MOM_domain)) then
     handle%domain_decomposed = .true.
-    call hor_index_init(MOM_domain, handle%HI)
+
+    ! Input files use unrotated indexing.
+    if (associated(MOM_domain%domain_in)) then
+      call hor_index_init(MOM_domain%domain_in, handle%HI)
+    else
+      call hor_index_init(MOM_domain, handle%HI)
+    endif
   endif
 
   call handle%axes%init()

--- a/src/framework/MOM_io_file.F90
+++ b/src/framework/MOM_io_file.F90
@@ -34,6 +34,7 @@ use MOM_netcdf, only : write_netcdf_axis
 use MOM_netcdf, only : write_netcdf_attribute
 use MOM_netcdf, only : get_netcdf_size
 use MOM_netcdf, only : get_netcdf_fields
+use MOM_netcdf, only : get_netcdf_filename
 use MOM_netcdf, only : read_netcdf_field
 
 use MOM_error_handler, only : MOM_error, FATAL
@@ -1757,8 +1758,9 @@ subroutine get_field_nc(handle, label, values, rescale)
   ! NOTE: Data on face and vertex points is not yet supported.  This is a
   ! temporary check to detect such cases, but may be removed in the future.
   if (.not. (compute_domain .or. data_domain)) &
-    call MOM_error(FATAL, 'get_field_nc: Only compute and data domains ' // &
-        'are currently supported.')
+    call MOM_error(FATAL, 'get_field_nc trying to read '//trim(label)//' from '//&
+                   trim(get_netcdf_filename(handle%handle_nc))//&
+                   ': Only compute and data domains are currently supported.')
 
   field_nc = handle%fields%get(label)
 

--- a/src/framework/MOM_netcdf.F90
+++ b/src/framework/MOM_netcdf.F90
@@ -39,6 +39,7 @@ public :: write_netcdf_axis
 public :: write_netcdf_attribute
 public :: get_netcdf_size
 public :: get_netcdf_fields
+public :: get_netcdf_filename
 public :: read_netcdf_field
 
 
@@ -722,6 +723,14 @@ subroutine get_netcdf_fields(handle, axes, fields)
   fields(:) = vars(:nfields)
 end subroutine get_netcdf_fields
 
+!> Return the name of a file from a netCDF handle
+function get_netcdf_filename(handle)
+  type(netcdf_file_type), intent(in) :: handle !< A netCDF file handle
+  character(len=:), allocatable :: get_netcdf_filename !< The name of the file that this handle refers to.
+
+  get_netcdf_filename = handle%filename
+
+end function
 
 !> Read the values of a field from a netCDF file
 subroutine read_netcdf_field(handle, field, values, bounds)

--- a/src/framework/MOM_restart.F90
+++ b/src/framework/MOM_restart.F90
@@ -1406,6 +1406,17 @@ subroutine save_restart(directory, time, G, CS, time_stamped, filename, GV, num_
     restartname = trim(CS%restartfile)//trim(restartname)
   endif ; endif
 
+  ! Determine if there is a filename_appendix (used for ensemble runs).
+  call get_filename_appendix(filename_appendix)
+  if (len_trim(filename_appendix) > 0) then
+    length = len_trim(restartname)
+    if (restartname(length-2:length) == '.nc') then
+      restartname = restartname(1:length-3)//'.'//trim(filename_appendix)//'.nc'
+    else
+      restartname = restartname(1:length)  //'.'//trim(filename_appendix)
+    endif
+  endif
+
   next_var = 1
   do while (next_var <= CS%novars )
     start_var = next_var
@@ -1429,17 +1440,6 @@ subroutine save_restart(directory, time, G, CS, time_stamped, filename, GV, num_
 
     enddo
     next_var = m
-
-    ! Determine if there is a filename_appendix (used for ensemble runs).
-    call get_filename_appendix(filename_appendix)
-    if (len_trim(filename_appendix) > 0) then
-      length = len_trim(restartname)
-      if (restartname(length-2:length) == '.nc') then
-        restartname = restartname(1:length-3)//'.'//trim(filename_appendix)//'.nc'
-      else
-        restartname = restartname(1:length)  //'.'//trim(filename_appendix)
-      endif
-    endif
 
     restartpath = trim(directory) // trim(restartname)
 

--- a/src/framework/MOM_string_functions.F90
+++ b/src/framework/MOM_string_functions.F90
@@ -86,7 +86,7 @@ end function left_ints
 
 !> Returns a left-justified string with a real formatted like '(G)'
 function left_real(val)
-  real, intent(in)  :: val !< The real variable to convert to a string
+  real, intent(in)  :: val !< The real variable to convert to a string, in arbitrary units [A]
   character(len=32) :: left_real !< The output string
 
   integer :: l, ind
@@ -139,7 +139,7 @@ end function left_real
 !> Returns a character string of a comma-separated, compact formatted, reals
 !! e.g. "1., 2., 5*3., 5.E2"
 function left_reals(r,sep)
-  real, intent(in) :: r(:) !< The array of real variables to convert to a string
+  real, intent(in) :: r(:) !< The array of real variables to convert to a string, in arbitrary units [A]
   character(len=*), optional, intent(in) :: sep !< The separator between
                                     !! successive values, by default it is ', '.
   character(len=:), allocatable :: left_reals !< The output string
@@ -179,10 +179,10 @@ end function left_reals
 !> Returns True if the string can be read/parsed to give the exact value of "val"
 function isFormattedFloatEqualTo(str, val)
   character(len=*), intent(in) :: str !< The string to parse
-  real,             intent(in) :: val !< The real value to compare with
+  real,             intent(in) :: val !< The real value to compare with, in arbitrary units [A]
   logical                      :: isFormattedFloatEqualTo
   ! Local variables
-  real :: scannedVal
+  real :: scannedVal ! The value extraced from str, in arbitrary units [A]
 
   isFormattedFloatEqualTo=.false.
   read(str(1:),*,err=987) scannedVal
@@ -263,12 +263,12 @@ integer function extract_integer(string, separators, n, missing_value)
 
 end function extract_integer
 
-!> Returns the real corresponding to the nth word in the argument.
+!> Returns the real corresponding to the nth word in the argument, in arbitrary units [A].
 real function extract_real(string, separators, n, missing_value)
   character(len=*), intent(in) :: string     !< String to scan
   character(len=*), intent(in) :: separators !< Characters to use for delineation
   integer,          intent(in) :: n          !< Number of word to extract
-  real, optional,   intent(in) :: missing_value !< Value to assign if word is missing
+  real, optional,   intent(in) :: missing_value !< Value to assign if word is missing, in arbitrary units [A]
   ! Local variables
   character(len=20) :: word
 
@@ -314,6 +314,7 @@ logical function string_functions_unit_tests(verbose)
   logical, intent(in) :: verbose !< If true, write results to stdout
   ! Local variables
   integer :: i(5) = (/ -1, 1, 3, 3, 0 /)
+  ! This is an array of real test values, in arbitrary units [A]
   real :: r(8) = (/ 0., 1., -2., 1.3, 3.E-11, 3.E-11, 3.E-11, -5.1E12 /)
   logical :: fail, v
   fail = .false.
@@ -387,8 +388,8 @@ end function localTestI
 !> True if r1 is not equal to r2. False otherwise.
 logical function localTestR(verbose,r1,r2)
   logical, intent(in) :: verbose !< If true, write results to stdout
-  real, intent(in) :: r1 !< Float
-  real, intent(in) :: r2 !< Float
+  real, intent(in) :: r1 !< The first value to compare, in arbitrary units [A]
+  real, intent(in) :: r2 !< The first value to compare, in arbitrary units [A]
   localTestR=.false.
   if (r1/=r2) localTestR=.true.
   if (localTestR .or. verbose) then

--- a/src/ice_shelf/MOM_ice_shelf_dynamics.F90
+++ b/src/ice_shelf/MOM_ice_shelf_dynamics.F90
@@ -3071,9 +3071,9 @@ subroutine calc_shelf_taub(CS, ISS, G, US, u_shlf, v_shlf)
   real :: umid, vmid, unorm, eps_min ! Velocities [L T-1 ~> m s-1]
   real :: alpha !Coulomb coefficient [nondim]
   real :: Hf !"floatation thickness" for Coulomb friction [Z ~> m]
-  real :: fN !Effective pressure (ice pressure - ocean pressure) for Coulomb friction [R L2 T-2 ~> Pa]
+  real :: fN !Effective pressure (ice pressure - ocean pressure) for Coulomb friction [Pa]
   real :: fB !for Coulomb Friction [(T L-1)^CS%CF_PostPeak ~> (s m-1)^CS%CF_PostPeak]
-  real :: fN_scale !To convert effective pressure to mks units during Coulomb friction
+  real :: fN_scale !To convert effective pressure to mks units during Coulomb friction [Pa T2 R-1 L-2 ~> 1]
 
   isc = G%isc ; jsc = G%jsc ; iec = G%iec ; jec = G%jec
   iscq = G%iscB ; iecq = G%iecB ; jscq = G%jscB ; jecq = G%jecB

--- a/src/ice_shelf/MOM_ice_shelf_dynamics.F90
+++ b/src/ice_shelf/MOM_ice_shelf_dynamics.F90
@@ -2683,8 +2683,8 @@ end subroutine CG_action_subgrid_basal
 !! Returns the sum of the elements in a square matrix. This sum is bitwise identical even if the matrices are rotated.
 subroutine sum_square_matrix(sum_out, mat_in, n)
   integer, intent(in) :: n !< The length and width of each matrix in mat_in
-  real, dimension(n,n), intent(in) :: mat_in !< The four n x n matrices to be summed individually
-  real, intent(out) :: sum_out !< The sums of each of the 4 matrices given in mat_in
+  real, dimension(n,n), intent(in) :: mat_in !< The n x n matrix whose elements will be summed
+  real, intent(out) :: sum_out !< The sum of the elements of matrix mat_in
   integer :: s0,e0,s1,e1
 
   sum_out=0.0

--- a/src/initialization/MOM_coord_initialization.F90
+++ b/src/initialization/MOM_coord_initialization.F90
@@ -235,7 +235,7 @@ subroutine set_coord_from_TS_ref(Rlay, g_prime, GV, US, param_file, eqn_of_state
                  "The initial temperature of the lightest layer.", &
                  units="degC", scale=US%degC_to_C, fail_if_missing=.true.)
   call get_param(param_file, mdl, "S_REF", S_ref, &
-                 "The initial salinities.", units="PSU", default=35.0, scale=US%ppt_to_S)
+                 "The initial salinities.", units="ppt", default=35.0, scale=US%ppt_to_S)
   call get_param(param_file, mdl, "GFS", g_fs, &
                  "The reduced gravity at the free surface.", units="m s-2", &
                  default=GV%g_Earth*US%L_T_to_m_s**2*US%m_to_Z, scale=US%m_s_to_L_T**2*US%Z_to_m)
@@ -376,13 +376,13 @@ subroutine set_coord_from_TS_range(Rlay, g_prime, GV, US, param_file, eqn_of_sta
 
   call get_param(param_file, mdl, "S_REF", S_Ref, &
                  "The default initial salinities.", &
-                 units="PSU", default=35.0, scale=US%ppt_to_S)
+                 units="ppt", default=35.0, scale=US%ppt_to_S)
   call get_param(param_file, mdl, "TS_RANGE_S_LIGHT", S_Light, &
                  "The initial lightest salinities when COORD_CONFIG is set to ts_range.", &
-                 units="PSU", default=US%S_to_ppt*S_Ref, scale=US%ppt_to_S)
+                 units="ppt", default=US%S_to_ppt*S_Ref, scale=US%ppt_to_S)
   call get_param(param_file, mdl, "TS_RANGE_S_DENSE", S_Dense, &
                  "The initial densest salinities when COORD_CONFIG is set to ts_range.", &
-                 units="PSU", default=US%S_to_ppt*S_Ref, scale=US%ppt_to_S)
+                 units="ppt", default=US%S_to_ppt*S_Ref, scale=US%ppt_to_S)
 
   call get_param(param_file, mdl, "TS_RANGE_RESOLN_RATIO", res_rat, &
                  "The ratio of density space resolution in the densest "//&

--- a/src/initialization/MOM_shared_initialization.F90
+++ b/src/initialization/MOM_shared_initialization.F90
@@ -256,8 +256,8 @@ subroutine apply_topography_edits_from_file(D, G, param_file, US)
   call close_file_to_read(ncid, topo_edits_file)
 
   do n = 1, n_edits
-    i = ig(n) - G%isd_global + 2 ! +1 for python indexing and +1 for ig-isd_global+1
-    j = jg(n) - G%jsd_global + 2
+    i = ig(n) - G%idg_offset + 1 ! +1 for python indexing
+    j = jg(n) - G%jdg_offset + 1
     if (i>=G%isc .and. i<=G%iec .and. j>=G%jsc .and. j<=G%jec) then
       if (new_depth(n) /= mask_depth) then
         write(stdout,'(a,3i5,f8.2,a,f8.2,2i4)') &

--- a/src/initialization/MOM_state_initialization.F90
+++ b/src/initialization/MOM_state_initialization.F90
@@ -343,7 +343,8 @@ subroutine MOM_initialize_state(u, v, h, tv, Time, G, GV, US, PF, dirs, &
                                   just_read=just_read)
       case ("dumbbell"); call dumbbell_initialize_thickness(dz, depth_tot, G, GV, US, PF, &
                                   just_read=just_read)
-      case ("soliton"); call soliton_initialize_thickness(dz, depth_tot, G, GV, US)
+      case ("soliton"); call soliton_initialize_thickness(dz, depth_tot, G, GV, US, PF, &
+                                  just_read=just_read)
       case ("phillips"); call Phillips_initialize_thickness(dz, depth_tot, G, GV, US, PF, &
                                   just_read=just_read)
       case ("rossby_front")
@@ -508,7 +509,7 @@ subroutine MOM_initialize_state(u, v, h, tv, Time, G, GV, US, PF, dirs, &
     case ("phillips"); call Phillips_initialize_velocity(u, v, G, GV, US, PF, just_read)
     case ("rossby_front"); call Rossby_front_initialize_velocity(u, v, h, &
                                      G, GV, US, PF, just_read)
-    case ("soliton"); call soliton_initialize_velocity(u, v, G, GV, US)
+    case ("soliton"); call soliton_initialize_velocity(u, v, G, GV, US, PF, just_read)
     case ("USER"); call user_initialize_velocity(u, v, G, GV, US, PF, just_read)
     case default ; call MOM_error(FATAL,  "MOM_initialize_state: "//&
           "Unrecognized velocity configuration "//trim(config))

--- a/src/initialization/MOM_state_initialization.F90
+++ b/src/initialization/MOM_state_initialization.F90
@@ -1745,7 +1745,7 @@ subroutine initialize_temp_salt_fit(T, S, G, GV, US, param_file, eqn_of_state, P
                  units="degC", scale=US%degC_to_C, fail_if_missing=.not.just_read, do_not_log=just_read)
   call get_param(param_file, mdl, "S_REF", S_Ref, &
                  "A reference salinity used in initialization.", &
-                 units="PSU", default=35.0, scale=US%ppt_to_S, do_not_log=just_read)
+                 units="ppt", default=35.0, scale=US%ppt_to_S, do_not_log=just_read)
   call get_param(param_file, mdl, "FIT_SALINITY", fit_salin, &
                  "If true, accept the prescribed temperature and fit the "//&
                  "salinity; otherwise take salinity and fit temperature.", &
@@ -1829,10 +1829,10 @@ subroutine initialize_temp_salt_linear(T, S, G, GV, US, param_file, just_read)
                  units="degC", scale=US%degC_to_C, fail_if_missing=.not.just_read, do_not_log=just_read)
   call get_param(param_file, mdl, "S_TOP", S_top, &
                  "Initial salinity of the top surface.", &
-                 units="PSU", scale=US%ppt_to_S, fail_if_missing=.not.just_read, do_not_log=just_read)
+                 units="ppt", scale=US%ppt_to_S, fail_if_missing=.not.just_read, do_not_log=just_read)
   call get_param(param_file, mdl, "S_RANGE", S_range, &
                  "Initial salinity difference (top-bottom).", &
-                 units="PSU", scale=US%ppt_to_S, fail_if_missing=.not.just_read, do_not_log=just_read)
+                 units="ppt", scale=US%ppt_to_S, fail_if_missing=.not.just_read, do_not_log=just_read)
 
   if (just_read) return ! All run-time parameters have been read, so return.
 
@@ -2645,7 +2645,7 @@ subroutine MOM_temp_salt_initialize_from_Z(h, tv, depth_tot, G, GV, US, PF, just
                  units="degC", default=0.0, scale=US%degC_to_C, do_not_log=just_read)
   call get_param(PF, mdl, "LAND_FILL_SALIN", salt_land_fill, &
                  "A value to use to fill in ocean salinities on land points.", &
-                 units="1e-3", default=35.0, scale=US%ppt_to_S, do_not_log=just_read)
+                 units="ppt", default=35.0, scale=US%ppt_to_S, do_not_log=just_read)
   call get_param(PF, mdl, "HORIZ_INTERP_TOL_TEMP", tol_temp, &
                  "The tolerance in temperature changes between iterations when interpolating "//&
                  "from an input dataset using horiz_interp_and_extrap_tracer.  This routine "//&
@@ -2655,7 +2655,7 @@ subroutine MOM_temp_salt_initialize_from_Z(h, tv, depth_tot, G, GV, US, PF, just
                  "The tolerance in salinity changes between iterations when interpolating "//&
                  "from an input dataset using horiz_interp_and_extrap_tracer.  This routine "//&
                  "converges slowly, so an overly small tolerance can get expensive.", &
-                 units="1e-3", default=1.0e-3, scale=US%ppt_to_S, do_not_log=just_read)
+                 units="ppt", default=1.0e-3, scale=US%ppt_to_S, do_not_log=just_read)
 
   if (just_read) then
     if ((.not.useALEremapping) .and. adjust_temperature) &

--- a/src/initialization/MOM_state_initialization.F90
+++ b/src/initialization/MOM_state_initialization.F90
@@ -1915,7 +1915,6 @@ subroutine initialize_sponges_file(G, GV, US, use_temperature, tv, u, v, depth_t
   character(len=40) :: mdl = "initialize_sponges_file"
   character(len=200) :: damping_file, uv_damping_file, state_file, state_uv_file  ! Strings for filenames
   character(len=200) :: filename, inputdir ! Strings for file/path and path.
-  type(verticalGrid_type) :: GV_loc ! A temporary vertical grid structure
 
   logical :: use_ALE ! True if ALE is being used, False if in layered mode
   logical :: time_space_interp_sponge ! If true use sponge data that need to be interpolated in both
@@ -2102,19 +2101,11 @@ subroutine initialize_sponges_file(G, GV, US, use_temperature, tv, u, v, depth_t
       enddo; enddo ; enddo
       deallocate(eta)
 
-      allocate(h(isd:ied,jsd:jed,nz_data))
       if (use_temperature) then
         allocate(tmp_T(isd:ied,jsd:jed,nz_data))
         allocate(tmp_S(isd:ied,jsd:jed,nz_data))
         call MOM_read_data(filename, potemp_var, tmp_T(:,:,:), G%Domain, scale=US%degC_to_C)
         call MOM_read_data(filename, salin_var, tmp_S(:,:,:), G%Domain, scale=US%ppt_to_S)
-      endif
-
-      GV_loc = GV ; GV_loc%ke = nz_data
-      if (use_temperature .and. associated(tv%eqn_of_state)) then
-        call dz_to_thickness(dz, tmp_T, tmp_S, tv%eqn_of_state, h, G, GV_loc, US)
-      else
-        call dz_to_thickness_simple(dz, h, G, GV_loc, US, layer_mode=.true.)
       endif
 
       if (sponge_uv) then
@@ -2132,7 +2123,6 @@ subroutine initialize_sponges_file(G, GV, US, use_temperature, tv, u, v, depth_t
         deallocate(tmp_S)
         deallocate(tmp_T)
       endif
-      deallocate(h)
       deallocate(dz)
 
       if (sponge_uv) then

--- a/src/initialization/MOM_state_initialization.F90
+++ b/src/initialization/MOM_state_initialization.F90
@@ -2074,9 +2074,9 @@ subroutine initialize_sponges_file(G, GV, US, use_temperature, tv, u, v, depth_t
 !  else
     ! Initialize sponges without supplying sponge grid
 !    if (sponge_uv) then
-!      call initialize_ALE_sponge(Idamp, G, GV, param_file, ALE_CSp, Idamp_u, Idamp_v)
+!      call initialize_ALE_sponge(Idamp, G, GV, US, param_file, ALE_CSp, Idamp_u, Idamp_v)
 !    else
-!      call initialize_ALE_sponge(Idamp, G, GV, param_file, ALE_CSp)
+!      call initialize_ALE_sponge(Idamp, G, GV, US, param_file, ALE_CSp)
 !    endif
   endif
 
@@ -2118,9 +2118,11 @@ subroutine initialize_sponges_file(G, GV, US, use_temperature, tv, u, v, depth_t
       endif
 
       if (sponge_uv) then
-        call initialize_ALE_sponge(Idamp, G, GV, param_file, ALE_CSp, h, nz_data, Idamp_u, Idamp_v)
+        call initialize_ALE_sponge(Idamp, G, GV, param_file, ALE_CSp, dz, nz_data, Idamp_u, Idamp_v, &
+                                   data_h_is_Z=.true.)
       else
-        call initialize_ALE_sponge(Idamp, G, GV, param_file, ALE_CSp, h, nz_data)
+        call initialize_ALE_sponge(Idamp, G, GV, param_file, ALE_CSp, dz, nz_data, &
+                                   data_h_is_Z=.true.)
       endif
       if (use_temperature) then
         call set_up_ALE_sponge_field(tmp_T, G, GV, tv%T, ALE_CSp, 'temp', &
@@ -2147,9 +2149,9 @@ subroutine initialize_sponges_file(G, GV, US, use_temperature, tv, u, v, depth_t
     else
       ! Initialize sponges without supplying sponge grid
       if (sponge_uv) then
-        call initialize_ALE_sponge(Idamp, G, GV, param_file, ALE_CSp, Idamp_u, Idamp_v)
+        call initialize_ALE_sponge(Idamp, G, GV, US, param_file, ALE_CSp, Idamp_u, Idamp_v)
       else
-        call initialize_ALE_sponge(Idamp, G, GV, param_file, ALE_CSp)
+        call initialize_ALE_sponge(Idamp, G, GV, US, param_file, ALE_CSp)
       endif
       ! The remaining calls to set_up_sponge_field can be in any order.
       if ( use_temperature) then

--- a/src/initialization/MOM_tracer_initialization_from_Z.F90
+++ b/src/initialization/MOM_tracer_initialization_from_Z.F90
@@ -200,8 +200,10 @@ subroutine MOM_initialize_tracer_from_Z(h, tr, G, GV, US, PF, src_file, src_var_
     enddo ; enddo
 
     if (h_is_in_Z_units) then
+      ! Because h is in units of [Z ~> m], dzSrc is already in the right units, but we need to
+      ! specify negligible thickness values with the right units.
       dz_neglect = set_dz_neglect(GV, US, remap_answer_date, dz_neglect_edge)
-      call ALE_remap_scalar(remapCS, G, GV, kd, hSrc, tr_z, h, tr, all_cells=.false., answer_date=remap_answer_date, &
+      call ALE_remap_scalar(remapCS, G, GV, kd, dzSrc, tr_z, h, tr, all_cells=.false., answer_date=remap_answer_date, &
                             H_neglect=dz_neglect, H_neglect_edge=dz_neglect_edge)
     else
       ! Equation of state data is not available, so a simpler rescaling will have to suffice,

--- a/src/initialization/MOM_tracer_initialization_from_Z.F90
+++ b/src/initialization/MOM_tracer_initialization_from_Z.F90
@@ -217,7 +217,7 @@ subroutine MOM_initialize_tracer_from_Z(h, tr, G, GV, US, PF, src_file, src_var_
     deallocate( h1 )
 
     do k=1,nz
-      call myStats(tr(:,:,k), missing_value, is, ie, js, je, k, 'Tracer from ALE()')
+      call myStats(tr(:,:,k), missing_value, G, k, 'Tracer from ALE()')
     enddo
     call cpu_clock_end(id_clock_ALE)
   endif ! useALEremapping

--- a/src/initialization/MOM_tracer_initialization_from_Z.F90
+++ b/src/initialization/MOM_tracer_initialization_from_Z.F90
@@ -3,20 +3,21 @@ module MOM_tracer_initialization_from_Z
 
 ! This file is part of MOM6. See LICENSE.md for the license.
 
-use MOM_debugging, only : hchksum
-use MOM_cpu_clock, only : cpu_clock_id, cpu_clock_begin, cpu_clock_end
-use MOM_cpu_clock, only : CLOCK_ROUTINE, CLOCK_LOOP
-use MOM_domains, only : pass_var
+use MOM_debugging,     only : hchksum
+use MOM_cpu_clock,     only : cpu_clock_id, cpu_clock_begin, cpu_clock_end
+use MOM_cpu_clock,     only : CLOCK_ROUTINE, CLOCK_LOOP
+use MOM_domains,       only : pass_var
 use MOM_error_handler, only : MOM_mesg, MOM_error, FATAL, WARNING
 use MOM_error_handler, only : callTree_enter, callTree_leave, callTree_waypoint
-use MOM_file_parser, only : get_param, param_file_type, log_version
-use MOM_grid, only : ocean_grid_type
+use MOM_file_parser,   only : get_param, param_file_type, log_version
+use MOM_grid,          only : ocean_grid_type
 use MOM_horizontal_regridding, only : myStats, horiz_interp_and_extrap_tracer
 use MOM_interface_heights, only : dz_to_thickness_simple
-use MOM_remapping, only : remapping_CS, initialize_remapping
-use MOM_unit_scaling, only : unit_scale_type
-use MOM_verticalGrid, only : verticalGrid_type
-use MOM_ALE, only : ALE_remap_scalar
+use MOM_regridding,    only : set_dz_neglect
+use MOM_remapping,     only : remapping_CS, initialize_remapping
+use MOM_unit_scaling,  only : unit_scale_type
+use MOM_verticalGrid,  only : verticalGrid_type
+use MOM_ALE,           only : ALE_remap_scalar
 
 implicit none ; private
 
@@ -36,12 +37,13 @@ contains
 !> Initializes a tracer from a z-space data file, including any lateral regridding that is needed.
 subroutine MOM_initialize_tracer_from_Z(h, tr, G, GV, US, PF, src_file, src_var_nam, &
                           src_var_unit_conversion, src_var_record, homogenize, &
-                          useALEremapping, remappingScheme, src_var_gridspec )
+                          useALEremapping, remappingScheme, src_var_gridspec, h_in_Z_units )
   type(ocean_grid_type),      intent(inout) :: G   !< Ocean grid structure.
   type(verticalGrid_type),    intent(in)    :: GV  !< Ocean vertical grid structure.
   type(unit_scale_type),      intent(in)    :: US  !< A dimensional unit scaling type
   real, dimension(SZI_(G),SZJ_(G),SZK_(GV)), &
-                              intent(in)    :: h   !< Layer thickness [H ~> m or kg m-2].
+                              intent(in)    :: h   !< Layer thicknesses, in [H ~> m or kg m-2] or
+                                                   !! [Z ~> m] depending on the value of h_in_Z_units.
   real, dimension(:,:,:),     pointer       :: tr  !< Pointer to array to be initialized [CU ~> conc]
   type(param_file_type),      intent(in)    :: PF  !< parameter file
   character(len=*),           intent(in)    :: src_file !< source filename
@@ -54,12 +56,18 @@ subroutine MOM_initialize_tracer_from_Z(h, tr, G, GV, US, PF, src_file, src_var_
   character(len=*), optional, intent(in)    :: remappingScheme !< remapping scheme to use.
   character(len=*), optional, intent(in)    :: src_var_gridspec !< Source variable name in a gridspec file.
                                                                 !! This is not implemented yet.
+  logical,          optional, intent(in)    :: h_in_Z_units !< If present and true, the input grid
+                                                            !! thicknesses are in the units of height
+                                                            !! ([Z ~> m]) instead of the usual units of
+                                                            !! thicknesses ([H ~> m or kg m-2])
+
   ! Local variables
   real :: land_fill = 0.0  ! A value to use to replace missing values [CU ~> conc]
   real :: convert ! A conversion factor into the model's internal units [CU conc-1 ~> 1]
   integer            :: recnum
   character(len=64)  :: remapScheme
   logical            :: homog, useALE
+  logical            :: h_is_in_Z_units
 
   ! This include declares and sets the variable "version".
 # include "version_variable.h"
@@ -84,6 +92,10 @@ subroutine MOM_initialize_tracer_from_Z(h, tr, G, GV, US, PF, src_file, src_var_
   type(verticalGrid_type) :: GV_loc ! A temporary vertical grid structure
 
   real :: missing_value ! A value indicating that there is no valid input data at this point [CU ~> conc]
+  real :: dz_neglect              ! A negligibly small vertical layer extent used in
+                                  ! remapping cell reconstructions [Z ~> m]
+  real :: dz_neglect_edge         ! A negligibly small vertical layer extent used in
+                                  ! remapping edge value calculations [Z ~> m]
   integer :: nPoints    ! The number of valid input data points in a column
   integer :: id_clock_routine, id_clock_ALE
   integer :: default_answer_date  ! The default setting for the various ANSWER_DATE flags.
@@ -143,6 +155,8 @@ subroutine MOM_initialize_tracer_from_Z(h, tr, G, GV, US, PF, src_file, src_var_
   convert = 1.0
   if (PRESENT(src_var_unit_conversion)) convert = src_var_unit_conversion
 
+  h_is_in_Z_units = .false. ; if (present(h_in_Z_units)) h_is_in_Z_units = h_in_Z_units
+
   call horiz_interp_and_extrap_tracer(src_file, src_var_nam, recnum, &
             G, tr_z, mask_z, z_in, z_edges_in, missing_value, &
             scale=convert, homogenize=homog, m_to_Z=US%m_to_Z, answer_date=hor_regrid_answer_date)
@@ -185,12 +199,18 @@ subroutine MOM_initialize_tracer_from_Z(h, tr, G, GV, US, PF, src_file, src_var_
       dzSrc(i,j,:) = h1(:)
     enddo ; enddo
 
-    ! Equation of state data is not available, so a simpler rescaling will have to suffice,
-    ! but it might be problematic in non-Boussinesq mode.
-    GV_loc = GV ; GV_loc%ke = kd
-    call dz_to_thickness_simple(dzSrc, hSrc, G, GV_loc, US)
+    if (h_is_in_Z_units) then
+      dz_neglect = set_dz_neglect(GV, US, remap_answer_date, dz_neglect_edge)
+      call ALE_remap_scalar(remapCS, G, GV, kd, hSrc, tr_z, h, tr, all_cells=.false., answer_date=remap_answer_date, &
+                            H_neglect=dz_neglect, H_neglect_edge=dz_neglect_edge)
+    else
+      ! Equation of state data is not available, so a simpler rescaling will have to suffice,
+      ! but it might be problematic in non-Boussinesq mode.
+      GV_loc = GV ; GV_loc%ke = kd
+      call dz_to_thickness_simple(dzSrc, hSrc, G, GV_loc, US)
 
-    call ALE_remap_scalar(remapCS, G, GV, kd, hSrc, tr_z, h, tr, all_cells=.false., answer_date=remap_answer_date )
+      call ALE_remap_scalar(remapCS, G, GV, kd, hSrc, tr_z, h, tr, all_cells=.false., answer_date=remap_answer_date )
+    endif
 
     deallocate( hSrc )
     deallocate( dzSrc )

--- a/src/parameterizations/lateral/MOM_Zanna_Bolton.F90
+++ b/src/parameterizations/lateral/MOM_Zanna_Bolton.F90
@@ -1083,7 +1083,7 @@ subroutine compute_energy_source(u, v, h, fx, fy, G, GV, CS)
       call do_group_pass(pass_KE_uv, G%domain)
       do j=js,je ; do i=is,ie
         KE_term(i,j,k) = 0.5 * G%IareaT(i,j) &
-            * (KE_u(I,j) + KE_u(I-1,j) + KE_v(i,J) + KE_v(i,J-1))
+            * ((KE_u(I,j) + KE_u(I-1,j)) + (KE_v(i,J) + KE_v(i,J-1)))
       enddo ; enddo
     enddo
 

--- a/src/parameterizations/lateral/MOM_hor_visc.F90
+++ b/src/parameterizations/lateral/MOM_hor_visc.F90
@@ -2973,7 +2973,7 @@ end subroutine smooth_x9_h
 !! input fields have valid values in the first two halo points upon entry.
 subroutine smooth_x9_uv(G, field_u, field_v, zero_land)
   type(ocean_grid_type),             intent(in)    :: G         !< Ocean grid
-  real, dimension(SZIB_(G),SZJ_(G)), intent(inout) :: field_u   !< u-point field to be smoothed[arbitrary]
+  real, dimension(SZIB_(G),SZJ_(G)), intent(inout) :: field_u   !< u-point field to be smoothed [arbitrary]
   real, dimension(SZI_(G),SZJB_(G)), intent(inout) :: field_v   !< v-point field to be smoothed [arbitrary]
   logical,                 optional, intent(in)    :: zero_land !< If present and false, return the average
                                                                 !! of the surrounding ocean points when

--- a/src/parameterizations/lateral/MOM_hor_visc.F90
+++ b/src/parameterizations/lateral/MOM_hor_visc.F90
@@ -561,12 +561,12 @@ subroutine horizontal_viscosity(u, v, h, diffu, diffv, MEKE, VarMix, G, GV, US, 
   !$OMP   CS, G, GV, US, OBC, VarMix, MEKE, u, v, h, &
   !$OMP   is, ie, js, je, Isq, Ieq, Jsq, Jeq, nz, &
   !$OMP   apply_OBC, rescale_Kh, legacy_bound, find_FrictWork, &
-  !$OMP   use_MEKE_Ku, use_MEKE_Au, &
+  !$OMP   use_MEKE_Ku, use_MEKE_Au, use_cont_huv, &
   !$OMP   backscat_subround, GME_effic_h, GME_effic_q, &
   !$OMP   h_neglect, h_neglect3, inv_PI3, inv_PI6, &
   !$OMP   diffu, diffv, Kh_h, Kh_q, Ah_h, Ah_q, FrictWork, FrictWork_GME, &
   !$OMP   div_xx_h, sh_xx_h, vort_xy_q, sh_xy_q, GME_coeff_h, GME_coeff_q, &
-  !$OMP   KH_u_GME, KH_v_GME, grid_Re_Kh, grid_Re_Ah, NoSt, ShSt &
+  !$OMP   KH_u_GME, KH_v_GME, grid_Re_Kh, grid_Re_Ah, NoSt, ShSt, hu_cont, hv_cont &
   !$OMP ) &
   !$OMP private( &
   !$OMP   i, j, k, n, &

--- a/src/parameterizations/lateral/MOM_internal_tides.F90
+++ b/src/parameterizations/lateral/MOM_internal_tides.F90
@@ -146,15 +146,20 @@ type, public :: int_tide_CS ; private
                         !< The internal wave energy density as a function of (i,j,angle,frequency,mode)
                         !! integrated within an angular and frequency band [R Z3 T-2 ~> J m-2]
   real, allocatable :: En_restart_mode1(:,:,:,:)
-                        !< The internal wave energy density as a function of (i,j,angle,freq) for mode 1
+                        !< The internal wave energy density as a function of (i,j,angle,freq)
+                        !! for mode 1 [R Z3 T-2 ~> J m-2]
   real, allocatable :: En_restart_mode2(:,:,:,:)
-                        !< The internal wave energy density as a function of (i,j,angle,freq) for mode 2
+                        !< The internal wave energy density as a function of (i,j,angle,freq)
+                        !! for mode 2 [R Z3 T-2 ~> J m-2]
   real, allocatable :: En_restart_mode3(:,:,:,:)
-                        !< The internal wave energy density as a function of (i,j,angle,freq) for mode 3
+                        !< The internal wave energy density as a function of (i,j,angle,freq)
+                        !! for mode 3 [R Z3 T-2 ~> J m-2]
   real, allocatable :: En_restart_mode4(:,:,:,:)
-                        !< The internal wave energy density as a function of (i,j,angle,freq) for mode 4
+                        !< The internal wave energy density as a function of (i,j,angle,freq)
+                        !! for mode 4 [R Z3 T-2 ~> J m-2]
   real, allocatable :: En_restart_mode5(:,:,:,:)
-                        !< The internal wave energy density as a function of (i,j,angle,freq) for mode 5
+                        !< The internal wave energy density as a function of (i,j,angle,freq)
+                        !! for mode 5 [R Z3 T-2 ~> J m-2]
 
   real, allocatable, dimension(:) :: frequency  !< The frequency of each band [T-1 ~> s-1].
 
@@ -1795,9 +1800,9 @@ subroutine propagate_y(En, speed_y, Cgy_av, dCgy, dt, G, US, Nangle, CS, LB, res
   real, dimension(G%isd:G%ied,G%JsdB:G%JedB),      &
                            intent(in)    :: speed_y !< The magnitude of the group velocity at the
                                                !! Cv points [L T-1 ~> m s-1].
-  real, dimension(Nangle), intent(in)    :: Cgy_av !< The average y-projection in each angular band.
+  real, dimension(Nangle), intent(in)    :: Cgy_av !< The average y-projection in each angular band [nondim]
   real, dimension(Nangle), intent(in)    :: dCgy !< The difference in y-projections between the
-                                               !! edges of each angular band.
+                                               !! edges of each angular band [nondim]
   real,                    intent(in)    :: dt !< Time increment [T ~> s].
   type(unit_scale_type),   intent(in)    :: US !< A dimensional unit scaling type
   type(int_tide_CS),       intent(in)    :: CS !< Internal tide control structure
@@ -2425,7 +2430,7 @@ subroutine register_int_tide_restarts(G, US, param_file, CS, restart_CS)
   character(64) :: var_name, cfr
 
   type(axis_info) :: axes_inttides(2)
-  real, dimension(:), allocatable :: angles, freqs
+  real, dimension(:), allocatable :: angles, freqs ! Lables for angles and frequencies [nondim]
 
   isd = G%isd ; ied = G%ied ; jsd = G%jsd ; jed = G%jed
 

--- a/src/parameterizations/lateral/MOM_lateral_mixing_coeffs.F90
+++ b/src/parameterizations/lateral/MOM_lateral_mixing_coeffs.F90
@@ -170,7 +170,7 @@ type, public :: VarMix_CS
 end type VarMix_CS
 
 public VarMix_init, VarMix_end, calc_slope_functions, calc_resoln_function
-public calc_QG_Leith_viscosity, calc_depth_function
+public calc_QG_slopes, calc_QG_Leith_viscosity, calc_depth_function
 
 contains
 
@@ -474,14 +474,13 @@ subroutine calc_slope_functions(h, tv, dt, G, GV, US, CS, OBC)
   type(VarMix_CS),                           intent(inout) :: CS !< Variable mixing control structure
   type(ocean_OBC_type),                      pointer       :: OBC !< Open boundaries control structure
   ! Local variables
-  real, dimension(SZI_(G), SZJ_(G),SZK_(GV)+1) :: &
-    e             ! The interface heights relative to mean sea level [Z ~> m].
-  real, dimension(SZIB_(G), SZJ_(G),SZK_(GV)+1) :: N2_u ! Square of Brunt-Vaisala freq at u-points [L2 Z-2 T-2 ~> s-2]
-  real, dimension(SZI_(G), SZJB_(G),SZK_(GV)+1) :: N2_v ! Square of Brunt-Vaisala freq at v-points [L2 Z-2 T-2 ~> s-2]
-  real, dimension(SZIB_(G), SZJ_(G),SZK_(GV)+1) :: dzu ! Z-thickness at u-points [Z ~> m]
-  real, dimension(SZI_(G), SZJB_(G),SZK_(GV)+1) :: dzv ! Z-thickness at v-points [Z ~> m]
-  real, dimension(SZIB_(G), SZJ_(G),SZK_(GV)+1) :: dzSxN ! |Sx| N times dz at u-points [Z T-1 ~> m s-1]
-  real, dimension(SZI_(G), SZJB_(G),SZK_(GV)+1) :: dzSyN ! |Sy| N times dz at v-points [Z T-1 ~> m s-1]
+  real, dimension(SZI_(G),SZJ_(G),SZK_(GV)+1)  :: e    ! The interface heights relative to mean sea level [Z ~> m]
+  real, dimension(SZIB_(G),SZJ_(G),SZK_(GV)+1) :: N2_u ! Square of Brunt-Vaisala freq at u-points [L2 Z-2 T-2 ~> s-2]
+  real, dimension(SZI_(G),SZJB_(G),SZK_(GV)+1) :: N2_v ! Square of Brunt-Vaisala freq at v-points [L2 Z-2 T-2 ~> s-2]
+  real, dimension(SZIB_(G),SZJ_(G),SZK_(GV)+1) :: dzu  ! Z-thickness at u-points [Z ~> m]
+  real, dimension(SZI_(G),SZJB_(G),SZK_(GV)+1) :: dzv  ! Z-thickness at v-points [Z ~> m]
+  real, dimension(SZIB_(G),SZJ_(G),SZK_(GV)+1) :: dzSxN ! |Sx| N times dz at u-points [Z T-1 ~> m s-1]
+  real, dimension(SZI_(G),SZJB_(G),SZK_(GV)+1) :: dzSyN ! |Sy| N times dz at v-points [Z T-1 ~> m s-1]
 
   if (.not. CS%initialized) call MOM_error(FATAL, "MOM_lateral_mixing_coeffs.F90, calc_slope_functions: "//&
          "Module must be initialized before it is used.")
@@ -996,18 +995,47 @@ subroutine calc_slope_functions_using_just_e(h, G, GV, US, CS, e, calculate_slop
 
 end subroutine calc_slope_functions_using_just_e
 
+
+!> Calculates and returns isopycnal slopes with wider halos for use in finding QG viscosity.
+subroutine calc_QG_slopes(h, tv, dt, G, GV, US, slope_x, slope_y, CS, OBC)
+  type(ocean_grid_type),                        intent(in)    :: G  !< Ocean grid structure
+  type(verticalGrid_type),                      intent(in)    :: GV !< Vertical grid structure
+  type(unit_scale_type),                        intent(in)    :: US !< A dimensional unit scaling type
+  real, dimension(SZI_(G),SZJ_(G),SZK_(GV)),    intent(in)    :: h  !< Layer thickness [H ~> m or kg m-2]
+  type(thermo_var_ptrs),                        intent(in)    :: tv !< Thermodynamic variables
+  real,                                         intent(in)    :: dt !< Time increment [T ~> s]
+  real, dimension(SZIB_(G),SZJ_(G),SZK_(GV)+1), intent(inout) :: slope_x !< Isopycnal slope in i-dir [Z L-1 ~> nondim]
+  real, dimension(SZI_(G),SZJB_(G),SZK_(GV)+1), intent(inout) :: slope_y !< Isopycnal slope in j-dir [Z L-1 ~> nondim]
+  type(VarMix_CS),                              intent(in)    :: CS !< Variable mixing control structure
+  type(ocean_OBC_type),                         pointer       :: OBC !< Open boundaries control structure
+  ! Local variables
+  real, dimension(SZI_(G),SZJ_(G),SZK_(GV)+1)  :: e    ! The interface heights relative to mean sea level [Z ~> m]
+
+  if (.not. CS%initialized) call MOM_error(FATAL, "MOM_lateral_mixing_coeffs.F90, calc_QG_slopes: "//&
+         "Module must be initialized before it is used.")
+
+  call find_eta(h, tv, G, GV, US, e, halo_size=3)
+  call calc_isoneutral_slopes(G, GV, US, h, e, tv, dt*CS%kappa_smooth, CS%use_stanley_iso, &
+                              slope_x, slope_y, halo=2, OBC=OBC)
+
+end subroutine calc_QG_slopes
+
 !> Calculates the Leith Laplacian and bi-harmonic viscosity coefficients
-subroutine calc_QG_Leith_viscosity(CS, G, GV, US, h, k, div_xx_dx, div_xx_dy, vort_xy_dx, vort_xy_dy)
+subroutine calc_QG_Leith_viscosity(CS, G, GV, US, h, dz, k, div_xx_dx, div_xx_dy, slope_x, slope_y, &
+                                   vort_xy_dx, vort_xy_dy)
   type(VarMix_CS),                           intent(inout) :: CS !< Variable mixing coefficients
-  type(ocean_grid_type),                     intent(in)  :: G  !< Ocean grid structure
-  type(verticalGrid_type),                   intent(in)  :: GV !< The ocean's vertical grid structure.
-  type(unit_scale_type),                     intent(in)  :: US   !< A dimensional unit scaling type
-  real, dimension(SZI_(G),SZJ_(G),SZK_(GV)), intent(inout) :: h !< Layer thickness [H ~> m or kg m-2]
-  integer,                                   intent(in)  :: k  !< Layer for which to calculate vorticity magnitude
-  real, dimension(SZIB_(G),SZJ_(G)),         intent(in)  :: div_xx_dx  !< x-derivative of horizontal divergence
+  type(ocean_grid_type),                     intent(in)    :: G  !< Ocean grid structure
+  type(verticalGrid_type),                   intent(in)    :: GV !< The ocean's vertical grid structure.
+  type(unit_scale_type),                     intent(in)    :: US !< A dimensional unit scaling type
+  real, dimension(SZI_(G),SZJ_(G),SZK_(GV)), intent(in)    :: h  !< Layer thickness [H ~> m or kg m-2]
+  real, dimension(SZI_(G),SZJ_(G),SZK_(GV)), intent(in)    :: dz !< Layer vertical extents [Z ~> m]
+  integer,                                   intent(in)    :: k  !< Layer for which to calculate vorticity magnitude
+  real, dimension(SZIB_(G),SZJ_(G)),         intent(in)    :: div_xx_dx  !< x-derivative of horizontal divergence
                                                                  !! (d/dx(du/dx + dv/dy)) [L-1 T-1 ~> m-1 s-1]
-  real, dimension(SZI_(G),SZJB_(G)),         intent(in)  :: div_xx_dy  !< y-derivative of horizontal divergence
+  real, dimension(SZI_(G),SZJB_(G)),         intent(in)    :: div_xx_dy  !< y-derivative of horizontal divergence
                                                                  !! (d/dy(du/dx + dv/dy)) [L-1 T-1 ~> m-1 s-1]
+  real, dimension(SZIB_(G),SZJ_(G),SZK_(GV)+1), intent(inout) :: slope_x !< Isopycnal slope in i-dir [Z L-1 ~> nondim]
+  real, dimension(SZI_(G),SZJB_(G),SZK_(GV)+1), intent(inout) :: slope_y !< Isopycnal slope in j-dir [Z L-1 ~> nondim]
   real, dimension(SZI_(G),SZJB_(G)),         intent(inout) :: vort_xy_dx !< x-derivative of vertical vorticity
                                                                  !! (d/dx(dv/dx - du/dy)) [L-1 T-1 ~> m-1 s-1]
   real, dimension(SZIB_(G),SZJ_(G)),         intent(inout) :: vort_xy_dy !< y-derivative of vertical vorticity
@@ -1030,6 +1058,8 @@ subroutine calc_QG_Leith_viscosity(CS, G, GV, US, h, k, div_xx_dx, div_xx_dy, vo
   real :: h_at_slope_below ! The thickness below [H ~> m or kg m-2]
   real :: Ih ! The inverse of a combination of thicknesses [H-1 ~> m-1 or m2 kg-1]
   real :: f  ! A copy of the Coriolis parameter [T-1 ~> s-1]
+  real :: Z_to_H  ! A local copy of depth to thickness conversion factors or the inverse of the
+                  ! mass-weighted average specific volumes around an interface [H Z-1 ~> nondim or kg m-3]
   real :: inv_PI3 ! The inverse of pi cubed [nondim]
   integer :: i, j, is, ie, js, je, Isq, Ieq, Jsq, Jeq, nz
 
@@ -1038,41 +1068,41 @@ subroutine calc_QG_Leith_viscosity(CS, G, GV, US, h, k, div_xx_dx, div_xx_dy, vo
   nz = GV%ke
 
   inv_PI3 = 1.0 / ((4.0*atan(1.0))**3)
+  Z_to_H = GV%Z_to_H  ! This will be replaced with a varying value in non-Boussinesq mode.
 
   if ((k > 1) .and. (k < nz)) then
 
-    ! With USE_QG_LEITH_VISC=True, this might need to change to
-    !  do j=js-2,je+2 ; do I=is-2,ie+1
-    ! but other arrays used here (e.g., h and CS%slope_x) would also need to have wider valid halos.
-    do j=js-1,je+1 ; do I=is-2,Ieq+1
+    do j=js-2,je+2 ; do I=is-2,ie+1
       h_at_slope_above = 2. * ( h(i,j,k-1) * h(i+1,j,k-1) ) * ( h(i,j,k) * h(i+1,j,k) ) / &
                          ( ( h(i,j,k-1) * h(i+1,j,k-1) ) * ( h(i,j,k) + h(i+1,j,k) ) &
-                         + ( h(i,j,k) * h(i+1,j,k) ) * ( h(i,j,k-1) + h(i+1,j,k-1) ) + GV%H_subroundoff**2 )
+                         + ( h(i,j,k) * h(i+1,j,k) ) * ( h(i,j,k-1) + h(i+1,j,k-1) ) + GV%H_subroundoff**3 )
       h_at_slope_below = 2. * ( h(i,j,k) * h(i+1,j,k) ) * ( h(i,j,k+1) * h(i+1,j,k+1) ) / &
                          ( ( h(i,j,k) * h(i+1,j,k) ) * ( h(i,j,k+1) + h(i+1,j,k+1) ) &
-                         + ( h(i,j,k+1) * h(i+1,j,k+1) ) * ( h(i,j,k) + h(i+1,j,k) ) + GV%H_subroundoff**2 )
-      Ih = 1. / ( h_at_slope_above + h_at_slope_below + GV%H_subroundoff )
-      dslopex_dz(I,j) = 2. * ( CS%slope_x(i,j,k) - CS%slope_x(i,j,k+1) ) * (GV%Z_to_H * Ih)
+                         + ( h(i,j,k+1) * h(i+1,j,k+1) ) * ( h(i,j,k) + h(i+1,j,k) ) + GV%H_subroundoff**3 )
+      Ih = 1./ ( h_at_slope_above + h_at_slope_below + GV%H_subroundoff )
+      if (.not.GV%Boussinesq) &
+        Z_to_H = ( (h(i,j,k-1) + h(i+1,j,k-1)) + (h(i,j,k) + h(i+1,j,k)) ) / &
+                 ( (dz(i,j,k-1) + dz(i+1,j,k-1)) + (dz(i,j,k) + dz(i+1,j,k)) + GV%dZ_subroundoff)
+      dslopex_dz(I,j) = 2. * ( slope_x(I,j,k) - slope_x(I,j,k+1) ) * (Z_to_H * Ih)
       h_at_u(I,j) = 2. * ( h_at_slope_above * h_at_slope_below ) * Ih
     enddo ; enddo
 
-    ! With USE_QG_LEITH_VISC=True, this might need to change to
-    !  do J=js-2,je+1 ; do i=is-2,ie+2
-    do J=js-2,Jeq+1 ; do i=is-1,ie+1
+    do J=js-2,je+1 ; do i=is-2,ie+2
       h_at_slope_above = 2. * ( h(i,j,k-1) * h(i,j+1,k-1) ) * ( h(i,j,k) * h(i,j+1,k) ) / &
                          ( ( h(i,j,k-1) * h(i,j+1,k-1) ) * ( h(i,j,k) + h(i,j+1,k) ) &
-                         + ( h(i,j,k) * h(i,j+1,k) ) * ( h(i,j,k-1) + h(i,j+1,k-1) ) + GV%H_subroundoff**2 )
+                         + ( h(i,j,k) * h(i,j+1,k) ) * ( h(i,j,k-1) + h(i,j+1,k-1) ) + GV%H_subroundoff**3 )
       h_at_slope_below = 2. * ( h(i,j,k) * h(i,j+1,k) ) * ( h(i,j,k+1) * h(i,j+1,k+1) ) / &
                          ( ( h(i,j,k) * h(i,j+1,k) ) * ( h(i,j,k+1) + h(i,j+1,k+1) ) &
-                         + ( h(i,j,k+1) * h(i,j+1,k+1) ) * ( h(i,j,k) + h(i,j+1,k) ) + GV%H_subroundoff**2 )
-      Ih = 1. / ( h_at_slope_above + h_at_slope_below + GV%H_subroundoff )
-      dslopey_dz(i,J) = 2. * ( CS%slope_y(i,j,k) - CS%slope_y(i,j,k+1) ) * (GV%Z_to_H * Ih)
+                         + ( h(i,j,k+1) * h(i,j+1,k+1) ) * ( h(i,j,k) + h(i,j+1,k) ) + GV%H_subroundoff**3 )
+      Ih = 1./ ( h_at_slope_above + h_at_slope_below + GV%H_subroundoff )
+      if (.not.GV%Boussinesq) &
+        Z_to_H = ( (h(i,j,k-1) + h(i,j+1,k-1)) + (h(i,j,k) + h(i,j+1,k)) ) / &
+                 ( (dz(i,j,k-1) + dz(i,j+1,k-1)) + (dz(i,j,k) + dz(i,j+1,k)) + GV%dZ_subroundoff)
+      dslopey_dz(i,J) = 2. * ( slope_y(i,J,k) - slope_y(i,J,k+1) ) * (Z_to_H * Ih)
       h_at_v(i,J) = 2. * ( h_at_slope_above * h_at_slope_below ) * Ih
     enddo ; enddo
 
-    ! With USE_QG_LEITH_VISC=True, this might need to be
-    ! do J=js-2,je+1 ; do i=is-1,ie+1
-    do J=js-1,je ; do i=is-1,Ieq+1
+    do J=js-2,je+1 ; do i=is-1,ie+1
       f = 0.5 * ( G%CoriolisBu(I,J) + G%CoriolisBu(I-1,J) )
       vort_xy_dx(i,J) = vort_xy_dx(i,J) - f * &
             ( ( h_at_u(I,j) * dslopex_dz(I,j) + h_at_u(I-1,j+1) * dslopex_dz(I-1,j+1) ) &
@@ -1080,9 +1110,7 @@ subroutine calc_QG_Leith_viscosity(CS, G, GV, US, h, k, div_xx_dx, div_xx_dy, vo
               ( ( h_at_u(I,j) + h_at_u(I-1,j+1) ) + ( h_at_u(I-1,j) + h_at_u(I,j+1) ) + GV%H_subroundoff)
     enddo ; enddo
 
-    ! With USE_QG_LEITH_VISC=True, this might need to be
-    !  do j=js-1,je+1 ; do I=is-2,ie+1
-    do j=js-1,Jeq+1 ; do I=is-1,ie
+    do j=js-1,je+1 ; do I=is-2,ie+1
       f = 0.5 * ( G%CoriolisBu(I,J) + G%CoriolisBu(I,J-1) )
       vort_xy_dy(I,j) = vort_xy_dy(I,j) - f * &
             ( ( h_at_v(i,J) * dslopey_dz(i,J) + h_at_v(i+1,J-1) * dslopey_dz(i+1,J-1) ) &
@@ -1100,7 +1128,7 @@ subroutine calc_QG_Leith_viscosity(CS, G, GV, US, h, k, div_xx_dx, div_xx_dy, vo
                                                            + (div_xx_dy(i+1,J) + div_xx_dy(i,J-1))))**2)
       if (CS%use_beta_in_QG_Leith) then
         beta_u(I,j) = sqrt((0.5*(G%dF_dx(i,j)+G%dF_dx(i+1,j))**2) + &
-                          (0.5*(G%dF_dy(i,j)+G%dF_dy(i+1,j))**2))
+                           (0.5*(G%dF_dy(i,j)+G%dF_dy(i+1,j))**2))
         CS%KH_u_QG(I,j,k) = MIN(grad_vort_mag_u(I,j) + grad_div_mag_u(I,j), 3.0*beta_u(I,j)) * &
                             CS%Laplac3_const_u(I,j) * inv_PI3
       else
@@ -1116,7 +1144,7 @@ subroutine calc_QG_Leith_viscosity(CS, G, GV, US, h, k, div_xx_dx, div_xx_dy, vo
                                                            + (div_xx_dx(I,j+1) + div_xx_dx(I-1,j))))**2)
       if (CS%use_beta_in_QG_Leith) then
         beta_v(i,J) = sqrt((0.5*(G%dF_dx(i,j)+G%dF_dx(i,j+1))**2) + &
-                          (0.5*(G%dF_dy(i,j)+G%dF_dy(i,j+1))**2))
+                           (0.5*(G%dF_dy(i,j)+G%dF_dy(i,j+1))**2))
         CS%KH_v_QG(i,J,k) = MIN(grad_vort_mag_v(i,J) + grad_div_mag_v(i,J), 3.0*beta_v(i,J)) * &
                             CS%Laplac3_const_v(i,J) * inv_PI3
       else

--- a/src/parameterizations/lateral/MOM_mixed_layer_restrat.F90
+++ b/src/parameterizations/lateral/MOM_mixed_layer_restrat.F90
@@ -1936,12 +1936,12 @@ end function mixedlayer_restrat_unit_tests
 !> Returns true if any cell of u and u_true are not identical. Returns false otherwise.
 logical function test_answer(verbose, u, u_true, label, tol)
   logical,            intent(in) :: verbose !< If true, write results to stdout
-  real,               intent(in) :: u      !< Values to test
-  real,               intent(in) :: u_true !< Values to test against (correct answer)
+  real,               intent(in) :: u      !< Values to test in arbitrary units [A]
+  real,               intent(in) :: u_true !< Values to test against (correct answer) [A]
   character(len=*),   intent(in) :: label  !< Message
-  real, optional,     intent(in) :: tol    !< The tolerance for differences between u and u_true
+  real, optional,     intent(in) :: tol    !< The tolerance for differences between u and u_true [A]
   ! Local variables
-  real :: tolerance ! The tolerance for differences between u and u_true
+  real :: tolerance ! The tolerance for differences between u and u_true [A]
   integer :: k
 
   tolerance = 0.0 ; if (present(tol)) tolerance = tol

--- a/src/parameterizations/lateral/MOM_mixed_layer_restrat.F90
+++ b/src/parameterizations/lateral/MOM_mixed_layer_restrat.F90
@@ -1616,6 +1616,9 @@ logical function mixedlayer_restrat_init(Time, G, GV, US, param_file, diag, CS, 
   CS%use_Bodner = .false.
 
   call get_param(param_file, mdl, "DEBUG", CS%debug, default=.false., do_not_log=.true.)
+  call get_param(param_file, mdl, "DEFAULT_ANSWER_DATE", default_answer_date, &
+      "This sets the default value for the various _ANSWER_DATE parameters.", &
+      default=99991231, do_not_log=.true.)
   call openParameterBlock(param_file,'MLE') ! Prepend MLE% to all parameters
   if (GV%nkml==0) then
     call get_param(param_file, mdl, "USE_BODNER23", CS%use_Bodner, &
@@ -1657,9 +1660,6 @@ logical function mixedlayer_restrat_init(Time, G, GV, US, param_file, diag, CS, 
              "BLD, when the latter is shallower than the running mean. A value of 0 "//&
              "instantaneously sets the running mean to the current value filtered BLD.", &
              units="s", default=0., scale=US%s_to_T)
-    call get_param(param_file, mdl, "DEFAULT_ANSWER_DATE", default_answer_date, &
-             "This sets the default value for the various _ANSWER_DATE parameters.", &
-             default=99991231)
     call get_param(param_file, mdl, "ML_RESTRAT_ANSWER_DATE", CS%answer_date, &
              "The vintage of the order of arithmetic and expressions in the mixed layer "//&
              "restrat calculations.  Values below 20240201 recover the answers from the end "//&

--- a/src/parameterizations/lateral/MOM_mixed_layer_restrat.F90
+++ b/src/parameterizations/lateral/MOM_mixed_layer_restrat.F90
@@ -1767,8 +1767,10 @@ subroutine mixedlayer_restrat_register_restarts(HI, GV, US, param_file, CS, rest
                  units="s", default=0., scale=US%s_to_T, do_not_log=.true.)
   call get_param(param_file, mdl, "MLE_MLD_DECAY_TIME2", CS%MLE_MLD_decay_time2, &
                  units="s", default=0., scale=US%s_to_T, do_not_log=.true.)
-  call get_param(param_file, mdl, "MLE%USE_BODNER23", use_Bodner, &
+  call openParameterBlock(param_file, 'MLE', do_not_log=.true.)
+  call get_param(param_file, mdl, "USE_BODNER23", use_Bodner, &
                  default=.false., do_not_log=.true.)
+  call closeParameterBlock(param_file)
   if (CS%MLE_MLD_decay_time>0. .or. CS%MLE_MLD_decay_time2>0. .or. use_Bodner) then
     ! CS%MLD_filtered is used to keep a running mean of the PBL's actively mixed MLD.
     allocate(CS%MLD_filtered(HI%isd:HI%ied,HI%jsd:HI%jed), source=0.)

--- a/src/parameterizations/lateral/MOM_self_attr_load.F90
+++ b/src/parameterizations/lateral/MOM_self_attr_load.F90
@@ -20,14 +20,17 @@ public calc_SAL, scalar_SAL_sensitivity, SAL_init, SAL_end
 
 !> The control structure for the MOM_self_attr_load module
 type, public :: SAL_CS ; private
-  logical :: use_sal_scalar     !< If true, use the scalar approximation to calculate SAL.
-  logical :: use_sal_sht        !< If true, use online spherical harmonics to calculate SAL
-  logical :: use_tidal_sal_prev !< If true, read the tidal SAL from the previous iteration of
-                                !! the tides to facilitate convergence.
+  logical :: use_sal_scalar = .false.
+    !< If true, use the scalar approximation to calculate SAL.
+  logical :: use_sal_sht = .false.
+    !< If true, use online spherical harmonics to calculate SAL
+  logical :: use_tidal_sal_prev = .false.
+    !< If true, read the tidal SAL from the previous iteration of the tides to
+    !! facilitate convergence.
   real    :: sal_scalar_value   !< The constant of proportionality between sea surface height
                                 !! (really it should be bottom pressure) anomalies and bottom
                                 !! geopotential anomalies [nondim].
-  type(sht_CS) :: sht           !< Spherical harmonic transforms (SHT) control structure
+  type(sht_CS), allocatable :: sht  !< Spherical harmonic transforms (SHT) control structure
   integer :: sal_sht_Nd         !< Maximum degree for SHT [nodim]
   real, allocatable :: Love_Scaling(:) !< Love number for each SHT mode [nodim]
   real, allocatable :: Snm_Re(:), &    !< Real SHT coefficient for SHT SAL [Z ~> m]
@@ -218,6 +221,8 @@ subroutine SAL_init(G, US, param_file, CS)
 
     allocate(CS%Love_Scaling(lmax)); CS%Love_Scaling(:) = 0.0
     call calc_love_scaling(CS%sal_sht_Nd, rhoW, rhoE, CS%Love_Scaling)
+
+    allocate(CS%sht)
     call spherical_harmonics_init(G, param_file, CS%sht)
   endif
 
@@ -234,6 +239,7 @@ subroutine SAL_end(CS)
     if (allocated(CS%Snm_Re)) deallocate(CS%Snm_Re)
     if (allocated(CS%Snm_Im)) deallocate(CS%Snm_Im)
     call spherical_harmonics_end(CS%sht)
+    deallocate(CS%sht)
   endif
 end subroutine SAL_end
 

--- a/src/parameterizations/lateral/MOM_thickness_diffuse.F90
+++ b/src/parameterizations/lateral/MOM_thickness_diffuse.F90
@@ -773,11 +773,10 @@ subroutine thickness_diffuse_full(h, e, Kh_u, Kh_v, tv, uhD, vhD, cg1, dt, G, GV
 
   I4dt = 0.25 / dt
   I_slope_max2 = 1.0 / (CS%slope_max**2)
-  G_scale = GV%g_Earth * GV%H_to_Z
 
   h_neglect = GV%H_subroundoff ; h_neglect2 = h_neglect**2 ; hn_2 = 0.5*h_neglect
   dz_neglect = GV%dZ_subroundoff ; dz_neglect2 = dz_neglect**2
-  G_rho0 = GV%g_Earth / GV%Rho0
+  if (GV%Boussinesq) G_rho0 = GV%g_Earth / GV%Rho0
   N2_floor = CS%N2_floor * US%Z_to_L**2
 
   use_EOS = associated(tv%eqn_of_state)

--- a/src/parameterizations/stochastic/MOM_stochastics.F90
+++ b/src/parameterizations/stochastic/MOM_stochastics.F90
@@ -35,9 +35,9 @@ type, public:: stochastic_CS
   integer :: id_epbl2_wts = -1 !< Diagnostic id for epbl dissipation perturbation
   ! stochastic patterns
   real, allocatable :: sppt_wts(:,:)  !< Random pattern for ocean SPPT
-                                     !! tendencies with a number between 0 and 2
-  real, allocatable :: epbl1_wts(:,:) !< Random pattern for K.E. generation
-  real, allocatable :: epbl2_wts(:,:) !< Random pattern for K.E. dissipation
+                                      !! tendencies with a number between 0 and 2 [nondim]
+  real, allocatable :: epbl1_wts(:,:) !< Random pattern for K.E. generation [nondim]
+  real, allocatable :: epbl2_wts(:,:) !< Random pattern for K.E. dissipation [nondim]
   type(diag_ctrl), pointer :: diag   !< structure used to regulate timing of diagnostic output
   type(time_type), pointer :: Time !< Pointer to model time (needed for sponges)
 end type stochastic_CS

--- a/src/parameterizations/vertical/MOM_CVMix_ddiff.F90
+++ b/src/parameterizations/vertical/MOM_CVMix_ddiff.F90
@@ -245,8 +245,8 @@ subroutine compute_ddiff_coeffs(h, tv, G, GV, US, j, Kd_T, Kd_S, CS, R_rho)
       iFaceHeight(k+1) = iFaceHeight(k) - dh
     enddo
 
-    ! gets index of the level and interface above hbl
-    !kOBL = CVmix_kpp_compute_kOBL_depth(iFaceHeight, cellHeight, GV%Z_to_H*hbl(i,j))
+    ! gets index of the level and interface above hbl in [H ~> m or kg m-2]
+    !kOBL = CVmix_kpp_compute_kOBL_depth(iFaceHeight, cellHeight, hbl(i,j))
 
     Kd1_T(:) = 0.0 ; Kd1_S(:) = 0.0
     call CVMix_coeffs_ddiff(Tdiff_out=Kd1_T(:), &

--- a/src/parameterizations/vertical/MOM_bkgnd_mixing.F90
+++ b/src/parameterizations/vertical/MOM_bkgnd_mixing.F90
@@ -59,6 +59,8 @@ type, public :: bkgnd_mixing_cs ; private
   real    :: N0_2Omega              !< ratio of the typical Buoyancy frequency to
                                     !! twice the Earth's rotation period, used with the
                                     !! Henyey scaling from the mixing [nondim]
+  real    :: Henyey_max_lat         !< A latitude poleward of which the Henyey profile
+                                    !! is returned to the minimum diffusivity [degN]
   real    :: prandtl_bkgnd          !< Turbulent Prandtl number used to convert
                                     !! vertical background diffusivity into viscosity [nondim]
   real    :: Kd_tanh_lat_scale      !< A nondimensional scaling for the range of
@@ -282,6 +284,10 @@ subroutine bkgnd_mixing_init(Time, G, GV, US, param_file, diag, CS, physical_OBL
     call get_param(param_file, mdl, "OMEGA", CS%omega, &
                  "The rotation rate of the earth.", &
                  units="s-1", default=7.2921e-5, scale=US%T_to_s)
+    call get_param(param_file, mdl, "HENYEY_MAX_LAT", CS%Henyey_max_lat, &
+                  "A latitude poleward of which the Henyey profile "//&
+                  "is returned to the minimum diffusivity", &
+                  units="degN", default=95.0)
   endif
 
   call get_param(param_file, mdl, "KD_TANH_LAT_FN", CS%Kd_tanh_lat_fn, &
@@ -447,6 +453,7 @@ subroutine calculate_bkgnd_mixing(h, tv, N2_lay, Kd_lay, Kd_int, Kv_bkgnd, j, G,
       I_x30 = 2.0 / invcosh(CS%N0_2Omega*2.0) ! This is evaluated at 30 deg.
       do i=is,ie
         abs_sinlat = abs(sin(G%geoLatT(i,j)*deg_to_rad))
+        if (abs(G%geoLatT(i,j))>CS%Henyey_max_lat) abs_sinlat = min_sinlat
         Kd_sfc(i) = max(CS%Kd_min, CS%Kd * &
              ((abs_sinlat * invcosh(CS%N0_2Omega / max(min_sinlat, abs_sinlat))) * I_x30) )
       enddo

--- a/src/parameterizations/vertical/MOM_bulk_mixed_layer.F90
+++ b/src/parameterizations/vertical/MOM_bulk_mixed_layer.F90
@@ -164,7 +164,7 @@ contains
 !> This subroutine partially steps the bulk mixed layer model.
 !! See \ref BML for more details.
 subroutine bulkmixedlayer(h_3d, u_3d, v_3d, tv, fluxes, dt, ea, eb, G, GV, US, CS, &
-                          optics, Hml, aggregate_FW_forcing, dt_diag, last_call)
+                          optics, BLD, H_ml, aggregate_FW_forcing, dt_diag, last_call)
   type(ocean_grid_type),      intent(inout) :: G      !< The ocean's grid structure.
   type(verticalGrid_type),    intent(in)    :: GV     !< The ocean's vertical grid structure.
   type(unit_scale_type),      intent(in)    :: US     !< A dimensional unit scaling type
@@ -195,7 +195,10 @@ subroutine bulkmixedlayer(h_3d, u_3d, v_3d, tv, fluxes, dt, ea, eb, G, GV, US, C
   type(optics_type),          pointer       :: optics !< The structure that can be queried for the
                                                       !! inverse of the vertical absorption decay
                                                       !! scale for penetrating shortwave radiation.
-  real, dimension(:,:),       pointer       :: Hml    !< Active mixed layer depth [Z ~> m]
+  real, dimension(SZI_(G),SZJ_(G)), &
+                              intent(inout) :: BLD    !< Active mixed layer depth [Z ~> m]
+  real, dimension(SZI_(G),SZJ_(G)), &
+                              intent(inout) :: H_ml   !< Active mixed layer thickness [H ~> m or kg m-2].
   logical,                    intent(in)    :: aggregate_FW_forcing !< If true, the net incoming and
                                                      !! outgoing surface freshwater fluxes are
                                                      !! combined before being applied, instead of
@@ -605,25 +608,27 @@ subroutine bulkmixedlayer(h_3d, u_3d, v_3d, tv, fluxes, dt, ea, eb, G, GV, US, C
       CS%ML_depth(i,j) = h(i,0)  ! Store the diagnostic.
     enddo ; endif
 
-    if (associated(Hml)) then
-      ! Return the mixed layerd depth in [Z ~> m].
-      if (GV%Boussinesq .or. GV%semi_Boussinesq) then
-        do i=is,ie
-          Hml(i,j) = G%mask2dT(i,j) * GV%H_to_Z*h(i,0)
-        enddo
+    ! Return the mixed layer depth in [Z ~> m].
+    if (GV%Boussinesq .or. GV%semi_Boussinesq) then
+      do i=is,ie
+        BLD(i,j) = G%mask2dT(i,j) * GV%H_to_Z*h(i,0)
+      enddo
+    else
+      do i=is,ie ; dp_ml(i) = GV%g_Earth * GV%H_to_RZ * h(i,0) ; enddo
+      if (associated(tv%p_surf)) then
+        do i=is,ie ; p_sfc(i) = tv%p_surf(i,j) ; enddo
       else
-        do i=is,ie ; dp_ml(i) = GV%g_Earth * GV%H_to_RZ * h(i,0) ; enddo
-        if (associated(tv%p_surf)) then
-          do i=is,ie ; p_sfc(i) = tv%p_surf(i,j) ; enddo
-        else
-          do i=is,ie ; p_sfc(i) = 0.0 ; enddo
-        endif
-        call average_specific_vol(T(:,0), S(:,0), p_sfc, dp_ml, SpV_ml, tv%eqn_of_state)
-        do i=is,ie
-          Hml(i,j) = G%mask2dT(i,j) * GV%H_to_RZ * SpV_ml(i) *  h(i,0)
-        enddo
+        do i=is,ie ; p_sfc(i) = 0.0 ; enddo
       endif
+      call average_specific_vol(T(:,0), S(:,0), p_sfc, dp_ml, SpV_ml, tv%eqn_of_state)
+      do i=is,ie
+        BLD(i,j) = G%mask2dT(i,j) * GV%H_to_RZ * SpV_ml(i) *  h(i,0)
+      enddo
     endif
+    ! Return the mixed layer thickness in [H ~> m or kg m-2].
+    do i=is,ie
+      H_ml(i,j) = G%mask2dT(i,j) * h(i,0)
+    enddo
 
 ! At this point, return water to the original layers, but constrained to
 ! still be sorted.  After this point, all the water that is in massive

--- a/src/parameterizations/vertical/MOM_bulk_mixed_layer.F90
+++ b/src/parameterizations/vertical/MOM_bulk_mixed_layer.F90
@@ -4026,14 +4026,14 @@ subroutine bulkmixedlayer_init(Time, G, GV, US, param_file, diag, CS)
                  "during detrainment.", units="K", default=0.5, scale=US%degC_to_C)
   call get_param(param_file, mdl, "ALLOWED_DETRAIN_SALT_CHG", CS%Allowed_S_chg, &
                  "The amount by which salinity is allowed to exceed previous values "//&
-                 "during detrainment.", units="PSU", default=0.1, scale=US%ppt_to_S)
+                 "during detrainment.", units="ppt", default=0.1, scale=US%ppt_to_S)
   call get_param(param_file, mdl, "ML_DT_DS_WEIGHT", CS%dT_dS_wt, &
                  "When forced to extrapolate T & S to match the layer "//&
                  "densities, this factor (in deg C / PSU) is combined "//&
                  "with the derivatives of density with T & S to determine "//&
                  "what direction is orthogonal to density contours. It "//&
                  "should be a typical value of (dR/dS) / (dR/dT) in oceanic profiles.", &
-                 units="degC PSU-1", default=6.0, scale=US%degC_to_C*US%S_to_ppt)
+                 units="degC ppt-1", default=6.0, scale=US%degC_to_C*US%S_to_ppt)
   call get_param(param_file, mdl, "BUFFER_LAYER_EXTRAP_LIMIT", CS%BL_extrap_lim, &
                  "A limit on the density range over which extrapolation "//&
                  "can occur when detraining from the buffer layers, "//&

--- a/src/parameterizations/vertical/MOM_diabatic_aux.F90
+++ b/src/parameterizations/vertical/MOM_diabatic_aux.F90
@@ -643,7 +643,7 @@ subroutine set_pen_shortwave(optics, fluxes, G, GV, US, CS, opacity, tracer_flow
     if (CS%chl_from_file) then
       ! Only the 2-d surface chlorophyll can be read in from a file.  The
       ! same value is assumed for all layers.
-      call time_interp_external(CS%sbc_chl, CS%Time, chl_2d)
+      call time_interp_external(CS%sbc_chl, CS%Time, chl_2d, turns=G%HI%turns)
       do j=js,je ; do i=is,ie
         if ((G%mask2dT(i,j) > 0.0) .and. (chl_2d(i,j) < 0.0)) then
           write(mesg,'(" Time_interp negative chl of ",(1pe12.4)," at i,j = ",&
@@ -1899,7 +1899,11 @@ subroutine diabatic_aux_init(Time, G, GV, US, param_file, diag, CS, useALEalgori
         call log_param(param_file, mdl, "INPUTDIR/CHL_FILE", chl_filename)
         call get_param(param_file, mdl, "CHL_VARNAME", chl_varname, &
                    "Name of CHL_A variable in CHL_FILE.", default='CHL_A')
-        CS%sbc_chl = init_external_field(chl_filename, trim(chl_varname), MOM_domain=G%Domain)
+        if (modulo(G%Domain%turns, 4) /= 0) then
+          CS%sbc_chl = init_external_field(chl_filename, trim(chl_varname), MOM_domain=G%Domain%domain_in)
+        else
+          CS%sbc_chl = init_external_field(chl_filename, trim(chl_varname), MOM_domain=G%Domain)
+        endif
       endif
 
       CS%id_chl = register_diag_field('ocean_model', 'Chl_opac', diag%axesT1, Time, &

--- a/src/parameterizations/vertical/MOM_diabatic_driver.F90
+++ b/src/parameterizations/vertical/MOM_diabatic_driver.F90
@@ -1093,7 +1093,7 @@ subroutine diabatic_ALE_legacy(u, v, h, tv, Hml, fluxes, visc, ADp, CDp, dt, Tim
   ! Apply ALE sponge
   if (CS%use_sponge .and. associated(CS%ALE_sponge_CSp)) then
     call cpu_clock_begin(id_clock_sponge)
-    call apply_ALE_sponge(h, dt, G, GV, US, CS%ALE_sponge_CSp, CS%Time)
+    call apply_ALE_sponge(h, tv, dt, G, GV, US, CS%ALE_sponge_CSp, CS%Time)
     call cpu_clock_end(id_clock_sponge)
     if (CS%debug) then
       call MOM_state_chksum("apply_sponge ", u, v, h, G, GV, US, haloshift=0)
@@ -1616,7 +1616,7 @@ subroutine diabatic_ALE(u, v, h, tv, Hml, fluxes, visc, ADp, CDp, dt, Time_end, 
   ! Apply ALE sponge
   if (CS%use_sponge .and. associated(CS%ALE_sponge_CSp)) then
     call cpu_clock_begin(id_clock_sponge)
-    call apply_ALE_sponge(h, dt, G, GV, US, CS%ALE_sponge_CSp, CS%Time)
+    call apply_ALE_sponge(h, tv, dt, G, GV, US, CS%ALE_sponge_CSp, CS%Time)
     call cpu_clock_end(id_clock_sponge)
     if (CS%debug) then
       call MOM_state_chksum("apply_sponge ", u, v, h, G, GV, US, haloshift=0)

--- a/src/parameterizations/vertical/MOM_diabatic_driver.F90
+++ b/src/parameterizations/vertical/MOM_diabatic_driver.F90
@@ -676,6 +676,14 @@ subroutine diabatic_ALE_legacy(u, v, h, tv, BLD, fluxes, visc, ADp, CDp, dt, Tim
     call cpu_clock_begin(id_clock_kpp)
     ! total vertical viscosity in the interior is represented via visc%Kv_shear
 
+    ! NOTE: The following do not require initialization, but their checksums do
+    !   require initialization, and past versions were initialized to zero.
+    KPP_NLTheat(:,:,:) = 0.
+    KPP_NLTscalar(:,:,:) = 0.
+    KPP_buoy_flux(:,:,:) = 0.
+    KPP_temp_flux(:,:) = 0.
+    KPP_salt_flux(:,:) = 0.
+
     ! KPP needs the surface buoyancy flux but does not update state variables.
     ! We could make this call higher up to avoid a repeat unpacking of the surface fluxes.
     ! Sets: KPP_buoy_flux, KPP_temp_flux, KPP_salt_flux
@@ -1288,6 +1296,14 @@ subroutine diabatic_ALE(u, v, h, tv, BLD, fluxes, visc, ADp, CDp, dt, Time_end, 
       visc%Kv_shear(i,j,k) = visc%Kv_shear(i,j,k) + visc%Kv_slow(i,j,k)
     enddo ; enddo ; enddo
 
+    ! NOTE: The following do not require initialization, but their checksums do
+    !   require initialization, and past versions were initialized to zero.
+    KPP_NLTheat(:,:,:) = 0.
+    KPP_NLTscalar(:,:,:) = 0.
+    KPP_buoy_flux(:,:,:) = 0.
+    KPP_temp_flux(:,:) = 0.
+    KPP_salt_flux(:,:) = 0.
+
     ! KPP needs the surface buoyancy flux but does not update state variables.
     ! We could make this call higher up to avoid a repeat unpacking of the surface fluxes.
     ! Sets: KPP_buoy_flux, KPP_temp_flux, KPP_salt_flux
@@ -1885,6 +1901,15 @@ subroutine layered_diabatic(u, v, h, tv, BLD, fluxes, visc, ADp, CDp, dt, Time_e
 
   if (CS%useKPP) then
     call cpu_clock_begin(id_clock_kpp)
+
+    ! NOTE: The following do not require initialization, but their checksums do
+    !   require initialization, and past versions were initialized to zero.
+    KPP_NLTheat(:,:,:) = 0.
+    KPP_NLTscalar(:,:,:) = 0.
+    KPP_buoy_flux(:,:,:) = 0.
+    KPP_temp_flux(:,:) = 0.
+    KPP_salt_flux(:,:) = 0.
+
     ! KPP needs the surface buoyancy flux but does not update state variables.
     ! We could make this call higher up to avoid a repeat unpacking of the surface fluxes.
     ! Sets: KPP_buoy_flux, KPP_temp_flux, KPP_salt_flux

--- a/src/parameterizations/vertical/MOM_diabatic_driver.F90
+++ b/src/parameterizations/vertical/MOM_diabatic_driver.F90
@@ -825,7 +825,7 @@ subroutine diabatic_ALE_legacy(u, v, h, tv, BLD, fluxes, visc, ADp, CDp, dt, Tim
     skinbuoyflux(:,:) = 0.0
     call applyBoundaryFluxesInOut(CS%diabatic_aux_CSp, G, GV, US, dt, fluxes, CS%optics, &
             optics_nbands(CS%optics), h, tv, CS%aggregate_FW_forcing, CS%evap_CFL_limit, &
-            CS%minimum_forcing_depth, cTKE, dSV_dT, dSV_dS, SkinBuoyFlux=SkinBuoyFlux, MLD=visc%MLD)
+            CS%minimum_forcing_depth, cTKE, dSV_dT, dSV_dS, SkinBuoyFlux=SkinBuoyFlux, MLD_h=visc%h_ML)
 
     if (CS%debug) then
       call hchksum(ent_t, "after applyBoundaryFluxes ent_t", G%HI, haloshift=0, scale=GV%H_to_mks)
@@ -885,7 +885,7 @@ subroutine diabatic_ALE_legacy(u, v, h, tv, BLD, fluxes, visc, ADp, CDp, dt, Tim
   else
     call applyBoundaryFluxesInOut(CS%diabatic_aux_CSp, G, GV, US, dt, fluxes, CS%optics, &
                                   optics_nbands(CS%optics), h, tv, CS%aggregate_FW_forcing, &
-                                  CS%evap_CFL_limit, CS%minimum_forcing_depth, MLD=visc%MLD)
+                                  CS%evap_CFL_limit, CS%minimum_forcing_depth, MLD_h=visc%h_ML)
 
     ! Find the vertical distances across layers, which may have been modified by the net surface flux
     call thickness_to_dz(h, tv, dz, G, GV, US)
@@ -1377,7 +1377,7 @@ subroutine diabatic_ALE(u, v, h, tv, BLD, fluxes, visc, ADp, CDp, dt, Time_end, 
     skinbuoyflux(:,:) = 0.0
     call applyBoundaryFluxesInOut(CS%diabatic_aux_CSp, G, GV, US, dt, fluxes, CS%optics, &
             optics_nbands(CS%optics), h, tv, CS%aggregate_FW_forcing, CS%evap_CFL_limit, &
-            CS%minimum_forcing_depth, cTKE, dSV_dT, dSV_dS, SkinBuoyFlux=SkinBuoyFlux, MLD=visc%MLD)
+            CS%minimum_forcing_depth, cTKE, dSV_dT, dSV_dS, SkinBuoyFlux=SkinBuoyFlux, MLD_h=visc%h_ML)
 
     if (CS%debug) then
       call hchksum(ent_t, "after applyBoundaryFluxes ent_t", G%HI, haloshift=0, scale=GV%H_to_MKS)
@@ -1423,7 +1423,7 @@ subroutine diabatic_ALE(u, v, h, tv, BLD, fluxes, visc, ADp, CDp, dt, Time_end, 
   else
     call applyBoundaryFluxesInOut(CS%diabatic_aux_CSp, G, GV, US, dt, fluxes, CS%optics, &
                                   optics_nbands(CS%optics), h, tv, CS%aggregate_FW_forcing, &
-                                  CS%evap_CFL_limit, CS%minimum_forcing_depth, MLD=visc%MLD)
+                                  CS%evap_CFL_limit, CS%minimum_forcing_depth, MLD_h=visc%h_ML)
 
   endif   ! endif for CS%use_energetic_PBL
 

--- a/src/parameterizations/vertical/MOM_diabatic_driver.F90
+++ b/src/parameterizations/vertical/MOM_diabatic_driver.F90
@@ -1073,7 +1073,7 @@ subroutine diabatic_ALE_legacy(u, v, h, tv, BLD, fluxes, visc, ADp, CDp, dt, Tim
                               KPP_CSp=CS%KPP_CSp, &
                               nonLocalTrans=KPP_NLTscalar, &
                               evap_CFL_limit=CS%evap_CFL_limit, &
-                              minimum_forcing_depth=CS%minimum_forcing_depth)
+                              minimum_forcing_depth=CS%minimum_forcing_depth, h_BL=visc%h_ML)
 
   call cpu_clock_end(id_clock_tracers)
 
@@ -1587,7 +1587,7 @@ subroutine diabatic_ALE(u, v, h, tv, BLD, fluxes, visc, ADp, CDp, dt, Time_end, 
                               KPP_CSp=CS%KPP_CSp, &
                               nonLocalTrans=KPP_NLTscalar, &
                               evap_CFL_limit=CS%evap_CFL_limit, &
-                              minimum_forcing_depth=CS%minimum_forcing_depth)
+                              minimum_forcing_depth=CS%minimum_forcing_depth, h_BL=visc%h_ML)
 
   call cpu_clock_end(id_clock_tracers)
 
@@ -2381,8 +2381,7 @@ subroutine layered_diabatic(u, v, h, tv, BLD, fluxes, visc, ADp, CDp, dt, Time_e
 
     call call_tracer_column_fns(hold, h, eatr, ebtr, fluxes, BLD, dt, G, GV, US, tv, &
                               CS%optics, CS%tracer_flow_CSp, CS%debug, &
-                              KPP_CSp=CS%KPP_CSp, &
-                              nonLocalTrans=KPP_NLTscalar)
+                              KPP_CSp=CS%KPP_CSp, nonLocalTrans=KPP_NLTscalar, h_BL=visc%h_ML)
 
   elseif (CS%double_diffuse) then  ! extra diffusivity for passive tracers
 
@@ -2403,14 +2402,12 @@ subroutine layered_diabatic(u, v, h, tv, BLD, fluxes, visc, ADp, CDp, dt, Time_e
 
     call call_tracer_column_fns(hold, h, eatr, ebtr, fluxes, BLD, dt, G, GV, US, tv, &
                                 CS%optics, CS%tracer_flow_CSp, CS%debug, &
-                                KPP_CSp=CS%KPP_CSp, &
-                                nonLocalTrans=KPP_NLTscalar)
+                                KPP_CSp=CS%KPP_CSp, nonLocalTrans=KPP_NLTscalar, h_BL=visc%h_ML)
 
   else
     call call_tracer_column_fns(hold, h, ea, eb, fluxes, BLD, dt, G, GV, US, tv, &
                                 CS%optics, CS%tracer_flow_CSp, CS%debug, &
-                                KPP_CSp=CS%KPP_CSp, &
-                                nonLocalTrans=KPP_NLTscalar)
+                                KPP_CSp=CS%KPP_CSp, nonLocalTrans=KPP_NLTscalar, h_BL=visc%h_ML)
 
   endif  ! (CS%mix_boundary_tracers)
 

--- a/src/parameterizations/vertical/MOM_energetic_PBL.F90
+++ b/src/parameterizations/vertical/MOM_energetic_PBL.F90
@@ -13,6 +13,7 @@ use MOM_file_parser,    only : get_param, log_param, log_version, param_file_typ
 use MOM_forcing_type,   only : forcing
 use MOM_grid,           only : ocean_grid_type
 use MOM_interface_heights, only : thickness_to_dz
+use MOM_intrinsic_functions, only : cuberoot
 use MOM_string_functions, only : uppercase
 use MOM_unit_scaling,   only : unit_scale_type
 use MOM_variables,      only : thermo_var_ptrs
@@ -161,7 +162,10 @@ type, public :: energetic_PBL_CS ; private
   integer :: answer_date     !< The vintage of the order of arithmetic and expressions in the ePBL
                              !! calculations.  Values below 20190101 recover the answers from the
                              !! end of 2018, while higher values use updated and more robust forms
-                             !! of the same expressions.
+                             !! of the same expressions.  Values below 20240101 use A**(1./3.) to
+                             !! estimate the cube root of A in several expressions, while higher
+                             !! values use the integer root function cuberoot(A) and therefore
+                             !! can work with scaled variables.
   logical :: orig_PE_calc    !< If true, the ePBL code uses the original form of the
                              !! potential energy change code.  Otherwise, it uses a newer version
                              !! that can work with successive increments to the diffusivity in
@@ -335,8 +339,10 @@ subroutine energetic_PBL(h_3d, u_3d, v_3d, tv, fluxes, dt, Kd_int, G, GV, US, CS
     mixvel, &       ! A turbulent mixing velocity [Z T-1 ~> m s-1].
     mixlen, &       ! A turbulent mixing length [Z ~> m].
     SpV_dt          ! Specific volume interpolated to interfaces divided by dt or 1.0 / (dt * Rho0)
-                    ! times conversion factors in [m3 Z-3 R-1 T2 s-3 ~> m3 kg-1 s-1],
-                    ! used to convert local TKE into a turbulence velocity cubed.
+                    ! times conversion factors for answer dates before 20240101 in
+                    ! [m3 Z-3 R-1 T2 s-3 ~> m3 kg-1 s-1] or without the convsersion factors for
+                    ! answer dates of 20240101 and later in [R-1 T-1 ~> m3 kg-1 s-1], used to
+                    ! convert local TKE into a turbulence velocity cubed.
   real :: h_neglect ! A thickness that is so small it is usually lost
                     ! in roundoff and can be neglected [H ~> m or kg m-2].
 
@@ -348,6 +354,8 @@ subroutine energetic_PBL(h_3d, u_3d, v_3d, tv, fluxes, dt, Kd_int, G, GV, US, CS
   real :: I_rho     ! The inverse of the Boussinesq reference density times a ratio of scaling
                     ! factors [Z L-1 R-1 ~> m3 kg-1]
   real :: I_dt      ! The Adcroft reciprocal of the timestep [T-1 ~> s-1]
+  real :: I_rho0dt  ! The inverse of the Boussinesq reference density times the time
+                    ! step [R-1 T-1 ~> m3 kg-1 s-1]
   real :: B_Flux    ! The surface buoyancy flux [Z2 T-3 ~> m2 s-3]
   real :: MLD_io    ! The mixed layer depth found by ePBL_column [Z ~> m]
 
@@ -374,6 +382,7 @@ subroutine energetic_PBL(h_3d, u_3d, v_3d, tv, fluxes, dt, Kd_int, G, GV, US, CS
   h_neglect = GV%H_subroundoff
   I_rho = US%L_to_Z * GV%H_to_Z * GV%RZ_to_H ! == US%L_to_Z / GV%Rho0 ! This is not used when fully non-Boussinesq.
   I_dt = 0.0 ; if (dt > 0.0) I_dt = 1.0 / dt
+  I_rho0dt = 1.0 / (GV%Rho0 * dt)  ! This is not used when fully non-Boussinesq.
 
   ! Zero out diagnostics before accumulation.
   if (CS%TKE_diagnostics) then
@@ -403,9 +412,15 @@ subroutine energetic_PBL(h_3d, u_3d, v_3d, tv, fluxes, dt, Kd_int, G, GV, US, CS
     ! Set the inverse density used to translating local TKE into a turbulence velocity
     SpV_dt(:) = 0.0
     if ((dt > 0.0) .and. GV%Boussinesq .or. .not.allocated(tv%SpV_avg)) then
-      do K=1,nz+1
-        SpV_dt(K) = (US%Z_to_m**3*US%s_to_T**3) / (dt*GV%Rho0)
-      enddo
+      if (CS%answer_date < 20240101) then
+        do K=1,nz+1
+          SpV_dt(K) = (US%Z_to_m**3*US%s_to_T**3) / (dt*GV%Rho0)
+        enddo
+      else
+        do K=1,nz+1
+          SpV_dt(K) = I_rho0dt
+        enddo
+      endif
     endif
 
     !   Determine the initial mech_TKE and conv_PErel, including the energy required
@@ -442,11 +457,19 @@ subroutine energetic_PBL(h_3d, u_3d, v_3d, tv, fluxes, dt, Kd_int, G, GV, US, CS
       endif
 
       if (allocated(tv%SpV_avg) .and. .not.GV%Boussinesq) then
-        SpV_dt(1) = (US%Z_to_m**3*US%s_to_T**3) * tv%SpV_avg(i,j,1) * I_dt
-        do K=2,nz
-          SpV_dt(K) = (US%Z_to_m**3*US%s_to_T**3) * 0.5*(tv%SpV_avg(i,j,k-1) + tv%SpV_avg(i,j,k)) * I_dt
-        enddo
-        SpV_dt(nz+1) = (US%Z_to_m**3*US%s_to_T**3) * tv%SpV_avg(i,j,nz) * I_dt
+        if (CS%answer_date < 20240101) then
+          SpV_dt(1) = (US%Z_to_m**3*US%s_to_T**3) * tv%SpV_avg(i,j,1) * I_dt
+          do K=2,nz
+            SpV_dt(K) = (US%Z_to_m**3*US%s_to_T**3) * 0.5*(tv%SpV_avg(i,j,k-1) + tv%SpV_avg(i,j,k)) * I_dt
+          enddo
+          SpV_dt(nz+1) = (US%Z_to_m**3*US%s_to_T**3) * tv%SpV_avg(i,j,nz) * I_dt
+        else
+          SpV_dt(1) = tv%SpV_avg(i,j,1) * I_dt
+          do K=2,nz
+            SpV_dt(K) = 0.5*(tv%SpV_avg(i,j,k-1) + tv%SpV_avg(i,j,k)) * I_dt
+          enddo
+          SpV_dt(nz+1) = tv%SpV_avg(i,j,nz) * I_dt
+        endif
       endif
 
       B_flux = buoy_flux(i,j)
@@ -565,9 +588,13 @@ subroutine ePBL_column(h, dz, u, v, T0, S0, dSV_dT, dSV_dS, SpV_dt, TKE_forcing,
   real, dimension(SZK_(GV)), intent(in)  :: dSV_dS !< The partial derivative of in-situ specific
                                                    !! volume with salinity [R-1 S-1 ~> m3 kg-1 ppt-1].
   real, dimension(SZK_(GV)+1), intent(in) :: SpV_dt !< Specific volume interpolated to interfaces
-                                                   !! divided by dt or 1.0 / (dt * Rho0) times conversion
-                                                   !! factors in [m3 Z-3 R-1 T2 s-3 ~> m3 kg-1 s-1],
-                                                   !! used to convert local TKE into a turbulence velocity.
+                                                   !! divided by dt or 1.0 / (dt * Rho0), times conversion
+                                                   !! factors for answer dates before 20240101 in
+                                                   !! [m3 Z-3 R-1 T2 s-3 ~> m3 kg-1 s-1] or without
+                                                   !! the convsersion factors for answer dates of
+                                                   !! 20240101 and later in [R-1 T-1 ~> m3 kg-1 s-1],
+                                                   !! used to convert local TKE into a turbulence
+                                                   !! velocity cubed.
   real, dimension(SZK_(GV)), intent(in)  :: TKE_forcing !< The forcing requirements to homogenize the
                                                    !! forcing that has been applied to each layer
                                                    !! [R Z3 T-2 ~> J m-2].
@@ -819,7 +846,7 @@ subroutine ePBL_column(h, dz, u, v, T0, S0, dSV_dT, dSV_dS, SpV_dt, TKE_forcing,
   max_itt = 20
 
   dz_tt_min = 0.0
-  vstar_unit_scale = US%m_to_Z * US%T_to_s
+  if (CS%answer_date < 20240101) vstar_unit_scale = US%m_to_Z * US%T_to_s
 
   MLD_guess = MLD_io
 
@@ -1160,12 +1187,22 @@ subroutine ePBL_column(h, dz, u, v, T0, S0, dSV_dT, dSV_dS, SpV_dt, TKE_forcing,
           dz_tt = dztot + dz_tt_min
           TKE_here = mech_TKE + CS%wstar_ustar_coef*conv_PErel
           if (TKE_here > 0.0) then
-            if (CS%wT_scheme==wT_from_cRoot_TKE) then
-              vstar = CS%vstar_scale_fac * vstar_unit_scale * (SpV_dt(K)*TKE_here)**C1_3
-            elseif (CS%wT_scheme==wT_from_RH18) then
-              Surface_Scale = max(0.05, 1.0 - dztot / MLD_guess)
-              vstar = CS%vstar_scale_fac * Surface_Scale * (CS%vstar_surf_fac*u_star + &
-                        vstar_unit_scale * (CS%wstar_ustar_coef*conv_PErel*SpV_dt(K))**C1_3)
+            if (CS%answer_date < 20240101) then
+              if (CS%wT_scheme==wT_from_cRoot_TKE) then
+                vstar = CS%vstar_scale_fac * vstar_unit_scale * (SpV_dt(K)*TKE_here)**C1_3
+              elseif (CS%wT_scheme==wT_from_RH18) then
+                Surface_Scale = max(0.05, 1.0 - dztot / MLD_guess)
+                vstar = CS%vstar_scale_fac * Surface_Scale * (CS%vstar_surf_fac*u_star + &
+                          vstar_unit_scale * (CS%wstar_ustar_coef*conv_PErel*SpV_dt(K))**C1_3)
+              endif
+            else
+              if (CS%wT_scheme==wT_from_cRoot_TKE) then
+                vstar = CS%vstar_scale_fac * cuberoot(SpV_dt(K)*TKE_here)
+              elseif (CS%wT_scheme==wT_from_RH18) then
+                Surface_Scale = max(0.05, 1.0 - dztot / MLD_guess)
+                vstar = (CS%vstar_scale_fac * Surface_Scale) * ( CS%vstar_surf_fac*u_star + &
+                          cuberoot((CS%wstar_ustar_coef*conv_PErel) * SpV_dt(K)) )
+              endif
             endif
             hbs_here = min(hb_hs(K), MixLen_shape(K))
             mixlen(K) = MAX(CS%min_mix_len, ((dz_tt*hbs_here)*vstar) / &
@@ -1209,12 +1246,22 @@ subroutine ePBL_column(h, dz, u, v, T0, S0, dSV_dT, dSV_dS, SpV_dt, TKE_forcing,
               ! Does MKE_src need to be included in the calculation of vstar here?
               TKE_here = mech_TKE + CS%wstar_ustar_coef*(conv_PErel-PE_chg_max)
               if (TKE_here > 0.0) then
-                if (CS%wT_scheme==wT_from_cRoot_TKE) then
-                  vstar = CS%vstar_scale_fac * vstar_unit_scale * (SpV_dt(K)*TKE_here)**C1_3
-                elseif (CS%wT_scheme==wT_from_RH18) then
-                  Surface_Scale = max(0.05, 1. - dztot / MLD_guess)
-                  vstar = CS%vstar_scale_fac * Surface_Scale * (CS%vstar_surf_fac*u_star + &
-                                  vstar_unit_scale * (CS%wstar_ustar_coef*conv_PErel*SpV_dt(K))**C1_3)
+                if (CS%answer_date < 20240101) then
+                  if (CS%wT_scheme==wT_from_cRoot_TKE) then
+                    vstar = CS%vstar_scale_fac * vstar_unit_scale * (SpV_dt(K)*TKE_here)**C1_3
+                  elseif (CS%wT_scheme==wT_from_RH18) then
+                    Surface_Scale = max(0.05, 1. - dztot / MLD_guess)
+                    vstar = CS%vstar_scale_fac * Surface_Scale * (CS%vstar_surf_fac*u_star + &
+                                    vstar_unit_scale * (CS%wstar_ustar_coef*conv_PErel*SpV_dt(K))**C1_3)
+                  endif
+                else
+                  if (CS%wT_scheme==wT_from_cRoot_TKE) then
+                    vstar = CS%vstar_scale_fac * cuberoot(SpV_dt(K)*TKE_here)
+                  elseif (CS%wT_scheme==wT_from_RH18) then
+                    Surface_Scale = max(0.05, 1. - dztot / MLD_guess)
+                    vstar = (CS%vstar_scale_fac * Surface_Scale) * ( CS%vstar_surf_fac*u_star + &
+                                    cuberoot((CS%wstar_ustar_coef*conv_PErel) * SpV_dt(K)) )
+                  endif
                 endif
                 hbs_here = min(hb_hs(K), MixLen_shape(K))
                 mixlen(K) = max(CS%min_mix_len, ((dz_tt*hbs_here)*vstar) / &
@@ -2076,7 +2123,9 @@ subroutine energetic_PBL_init(Time, G, GV, US, param_file, diag, CS)
                  "The vintage of the order of arithmetic and expressions in the energetic "//&
                  "PBL calculations.  Values below 20190101 recover the answers from the "//&
                  "end of 2018, while higher values use updated and more robust forms of the "//&
-                 "same expressions.", &
+                 "same expressions.  Values below 20240101 use A**(1./3.) to estimate the cube "//&
+                 "root of A in several expressions, while higher values use the integer root "//&
+                 "function cuberoot(A) and therefore can work with scaled variables.", &
                  default=default_answer_date, do_not_log=.not.GV%Boussinesq)
   if (.not.GV%Boussinesq) CS%answer_date = max(CS%answer_date, 20230701)
 

--- a/src/parameterizations/vertical/MOM_set_diffusivity.F90
+++ b/src/parameterizations/vertical/MOM_set_diffusivity.F90
@@ -613,7 +613,8 @@ subroutine set_diffusivity(u, v, h, u_h, v_h, tv, fluxes, optics, visc, dt, Kd_i
     endif
 
     if (allocated(visc%Ray_u) .and. allocated(visc%Ray_v)) then
-      call uvchksum("Ray_[uv]", visc%Ray_u, visc%Ray_v, G%HI, 0, symmetric=.true., scale=GV%H_to_m*US%s_to_T)
+      call uvchksum("Ray_[uv]", visc%Ray_u, visc%Ray_v, G%HI, 0, &
+          symmetric=.true., scale=GV%H_to_m*US%s_to_T, scalar_pair=.true.)
     endif
 
   endif

--- a/src/parameterizations/vertical/MOM_set_viscosity.F90
+++ b/src/parameterizations/vertical/MOM_set_viscosity.F90
@@ -2694,6 +2694,7 @@ subroutine set_visc_register_restarts(HI, G, GV, US, param_file, visc, restart_C
   ! Local variables
   logical :: use_kappa_shear, KS_at_vertex
   logical :: adiabatic, useKPP, useEPBL
+  logical :: do_brine_plume, use_hor_bnd_diff, use_neutral_diffusion, use_fpmix
   logical :: use_CVMix_shear, MLE_use_PBL_MLD, MLE_use_Bodner, use_CVMix_conv
   integer :: isd, ied, jsd, jed, nz
   real :: hfreeze !< If hfreeze > 0 [Z ~> m], melt potential will be computed.
@@ -2757,25 +2758,43 @@ subroutine set_visc_register_restarts(HI, G, GV, US, param_file, visc, restart_C
     call safe_alloc_ptr(visc%Kv_slow, isd, ied, jsd, jed, nz+1)
   endif
 
-  ! visc%MLD is used to communicate the state of the (e)PBL or KPP to the rest of the model
+  ! visc%MLD and visc%h_ML are used to communicate the state of the (e)PBL or KPP to the rest of the model
   call get_param(param_file, mdl, "MLE_USE_PBL_MLD", MLE_use_PBL_MLD, &
                  default=.false., do_not_log=.true.)
-  ! visc%MLD needs to be allocated when melt potential is computed (HFREEZE>0)
+  ! visc%h_ML needs to be allocated when melt potential is computed (HFREEZE>0) or one of
+  ! several other parameterizations are in use.
   call get_param(param_file, mdl, "HFREEZE", hfreeze, &
                  units="m", default=-1.0, scale=US%m_to_Z, do_not_log=.true.)
+  call get_param(param_file, mdl, "DO_BRINE_PLUME", do_brine_plume, &
+                 "If true, use a brine plume parameterization from Nguyen et al., 2009.", &
+                 default=.false., do_not_log=.true.)
+  call get_param(param_file, mdl, "USE_HORIZONTAL_BOUNDARY_DIFFUSION", use_hor_bnd_diff, &
+                 default=.false., do_not_log=.true.)
+  call get_param(param_file, mdl, "USE_NEUTRAL_DIFFUSION", use_neutral_diffusion, &
+                 default=.false., do_not_log=.true.)
+  if (use_neutral_diffusion) &
+    call get_param(param_file, mdl, "NDIFF_INTERIOR_ONLY", use_neutral_diffusion, &
+                 default=.false., do_not_log=.true.)
+  call get_param(param_file, mdl, "FPMIX", use_fpmix, &
+                 default=.false., do_not_log=.true.)
 
-  if (hfreeze >= 0.0 .or. MLE_use_PBL_MLD) then
+  if (MLE_use_PBL_MLD) then
     call safe_alloc_ptr(visc%MLD, isd, ied, jsd, jed)
   endif
-  if (hfreeze >= 0.0 .or. MLE_use_PBL_MLD) then
+  if ((hfreeze >= 0.0) .or. MLE_use_PBL_MLD .or. do_brine_plume .or. use_fpmix .or. &
+      use_neutral_diffusion .or. use_hor_bnd_diff) then
     call safe_alloc_ptr(visc%h_ML, isd, ied, jsd, jed)
   endif
 
   if (MLE_use_PBL_MLD) then
     call register_restart_field(visc%MLD, "MLD", .false., restart_CS, &
                   "Instantaneous active mixing layer depth", units="m", conversion=US%Z_to_m)
+  endif
+  if (MLE_use_PBL_MLD .or. do_brine_plume .or. use_fpmix .or. &
+      use_neutral_diffusion .or. use_hor_bnd_diff) then
     call register_restart_field(visc%h_ML, "h_ML", .false., restart_CS, &
-                  "Instantaneous active mixing layer thickness", units=get_thickness_units(GV), conversion=GV%H_to_mks)
+                  "Instantaneous active mixing layer thickness", &
+                  units=get_thickness_units(GV), conversion=GV%H_to_mks)
   endif
 
   ! visc%sfc_buoy_flx is used to communicate the state of the (e)PBL or KPP to the rest of the model

--- a/src/parameterizations/vertical/MOM_set_viscosity.F90
+++ b/src/parameterizations/vertical/MOM_set_viscosity.F90
@@ -2693,7 +2693,7 @@ subroutine set_visc_register_restarts(HI, G, GV, US, param_file, visc, restart_C
   logical,                 intent(in) :: use_ice_shelf !< if true, register tau_shelf restarts
   ! Local variables
   logical :: use_kappa_shear, KS_at_vertex
-  logical :: adiabatic, useKPP, useEPBL
+  logical :: adiabatic, useKPP, useEPBL, use_ideal_age
   logical :: do_brine_plume, use_hor_bnd_diff, use_neutral_diffusion, use_fpmix
   logical :: use_CVMix_shear, MLE_use_PBL_MLD, MLE_use_Bodner, use_CVMix_conv
   integer :: isd, ied, jsd, jed, nz
@@ -2777,12 +2777,14 @@ subroutine set_visc_register_restarts(HI, G, GV, US, param_file, visc, restart_C
                  default=.false., do_not_log=.true.)
   call get_param(param_file, mdl, "FPMIX", use_fpmix, &
                  default=.false., do_not_log=.true.)
+  call get_param(param_file, mdl, "USE_IDEAL_AGE_TRACER", use_ideal_age, &
+                 default=.false., do_not_log=.true.)
 
   if (MLE_use_PBL_MLD) then
     call safe_alloc_ptr(visc%MLD, isd, ied, jsd, jed)
   endif
   if ((hfreeze >= 0.0) .or. MLE_use_PBL_MLD .or. do_brine_plume .or. use_fpmix .or. &
-      use_neutral_diffusion .or. use_hor_bnd_diff) then
+      use_neutral_diffusion .or. use_hor_bnd_diff .or. use_ideal_age) then
     call safe_alloc_ptr(visc%h_ML, isd, ied, jsd, jed)
   endif
 

--- a/src/parameterizations/vertical/MOM_set_viscosity.F90
+++ b/src/parameterizations/vertical/MOM_set_viscosity.F90
@@ -20,6 +20,7 @@ use MOM_forcing_type,  only : forcing, mech_forcing, find_ustar
 use MOM_grid,          only : ocean_grid_type
 use MOM_hor_index,     only : hor_index_type
 use MOM_interface_heights, only : thickness_to_dz
+! use MOM_intrinsic_functions, only : cuberoot
 use MOM_io,            only : slasher, MOM_read_data, vardesc, var_desc
 use MOM_kappa_shear,   only : kappa_shear_is_used, kappa_shear_at_vertex
 use MOM_open_boundary, only : ocean_OBC_type, OBC_segment_type, OBC_NONE, OBC_DIRECTION_E
@@ -258,40 +259,15 @@ subroutine set_viscous_BBL(u, v, h, tv, visc, G, GV, US, CS, pbv)
   real :: crv              ! crv is the curvature of the bottom depth across a
                            ! cell, times the cell width squared [Z ~> m].
   real :: crv_3            ! crv/3 [Z ~> m].
-  real :: C24_crv          ! 24/crv [Z-1 ~> m-1].
   real :: slope            ! The absolute value of the bottom depth slope across
                            ! a cell times the cell width [Z ~> m].
-  real :: apb_4a, ax2_3apb ! Various nondimensional ratios of crv and slope [nondim].
-  real :: a2x48_apb3, Iapb, Ibma_2 ! Combinations of crv (a) and slope (b) [Z-1 ~> m-1]
-  ! All of the following "volumes" have units of vertical heights because they are normalized
-  ! by the full horizontal area of a velocity cell.
   real :: Vol_bbl_chan     ! The volume of the bottom boundary layer as used in the channel
                            ! drag parameterization, normalized by the full horizontal area
                            ! of the velocity cell [Z ~> m].
-  real :: Vol_open         ! The cell volume above which it is open [Z ~> m].
-  real :: Vol_direct       ! With less than Vol_direct [Z ~> m], there is a direct
-                           ! solution of a cubic equation for L.
-  real :: Vol_2_reg        ! The cell volume above which there are two separate
-                           ! open areas that must be integrated [Z ~> m].
-  real :: vol              ! The volume below the interface whose normalized
-                           ! width is being sought [Z ~> m].
-  real :: vol_below        ! The volume below the interface below the one that
-                           ! is currently under consideration [Z ~> m].
-  real :: Vol_err          ! The error in the volume with the latest estimate of
-                           ! L, or the error for the interface below [Z ~> m].
-  real :: Vol_quit         ! The volume error below which to quit iterating [Z ~> m].
-  real :: Vol_tol          ! A volume error tolerance [Z ~> m].
+  real :: vol_below(SZK_(GV)+1) ! The volume below each interface, normalized by the full
+                           ! horizontal area of a velocity cell [Z ~> m].
   real :: L(SZK_(GV)+1)    ! The fraction of the full cell width that is open at
                            ! the depth of each interface [nondim].
-  real :: L_direct         ! The value of L above volume Vol_direct [nondim].
-  real :: L_max, L_min     ! Upper and lower bounds on the correct value for L [nondim].
-  real :: Vol_err_max      ! The volume error for the upper bound on the correct value for L [Z ~> m]
-  real :: Vol_err_min      ! The volume error for the lower bound on the correct value for L [Z ~> m]
-  real :: Vol_0            ! A deeper volume with known width L0 [Z ~> m].
-  real :: L0               ! The value of L above volume Vol_0 [nondim].
-  real :: dVol             ! vol - Vol_0 [Z ~> m].
-  real :: dV_dL2           ! The partial derivative of volume with L squared
-                           ! evaluated at L=L0 [Z ~> m].
   real :: h_neglect        ! A thickness that is so small it is usually lost
                            ! in roundoff and can be neglected [H ~> m or kg m-2].
   real :: dz_neglect       ! A vertical distance that is so small it is usually lost
@@ -315,14 +291,9 @@ subroutine set_viscous_BBL(u, v, h, tv, visc, G, GV, US, CS, pbv)
   real, parameter :: C1_3 = 1.0/3.0, C1_6 = 1.0/6.0, C1_12 = 1.0/12.0 ! Rational constants [nondim]
   real :: C2pi_3           ! An irrational constant, 2/3 pi. [nondim]
   real :: tmp              ! A temporary variable, sometimes in [Z ~> m]
-  real :: tmp_val_m1_to_p1 ! A temporary variable [nondim]
-  real :: curv_tol         ! Numerator of curvature cubed, used to estimate
-                           ! accuracy of a single L(:) Newton iteration [Z5 ~> m5]
-  logical :: use_L0, do_one_L_iter    ! Control flags for L(:) Newton iteration
   logical :: use_BBL_EOS, do_i(SZIB_(G))
   integer, dimension(2) :: EOSdom ! The computational domain for the equation of state
   integer :: i, j, k, is, ie, js, je, Isq, Ieq, Jsq, Jeq, nz, m, n, K2, nkmb, nkml
-  integer :: itt, maxitt=20
   type(ocean_OBC_type), pointer :: OBC => NULL()
 
   is = G%isc ; ie = G%iec ; js = G%jsc ; je = G%jec ; nz = GV%ke
@@ -332,7 +303,6 @@ subroutine set_viscous_BBL(u, v, h, tv, visc, G, GV, US, CS, pbv)
   dz_neglect = GV%dZ_subroundoff
 
   Rho0x400_G = 400.0*(GV%H_to_RZ / (US%L_to_Z**2 * GV%g_Earth))
-  Vol_quit = (0.9*GV%Angstrom_Z + dz_neglect)
   C2pi_3 = 8.0*atan(1.0)/3.0
 
   if (.not.CS%initialized) call MOM_error(FATAL,"MOM_set_viscosity(BBL): "//&
@@ -442,8 +412,7 @@ subroutine set_viscous_BBL(u, v, h, tv, visc, G, GV, US, CS, pbv)
   !$OMP                                     Isq,Ieq,Jsq,Jeq,h_neglect,dz_neglect,Rho0x400_G,C2pi_3, &
   !$OMP                                     U_bg_sq,cdrag_sqrt,cdrag_sqrt_H,cdrag_sqrt_H_RL, &
   !$OMP                                     cdrag_L_to_H,cdrag_RL_to_H,use_BBL_EOS,BBL_thick_max, &
-  !$OMP                                     OBC,maxitt,D_u,D_v,mask_u,mask_v,pbv) &
-  !$OMP                              firstprivate(Vol_quit)
+  !$OMP                                     OBC,D_u,D_v,mask_u,mask_v,pbv)
   do j=Jsq,Jeq ; do m=1,2
 
     if (m==1) then
@@ -865,12 +834,11 @@ subroutine set_viscous_BBL(u, v, h, tv, visc, G, GV, US, CS, pbv)
       if (CS%body_force_drag) bbl_thick = dz_bbl_drag(i)
 
       if (CS%Channel_drag) then
-        ! The drag within the bottommost Vol_bbl_chan is applied as a part of
-        ! an enhanced bottom viscosity, while above this the drag is applied
-        ! directly to the layers in question as a Rayleigh drag term.
 
-        ! Restrict the volume over which the channel drag is applied.
-        if (CS%Chan_drag_max_vol >= 0.0) Vol_bbl_chan = min(Vol_bbl_chan, CS%Chan_drag_max_vol)
+        vol_below(nz+1) = 0.0
+        do K=nz,1,-1
+          vol_below(K) = vol_below(K+1) + dz_vel(i,k)
+        enddo
 
         !### The harmonic mean edge depths here are not invariant to offsets!
         if (m==1) then
@@ -887,162 +855,33 @@ subroutine set_viscous_BBL(u, v, h, tv, visc, G, GV, US, CS, pbv)
           Dm = 2.0 * D_vel * tmp / (D_vel + tmp)
         endif
         if (Dm > Dp) then ; tmp = Dp ; Dp = Dm ; Dm = tmp ; endif
-
         crv_3 = (Dp + Dm - 2.0*D_vel) ; crv = 3.0*crv_3
         slope = Dp - Dm
+
         ! If the curvature is small enough, there is no reason not to assume
         ! a uniformly sloping or flat bottom.
         if (abs(crv) < 1e-2*(slope + CS%BBL_thick_min)) crv = 0.0
-        ! Each cell extends from x=-1/2 to 1/2, and has a topography
-        ! given by D(x) = crv*x^2 + slope*x + D - crv/12.
 
-        ! Calculate the volume above which the entire cell is open and the
-        ! other volumes at which the equation that is solved for L changes.
-        if (crv > 0.0) then
-          if (slope >= crv) then
-            Vol_open = D_vel - Dm ; Vol_2_reg = Vol_open
-          else
-            tmp = slope/crv
-            Vol_open = 0.25*slope*tmp + C1_12*crv
-            Vol_2_reg = 0.5*tmp**2 * (crv - C1_3*slope)
-          endif
-          ! Define some combinations of crv & slope for later use.
-          C24_crv = 24.0/crv ; Iapb = 1.0/(crv+slope)
-          apb_4a = (slope+crv)/(4.0*crv) ; a2x48_apb3 = (48.0*(crv*crv))*(Iapb**3)
-          ax2_3apb = 2.0*C1_3*crv*Iapb
-        elseif (crv == 0.0) then
-          Vol_open = 0.5*slope
-          if (slope > 0) Iapb = 1.0/slope
+        ! Determine the normalized open length (L) at each interface.
+        if (crv == 0.0) then
+          call find_L_open_uniform_slope(vol_below, Dp, Dm, L, GV)
+        elseif (crv > 0.0) then
+          call find_L_open_concave_analytic(vol_below, D_vel, Dp, Dm, C2pi_3, L, GV)
         else ! crv < 0.0
-          Vol_open = D_vel - Dm
-          if (slope >= -crv) then
-            Iapb = 1.0e30*US%Z_to_m ; if (slope+crv /= 0.0) Iapb = 1.0/(crv+slope)
-            Vol_direct = 0.0 ; L_direct = 0.0 ; C24_crv = 0.0
-          else
-            C24_crv = 24.0/crv ; Iapb = 1.0/(crv+slope)
-            L_direct = 1.0 + slope/crv ! L_direct < 1 because crv < 0
-            Vol_direct = -C1_6*crv*L_direct**3
-          endif
-          Ibma_2 = 2.0 / (slope - crv)
-        endif
+          call find_L_open_convex(vol_below, D_vel, Dp, Dm, L, GV, US, CS)
+        endif ! end of crv<0 cases.
 
-        L(nz+1) = 0.0 ; vol = 0.0 ; Vol_err = 0.0 ; BBL_visc_frac = 0.0
-        ! Determine the normalized open length at each interface.
+        ! Determine the Rayliegh drag contributions.
+
+        ! The drag within the bottommost Vol_bbl_chan is applied as a part of an enhanced bottom
+        ! viscosity, while above this the drag is applied directly to the layers in question as a
+        ! Rayleigh drag term.
+
+        ! Restrict the volume over which the channel drag is applied from the previously determined valu.e
+        if (CS%Chan_drag_max_vol >= 0.0) Vol_bbl_chan = min(Vol_bbl_chan, CS%Chan_drag_max_vol)
+
+        BBL_visc_frac = 0.0
         do K=nz,1,-1
-          vol_below = vol
-
-          vol = vol + dz_vel(i,k)
-          h_vel_pos = h_vel(i,k) + h_neglect
-
-          if (vol >= Vol_open) then ; L(K) = 1.0
-          elseif (crv == 0) then ! The bottom has no curvature.
-            L(K) = sqrt(2.0*vol*Iapb)
-          elseif (crv > 0) then
-            ! There may be a minimum depth, and there are
-            ! analytic expressions for L for all cases.
-            if (vol < Vol_2_reg) then
-              ! In this case, there is a contiguous open region and
-              !   vol = 0.5*L^2*(slope + crv/3*(3-4L)).
-              if (a2x48_apb3*vol < 1e-8) then ! Could be 1e-7?
-                ! There is a very good approximation here for massless layers.
-                L0 = sqrt(2.0*vol*Iapb) ; L(K) = L0*(1.0 + ax2_3apb*L0)
-              else
-                L(K) = apb_4a * (1.0 - &
-                         2.0 * cos(C1_3*acos(a2x48_apb3*vol - 1.0) - C2pi_3))
-              endif
-              ! To check the answers.
-              ! Vol_err = 0.5*(L(K)*L(K))*(slope + crv_3*(3.0-4.0*L(K))) - vol
-            else ! There are two separate open regions.
-              !   vol = slope^2/4crv + crv/12 - (crv/12)*(1-L)^2*(1+2L)
-              ! At the deepest volume, L = slope/crv, at the top L = 1.
-              !L(K) = 0.5 - cos(C1_3*acos(1.0 - C24_crv*(Vol_open - vol)) - C2pi_3)
-              tmp_val_m1_to_p1 = 1.0 - C24_crv*(Vol_open - vol)
-              tmp_val_m1_to_p1 = max(-1., min(1., tmp_val_m1_to_p1))
-              L(K) = 0.5 - cos(C1_3*acos(tmp_val_m1_to_p1) - C2pi_3)
-              ! To check the answers.
-              ! Vol_err = Vol_open - 0.25*crv_3*(1.0+2.0*L(K)) * (1.0-L(K))**2 - vol
-            endif
-          else ! a < 0.
-            if (vol <= Vol_direct) then
-              ! Both edges of the cell are bounded by walls.
-              L(K) = (-0.25*C24_crv*vol)**C1_3
-            else
-              ! x_R is at 1/2 but x_L is in the interior & L is found by solving
-              !   vol = 0.5*L^2*(slope + crv/3*(3-4L))
-
-              !  Vol_err = 0.5*(L(K+1)*L(K+1))*(slope + crv_3*(3.0-4.0*L(K+1))) - vol_below
-              ! Change to ...
-              !   if (min(vol_below + Vol_err, vol) <= Vol_direct) then ?
-              if (vol_below + Vol_err <= Vol_direct) then
-                L0 = L_direct ; Vol_0 = Vol_direct
-              else
-                L0 = L(K+1) ; Vol_0 = vol_below + Vol_err
-                ! Change to   Vol_0 = min(vol_below + Vol_err, vol) ?
-              endif
-
-              !   Try a relatively simple solution that usually works well
-              ! for massless layers.
-              dV_dL2 = 0.5*(slope+crv) - crv*L0 ; dVol = (vol-Vol_0)
-           !  dV_dL2 = 0.5*(slope+crv) - crv*L0 ; dVol = max(vol-Vol_0, 0.0)
-
-              use_L0 = .false.
-              do_one_L_iter = .false.
-              if (CS%answer_date < 20190101) then
-                curv_tol = GV%Angstrom_Z*dV_dL2**2 &
-                           * (0.25 * dV_dL2 * GV%Angstrom_Z - crv * L0 * dVol)
-                do_one_L_iter = (crv * crv * dVol**3) < curv_tol
-              else
-                ! The following code is more robust when GV%Angstrom_H=0, but
-                ! it changes answers.
-                use_L0 = (dVol <= 0.)
-
-                Vol_tol = max(0.5 * GV%Angstrom_Z + dz_neglect, 1e-14 * vol)
-                Vol_quit = max(0.9 * GV%Angstrom_Z + dz_neglect, 1e-14 * vol)
-
-                curv_tol = Vol_tol * dV_dL2**2 &
-                           * (dV_dL2 * Vol_tol - 2.0 * crv * L0 * dVol)
-                do_one_L_iter = (crv * crv * dVol**3) < curv_tol
-              endif
-
-              if (use_L0) then
-                L(K) = L0
-                Vol_err = 0.5*(L(K)*L(K))*(slope + crv_3*(3.0-4.0*L(K))) - vol
-              elseif (do_one_L_iter) then
-                ! One iteration of Newton's method should give an estimate
-                ! that is accurate to within Vol_tol.
-                L(K) = sqrt(L0*L0 + dVol / dV_dL2)
-                Vol_err = 0.5*(L(K)*L(K))*(slope + crv_3*(3.0-4.0*L(K))) - vol
-              else
-                if (dV_dL2*(1.0-L0*L0) < dVol + &
-                    dV_dL2 * (Vol_open - Vol)*Ibma_2) then
-                  L_max = sqrt(1.0 - (Vol_open - Vol)*Ibma_2)
-                else
-                  L_max = sqrt(L0*L0 + dVol / dV_dL2)
-                endif
-                L_min = sqrt(L0*L0 + dVol / (0.5*(slope+crv) - crv*L_max))
-
-                Vol_err_min = 0.5*(L_min**2)*(slope + crv_3*(3.0-4.0*L_min)) - vol
-                Vol_err_max = 0.5*(L_max**2)*(slope + crv_3*(3.0-4.0*L_max)) - vol
-           !    if ((abs(Vol_err_min) <= Vol_quit) .or. (Vol_err_min >= Vol_err_max)) then
-                if (abs(Vol_err_min) <= Vol_quit) then
-                  L(K) = L_min ; Vol_err = Vol_err_min
-                else
-                  L(K) = sqrt((L_min**2*Vol_err_max - L_max**2*Vol_err_min) / &
-                              (Vol_err_max - Vol_err_min))
-                  do itt=1,maxitt
-                    Vol_err = 0.5*(L(K)*L(K))*(slope + crv_3*(3.0-4.0*L(K))) - vol
-                    if (abs(Vol_err) <= Vol_quit) exit
-                    ! Take a Newton's method iteration. This equation has proven
-                    ! robust enough not to need bracketing.
-                    L(K) = L(K) - Vol_err / (L(K)* (slope + crv - 2.0*crv*L(K)))
-                    ! This would be a Newton's method iteration for L^2:
-                    !   L(K) = sqrt(L(K)*L(K) - Vol_err / (0.5*(slope+crv) - crv*L(K)))
-                  enddo
-                endif ! end of iterative solver
-              endif ! end of 1-boundary alternatives.
-            endif ! end of a<0 cases.
-          endif
-
           !modify L(K) for porous barrier parameterization
           if (m==1) then ; L(K) = L(K)*pbv%por_layer_widthU(I,j,K)
           else ; L(K) = L(K)*pbv%por_layer_widthV(i,J,K); endif
@@ -1050,8 +889,8 @@ subroutine set_viscous_BBL(u, v, h, tv, visc, G, GV, US, CS, pbv)
           ! Determine the drag contributing to the bottom boundary layer
           ! and the Rayleigh drag that acts on each layer.
           if (L(K) > L(K+1)) then
-            if (vol_below < Vol_bbl_chan) then
-              BBL_frac = (1.0-vol_below/Vol_bbl_chan)**2
+            if (vol_below(K+1) < Vol_bbl_chan) then
+              BBL_frac = (1.0-vol_below(K+1)/Vol_bbl_chan)**2
               BBL_visc_frac = BBL_visc_frac + BBL_frac*(L(K) - L(K+1))
             else
               BBL_frac = 0.0
@@ -1063,6 +902,7 @@ subroutine set_viscous_BBL(u, v, h, tv, visc, G, GV, US, CS, pbv)
               cdrag_conv = cdrag_L_to_H
             endif
 
+            h_vel_pos = h_vel(i,k) + h_neglect
             if (m==1) then ; Cell_width = G%dy_Cu(I,j)*pbv%por_face_areaU(I,j,k)
             else ; Cell_width = G%dx_Cv(i,J)*pbv%por_face_areaV(i,J,k) ; endif
             gam = 1.0 - L(K+1)/L(K)
@@ -1085,7 +925,7 @@ subroutine set_viscous_BBL(u, v, h, tv, visc, G, GV, US, CS, pbv)
             else ; visc%Ray_v(i,J,k) = 0.0 ; endif
           endif
 
-        enddo ! k loop to determine L(K).
+        enddo ! k loop to determine visc%Ray_[uv].
 
         ! Set the near-bottom viscosity to a value which will give
         ! the correct stress when the shear occurs over bbl_thick.
@@ -1201,6 +1041,299 @@ subroutine set_viscous_BBL(u, v, h, tv, visc, G, GV, US, CS, pbv)
   endif
 
 end subroutine set_viscous_BBL
+
+!> Determine the normalized open length of each interface, given the edge depths and normalized
+!! volumes below each interface.
+subroutine find_L_open_uniform_slope(vol_below, Dp, Dm, L, GV)
+  type(verticalGrid_type),     intent(in)  :: GV   !< The ocean's vertical grid structure.
+  real, dimension(SZK_(GV)+1), intent(in)  :: vol_below !< The volume below each interface, normalized by
+                                                   !! the full horizontal area of a velocity cell [Z ~> m]
+  real,                        intent(in)  :: Dp   !< The larger of the two depths at the edge
+                                                   !! of a velocity cell [Z ~> m]
+  real,                        intent(in)  :: Dm   !< The smaller of the two depths at the edge
+                                                   !! of a velocity cell [Z ~> m]
+  real, dimension(SZK_(GV)+1), intent(out) :: L    !< The fraction of the full cell width that is open at
+                                                   !! the depth of each interface [nondim]
+
+  ! Local variables
+  real :: slope     ! The absolute value of the bottom depth slope across a cell times the cell width [Z ~> m].
+  real :: I_slope   ! The inverse of the normalized slope [Z-1 ~> m-1]
+  real :: Vol_open  ! The cell volume above which it is open [Z ~> m].
+  integer :: K, nz
+
+  nz = GV%ke
+
+  slope = abs(Dp - Dm)
+  if (slope == 0.0) then
+    L(1:nz) = 1.0 ;  L(nz+1) = 0.0
+  else
+    Vol_open = 0.5*slope
+    I_slope = 1.0 / slope
+
+    L(nz+1) = 0.0
+    do K=nz,1,-1
+      if (vol_below(K) >= Vol_open) then ; L(K) = 1.0
+      else
+        ! With a uniformly sloping bottom, the calculation of L(K) is the solution of a simple quadratic equation.
+        L(K) = sqrt(2.0*vol_below(K)*I_slope)
+      endif
+    enddo
+  endif
+
+end subroutine find_L_open_uniform_slope
+
+!> Determine the normalized open length of each interface for concave bathymetry (from the ocean perspective) using
+!! analytic expressions.   In this case there can be two separate open regions.
+subroutine find_L_open_concave_analytic(vol_below, D_vel, Dp, Dm, C2pi_3, L, GV)
+  type(verticalGrid_type),     intent(in)  :: GV   !< The ocean's vertical grid structure.
+  real, dimension(SZK_(GV)+1), intent(in)  :: vol_below !< The volume below each interface, normalized by
+                                                   !! the full horizontal area of a velocity cell [Z ~> m]
+  real,                        intent(in)  :: D_vel !< The average bottom depth at a velocity point [Z ~> m]
+  real,                        intent(in)  :: Dp   !< The larger of the two depths at the edge
+                                                   !! of a velocity cell [Z ~> m]
+  real,                        intent(in)  :: Dm   !< The smaller of the two depths at the edge
+                                                   !! of a velocity cell [Z ~> m]
+  real,                        intent(in)  :: C2pi_3 !< An irrational constant, 2/3 pi [nondim]
+  real, dimension(SZK_(GV)+1), intent(out) :: L    !< The fraction of the full cell width that is open at
+                                                   !! the depth of each interface [nondim]
+
+  ! Local variables
+  real :: crv              ! crv is the curvature of the bottom depth across a
+                           ! cell, times the cell width squared [Z ~> m].
+  real :: crv_3            ! crv/3 [Z ~> m].
+  real :: slope            ! The absolute value of the bottom depth slope across
+                           ! a cell times the cell width [Z ~> m].
+  ! The following "volumes" have units of vertical heights because they are normalized
+  ! by the full horizontal area of a velocity cell.
+  real :: Vol_open         ! The cell volume above which the face is fully is open [Z ~> m].
+  real :: Vol_2_reg        ! The cell volume above which there are two separate
+                           ! open areas that must be integrated [Z ~> m].
+  real :: C24_crv          ! 24/crv [Z-1 ~> m-1].
+  real :: apb_4a, ax2_3apb ! Various nondimensional ratios of crv and slope [nondim].
+  real :: a2x48_apb3, Iapb ! Combinations of crv (a) and slope (b) [Z-1 ~> m-1]
+  real :: L0               ! A linear estimate of L approprate for tiny volumes [nondim].
+  real :: slope_crv        ! The slope divided by the curvature [nondim]
+  real :: tmp_val_m1_to_p1 ! A temporary variable [nondim]
+  real, parameter :: C1_3 = 1.0/3.0, C1_12 = 1.0/12.0 ! Rational constants [nondim]
+  integer :: K, nz
+
+  nz = GV%ke
+
+  ! Each cell extends from x=-1/2 to 1/2, and has a topography
+  ! given by D(x) = crv*x^2 + slope*x + D_vel - crv/12.
+  crv_3 = (Dp + Dm - 2.0*D_vel) ; crv = 3.0*crv_3
+  if (crv < 0.0) call MOM_error(FATAL, "find_L_open_concave should only be called with a positive curvature.")
+  slope = Dp - Dm
+
+  ! Calculate the volume above which the entire cell is open and the volume at which the
+  ! equation that is solved for L changes because there are two separate open regions.
+  if (slope >= crv) then
+    Vol_open = D_vel - Dm ; Vol_2_reg = Vol_open
+  else
+    slope_crv = slope / crv
+    Vol_open = 0.25*slope*slope_crv + C1_12*crv
+    Vol_2_reg = 0.5*slope_crv**2 * (crv - C1_3*slope)
+  endif
+  ! Define some combinations of crv & slope for later use.
+  C24_crv = 24.0/crv ; Iapb = 1.0/(crv+slope)
+  apb_4a = (slope+crv)/(4.0*crv) ; a2x48_apb3 = (48.0*(crv*crv))*(Iapb**3)
+  ax2_3apb = 2.0*C1_3*crv*Iapb
+
+  L(nz+1) = 0.0
+  ! Determine the normalized open length (L) at each interface.
+  do K=nz,1,-1
+    if (vol_below(K) >= Vol_open) then ! The whole cell is open.
+      L(K) = 1.0
+    elseif (vol_below(K) < Vol_2_reg) then
+      ! In this case, there is a contiguous open region and
+      !   vol_below(K) = 0.5*L^2*(slope + crv/3*(3-4L)).
+      if (a2x48_apb3*vol_below(K) < 1e-8) then ! Could be 1e-7?
+        ! There is a very good approximation here for massless layers.
+        L0 = sqrt(2.0*vol_below(K)*Iapb) ; L(K) = L0*(1.0 + ax2_3apb*L0)
+      else
+        L(K) = apb_4a * (1.0 - &
+                 2.0 * cos(C1_3*acos(a2x48_apb3*vol_below(K) - 1.0) - C2pi_3))
+      endif
+      ! To check the answers.
+      ! Vol_err = 0.5*(L(K)*L(K))*(slope + crv_3*(3.0-4.0*L(K))) - vol_below(K)
+    else ! There are two separate open regions.
+      !   vol_below(K) = slope^2/4crv + crv/12 - (crv/12)*(1-L)^2*(1+2L)
+      ! At the deepest volume, L = slope/crv, at the top L = 1.
+      !  L(K) = 0.5 - cos(C1_3*acos(1.0 - C24_crv*(Vol_open - vol_below(K))) - C2pi_3)
+      tmp_val_m1_to_p1 = 1.0 - C24_crv*(Vol_open - vol_below(K))
+      tmp_val_m1_to_p1 = max(-1., min(1., tmp_val_m1_to_p1))
+      L(K) = 0.5 - cos(C1_3*acos(tmp_val_m1_to_p1) - C2pi_3)
+      ! To check the answers.
+      ! Vol_err = Vol_open - 0.25*crv_3*(1.0+2.0*L(K)) * (1.0-L(K))**2 - vol_below(K)
+    endif
+  enddo ! k loop to determine L(K) in the concave case
+
+end subroutine find_L_open_concave_analytic
+
+
+!> Determine the normalized open length of each interface for convex bathymetry (from the ocean perspective) using
+!! Newton's method iterations.   In this case there is a single open region with the minimum depth
+!! at one edge of the cell.
+subroutine find_L_open_convex(vol_below, D_vel, Dp, Dm, L, GV, US, CS)
+  type(verticalGrid_type),     intent(in)  :: GV   !< The ocean's vertical grid structure.
+  real, dimension(SZK_(GV)+1), intent(in)  :: vol_below  !< The volume below each interface, normalized by
+                                                   !! the full horizontal area of a velocity cell [Z ~> m]
+  real,                        intent(in)  :: D_vel !< The average bottom depth at a velocity point [Z ~> m]
+  real,                        intent(in)  :: Dp   !< The larger of the two depths at the edge
+                                                   !! of a velocity cell [Z ~> m]
+  real,                        intent(in)  :: Dm   !< The smaller of the two depths at the edge
+                                                   !! of a velocity cell [Z ~> m]
+  real, dimension(SZK_(GV)+1), intent(out) :: L    !< The fraction of the full cell width that is open at
+                                                   !! the depth of each interface [nondim]
+  type(unit_scale_type),       intent(in)  :: US   !< A dimensional unit scaling type
+  type(set_visc_CS),           intent(in)  :: CS   !< The control structure returned by a previous
+                                                   !! call to set_visc_init.
+
+  ! Local variables
+  real :: crv              ! crv is the curvature of the bottom depth across a
+                           ! cell, times the cell width squared [Z ~> m].
+  real :: crv_3            ! crv/3 [Z ~> m].
+  real :: slope            ! The absolute value of the bottom depth slope across
+                           ! a cell times the cell width [Z ~> m].
+  ! All of the following "volumes" have units of vertical heights because they are normalized
+  ! by the full horizontal area of a velocity cell.
+  real :: Vol_err          ! The error in the volume with the latest estimate of
+                           ! L, or the error for the interface below [Z ~> m].
+  real :: Vol_quit         ! The volume error below which to quit iterating [Z ~> m].
+  real :: Vol_tol          ! A volume error tolerance [Z ~> m].
+  real :: Vol_open         ! The cell volume above which the face is fully open [Z ~> m].
+  real :: Vol_direct       ! With less than Vol_direct [Z ~> m], there is a direct
+                           ! solution of a cubic equation for L.
+  real :: Vol_err_max      ! The volume error for the upper bound on the correct value for L [Z ~> m]
+  real :: Vol_err_min      ! The volume error for the lower bound on the correct value for L [Z ~> m]
+  real :: Vol_0            ! A deeper volume with known width L0 [Z ~> m].
+  real :: dVol             ! vol - Vol_0 [Z ~> m].
+  real :: dV_dL2           ! The partial derivative of volume with L squared
+                           ! evaluated at L=L0 [Z ~> m].
+  real :: L_direct         ! The value of L above volume Vol_direct [nondim].
+  real :: L_max, L_min     ! Upper and lower bounds on the correct value for L [nondim].
+  real :: L0               ! The value of L above volume Vol_0 [nondim].
+  real :: Iapb, Ibma_2     ! Combinations of crv (a) and slope (b) [Z-1 ~> m-1]
+  real :: C24_crv          ! 24/crv [Z-1 ~> m-1].
+  real :: curv_tol         ! Numerator of curvature cubed, used to estimate
+                           ! accuracy of a single L(:) Newton iteration [Z5 ~> m5]
+  real, parameter :: C1_3 = 1.0/3.0, C1_6 = 1.0/6.0 ! Rational constants [nondim]
+  logical :: use_L0, do_one_L_iter  ! Control flags for L(:) Newton iteration
+  integer :: K, nz, itt, maxitt=20
+
+  nz = GV%ke
+
+  ! Each cell extends from x=-1/2 to 1/2, and has a topography
+  ! given by D(x) = crv*x^2 + slope*x + D_vel - crv/12.
+  crv_3 = (Dp + Dm - 2.0*D_vel) ; crv = 3.0*crv_3
+  if (crv > 0.0) call MOM_error(FATAL, "find_L_open_convex should only be called with a negative curvature.")
+  slope = Dp - Dm
+
+  ! Calculate the volume above which the entire cell is open and the volume at which the
+  ! equation that is solved for L changes because there is a direct solution.
+  Vol_open = D_vel - Dm
+  if (slope >= -crv) then
+    Iapb = 1.0e30*US%Z_to_m ; if (slope+crv /= 0.0) Iapb = 1.0/(crv+slope)
+    Vol_direct = 0.0 ; L_direct = 0.0 ; C24_crv = 0.0
+  else
+    C24_crv = 24.0/crv ; Iapb = 1.0/(crv+slope)
+    L_direct = 1.0 + slope/crv ! L_direct < 1 because crv < 0
+    Vol_direct = -C1_6*crv*L_direct**3
+  endif
+  Ibma_2 = 2.0 / (slope - crv)
+
+  if (CS%answer_date < 20190101) Vol_quit = (0.9*GV%Angstrom_Z + GV%dZ_subroundoff)
+
+  L(nz+1) = 0.0 ; Vol_err = 0.0
+  ! Determine the normalized open length (L) at each interface.
+  do K=nz,1,-1
+    if (vol_below(K) >= Vol_open) then
+      L(K) = 1.0
+    elseif (vol_below(K) <= Vol_direct) then
+      ! Both edges of the cell are bounded by walls.
+      ! if (CS%answer_date < 20240101)) then
+      L(K) = (-0.25*C24_crv*vol_below(K))**C1_3
+      ! else
+      !   L(K) = cuberoot(-0.25*C24_crv*vol_below(K))
+      ! endif
+    else
+      ! x_R is at 1/2 but x_L is in the interior & L is found by iteratively solving
+      !   vol_below(K) = 0.5*L^2*(slope + crv/3*(3-4L))
+
+      !  Vol_err = 0.5*(L(K+1)*L(K+1))*(slope + crv_3*(3.0-4.0*L(K+1))) - vol_below(K+1)
+      ! Change to ...
+      !   if (min(vol_below(K+1) + Vol_err, vol_below(K)) <= Vol_direct) then ?
+      if (vol_below(K+1) + Vol_err <= Vol_direct) then
+        L0 = L_direct ; Vol_0 = Vol_direct
+      else
+        L0 = L(K+1) ; Vol_0 = vol_below(K+1) + Vol_err
+        ! Change to   Vol_0 = min(vol_below(K+1) + Vol_err, vol_below(K)) ?
+      endif
+
+      !   Try a relatively simple solution that usually works well
+      ! for massless layers.
+      dV_dL2 = 0.5*(slope+crv) - crv*L0 ; dVol = (vol_below(K)-Vol_0)
+   !  dV_dL2 = 0.5*(slope+crv) - crv*L0 ; dVol = max(vol_below(K)-Vol_0, 0.0)
+
+      use_L0 = .false.
+      do_one_L_iter = .false.
+      if (CS%answer_date < 20190101) then
+        curv_tol = GV%Angstrom_Z*dV_dL2**2 &
+                   * (0.25 * dV_dL2 * GV%Angstrom_Z - crv * L0 * dVol)
+        do_one_L_iter = (crv * crv * dVol**3) < curv_tol
+      else
+        ! The following code is more robust when GV%Angstrom_H=0, but
+        ! it changes answers.
+        use_L0 = (dVol <= 0.)
+
+        Vol_tol = max(0.5 * GV%Angstrom_Z + GV%dZ_subroundoff, 1e-14 * vol_below(K))
+        Vol_quit = max(0.9 * GV%Angstrom_Z + GV%dZ_subroundoff, 1e-14 * vol_below(K))
+
+        curv_tol = Vol_tol * dV_dL2**2 &
+                   * (dV_dL2 * Vol_tol - 2.0 * crv * L0 * dVol)
+        do_one_L_iter = (crv * crv * dVol**3) < curv_tol
+      endif
+
+      if (use_L0) then
+        L(K) = L0
+        Vol_err = 0.5*(L(K)*L(K))*(slope + crv_3*(3.0-4.0*L(K))) - vol_below(K)
+      elseif (do_one_L_iter) then
+        ! One iteration of Newton's method should give an estimate
+        ! that is accurate to within Vol_tol.
+        L(K) = sqrt(L0*L0 + dVol / dV_dL2)
+        Vol_err = 0.5*(L(K)*L(K))*(slope + crv_3*(3.0-4.0*L(K))) - vol_below(K)
+      else
+        if (dV_dL2*(1.0-L0*L0) < dVol + &
+            dV_dL2 * (Vol_open - vol_below(K))*Ibma_2) then
+          L_max = sqrt(1.0 - (Vol_open - vol_below(K))*Ibma_2)
+        else
+          L_max = sqrt(L0*L0 + dVol / dV_dL2)
+        endif
+        L_min = sqrt(L0*L0 + dVol / (0.5*(slope+crv) - crv*L_max))
+
+        Vol_err_min = 0.5*(L_min**2)*(slope + crv_3*(3.0-4.0*L_min)) - vol_below(K)
+        Vol_err_max = 0.5*(L_max**2)*(slope + crv_3*(3.0-4.0*L_max)) - vol_below(K)
+   !    if ((abs(Vol_err_min) <= Vol_quit) .or. (Vol_err_min >= Vol_err_max)) then
+        if (abs(Vol_err_min) <= Vol_quit) then
+          L(K) = L_min ; Vol_err = Vol_err_min
+        else
+          L(K) = sqrt((L_min**2*Vol_err_max - L_max**2*Vol_err_min) / &
+                      (Vol_err_max - Vol_err_min))
+          do itt=1,maxitt
+            Vol_err = 0.5*(L(K)*L(K))*(slope + crv_3*(3.0-4.0*L(K))) - vol_below(K)
+            if (abs(Vol_err) <= Vol_quit) exit
+            ! Take a Newton's method iteration. This equation has proven
+            ! robust enough not to need bracketing.
+            L(K) = L(K) - Vol_err / (L(K)* (slope + crv - 2.0*crv*L(K)))
+            ! This would be a Newton's method iteration for L^2:
+            !   L(K) = sqrt(L(K)*L(K) - Vol_err / (0.5*(slope+crv) - crv*L(K)))
+          enddo
+        endif ! end of iterative solver
+      endif ! end of 1-boundary alternatives.
+    endif ! end of 0, 1- and 2- boundary cases.
+  enddo ! k loop to determine L(K) in the convex case
+
+end subroutine find_L_open_convex
 
 !> This subroutine finds a thickness-weighted value of v at the u-points.
 function set_v_at_u(v, h, G, GV, i, j, k, mask2dCv, OBC)

--- a/src/parameterizations/vertical/MOM_set_viscosity.F90
+++ b/src/parameterizations/vertical/MOM_set_viscosity.F90
@@ -1178,7 +1178,8 @@ subroutine find_L_open_concave_trigonometric(vol_below, D_vel, Dp, Dm, L, GV)
 
   ! Each cell extends from x=-1/2 to 1/2, and has a topography
   ! given by D(x) = crv*x^2 + slope*x + D_vel - crv/12.
-  crv_3 = (Dp + Dm - 2.0*D_vel) ; crv = 3.0*crv_3
+  !crv_3 = (Dp + Dm - 2.0*D_vel) ; crv = 3.0*crv_3
+  crv_3 = (Dp + Dm - (2.0*D_vel)) ; crv = 3.0*crv_3
   slope = Dp - Dm
 
   ! Calculate the volume above which the entire cell is open and the volume at which the
@@ -1205,10 +1206,13 @@ subroutine find_L_open_concave_trigonometric(vol_below, D_vel, Dp, Dm, L, GV)
       !   vol_below(K) = 0.5*L^2*(slope + crv/3*(3-4L)).
       if (a2x48_apb3*vol_below(K) < 1e-8) then ! Could be 1e-7?
         ! There is a very good approximation here for massless layers.
-        L0 = sqrt(2.0*vol_below(K)*Iapb) ; L(K) = L0*(1.0 + ax2_3apb*L0)
+        !L0 = sqrt(2.0*vol_below(K)*Iapb) ; L(K) = L0*(1.0 + ax2_3apb*L0)
+        L0 = sqrt(2.0*vol_below(K)*Iapb) ; L(K) = L0*(1.0 + (ax2_3apb*L0))
       else
+        !L(K) = apb_4a * (1.0 - &
+        !         2.0 * cos(C1_3*acos(a2x48_apb3*vol_below(K) - 1.0) - C2pi_3))
         L(K) = apb_4a * (1.0 - &
-                 2.0 * cos(C1_3*acos(a2x48_apb3*vol_below(K) - 1.0) - C2pi_3))
+                 2.0 * cos(C1_3*acos((a2x48_apb3*vol_below(K)) - 1.0) - C2pi_3))
       endif
       ! To check the answers.
       ! Vol_err = 0.5*(L(K)*L(K))*(slope + crv_3*(3.0-4.0*L(K))) - vol_below(K)

--- a/src/parameterizations/vertical/MOM_set_viscosity.F90
+++ b/src/parameterizations/vertical/MOM_set_viscosity.F90
@@ -30,7 +30,7 @@ use MOM_restart,       only : register_restart_field_as_obsolete, register_resta
 use MOM_safe_alloc,    only : safe_alloc_ptr, safe_alloc_alloc
 use MOM_unit_scaling,  only : unit_scale_type
 use MOM_variables,     only : thermo_var_ptrs, vertvisc_type, porous_barrier_type
-use MOM_verticalGrid,  only : verticalGrid_type
+use MOM_verticalGrid,  only : verticalGrid_type, get_thickness_units
 
 implicit none ; private
 
@@ -2767,10 +2767,15 @@ subroutine set_visc_register_restarts(HI, G, GV, US, param_file, visc, restart_C
   if (hfreeze >= 0.0 .or. MLE_use_PBL_MLD) then
     call safe_alloc_ptr(visc%MLD, isd, ied, jsd, jed)
   endif
+  if (hfreeze >= 0.0 .or. MLE_use_PBL_MLD) then
+    call safe_alloc_ptr(visc%h_ML, isd, ied, jsd, jed)
+  endif
 
   if (MLE_use_PBL_MLD) then
     call register_restart_field(visc%MLD, "MLD", .false., restart_CS, &
                   "Instantaneous active mixing layer depth", units="m", conversion=US%Z_to_m)
+    call register_restart_field(visc%h_ML, "h_ML", .false., restart_CS, &
+                  "Instantaneous active mixing layer thickness", units=get_thickness_units(GV), conversion=GV%H_to_mks)
   endif
 
   ! visc%sfc_buoy_flx is used to communicate the state of the (e)PBL or KPP to the rest of the model

--- a/src/parameterizations/vertical/MOM_set_viscosity.F90
+++ b/src/parameterizations/vertical/MOM_set_viscosity.F90
@@ -1072,7 +1072,8 @@ subroutine set_viscous_BBL(u, v, h, tv, visc, G, GV, US, CS, pbv)
 
   if (CS%debug) then
     if (allocated(visc%Ray_u) .and. allocated(visc%Ray_v)) &
-        call uvchksum("Ray [uv]", visc%Ray_u, visc%Ray_v, G%HI, haloshift=0, scale=GV%H_to_m*US%s_to_T)
+        call uvchksum("Ray [uv]", visc%Ray_u, visc%Ray_v, G%HI, haloshift=0, &
+                      scale=GV%H_to_m*US%s_to_T, scalar_pair=.true.)
     if (allocated(visc%kv_bbl_u) .and. allocated(visc%kv_bbl_v)) &
         call uvchksum("kv_bbl_[uv]", visc%kv_bbl_u, visc%kv_bbl_v, G%HI, &
                       haloshift=0, scale=GV%HZ_T_to_m2_s, scalar_pair=.true.)

--- a/src/parameterizations/vertical/MOM_set_viscosity.F90
+++ b/src/parameterizations/vertical/MOM_set_viscosity.F90
@@ -2265,6 +2265,13 @@ subroutine set_viscous_ML(u, v, h, tv, forces, visc, dt, G, GV, US, CS)
 
           if (.not.CS%linear_drag) then
             v_at_u = set_v_at_u(v, h, G, GV, i, j, k, mask_v, OBC)
+            ! Set the "back ground" friction velocity scale to either the tidal amplitude or place-holder constant
+            if (CS%BBL_use_tidal_bg) then
+              u2_bg(I) = 0.5*( G%mask2dT(i,j)*(CS%tideamp(i,j)*CS%tideamp(i,j))+ &
+                               G%mask2dT(i+1,j)*(CS%tideamp(i+1,j)*CS%tideamp(i+1,j)) )
+            else
+              u2_bg(I) = CS%drag_bg_vel * CS%drag_bg_vel
+            endif
             hutot = hutot + hweight * sqrt(u(I,j,k)**2 + v_at_u**2 + u2_bg(I))
           endif
           if (use_EOS) then
@@ -2537,6 +2544,13 @@ subroutine set_viscous_ML(u, v, h, tv, forces, visc, dt, G, GV, US, CS)
 
           if (.not.CS%linear_drag) then
             u_at_v = set_u_at_v(u, h, G, GV, i, J, k, mask_u, OBC)
+            ! Set the "back ground" friction velocity scale to either the tidal amplitude or place-holder constant
+            if (CS%BBL_use_tidal_bg) then
+              u2_bg(i) = 0.5*( G%mask2dT(i,j)*(CS%tideamp(i,j)*CS%tideamp(i,j))+ &
+                               G%mask2dT(i,j+1)*(CS%tideamp(i,j+1)*CS%tideamp(i,j+1)) )
+            else
+              u2_bg(i) = CS%drag_bg_vel * CS%drag_bg_vel
+            endif
             hutot = hutot + hweight * sqrt(v(i,J,k)**2 + u_at_v**2 + u2_bg(i))
           endif
           if (use_EOS) then

--- a/src/parameterizations/vertical/MOM_vert_friction.F90
+++ b/src/parameterizations/vertical/MOM_vert_friction.F90
@@ -234,11 +234,15 @@ subroutine vertFPmix(ui, vi, uold, vold, hbl_h, h, forces, dt, G, GV, US, CS, OB
   real, dimension(SZIB_(G),SZJ_(G),SZK_(GV)+1) :: omega_tau2w_u !< angle between mtm flux and wind at u-pts [rad]
   real, dimension(SZI_(G),SZJB_(G),SZK_(GV)+1) :: omega_tau2w_v !< angle between mtm flux and wind at v-pts [rad]
 
-  real :: pi, Cemp_CG, tmp, cos_tmp, sin_tmp, omega_tmp !< constants and dummy variables
-  real :: du, dv, depth, sigma, Wind_x, Wind_y          !< intermediate variables
-  real :: taux, tauy, tauxDG, tauyDG, tauxDGup, tauyDGup, ustar2, tauh !< intermediate variables
-  real :: tauNLup, tauNLdn, tauNL_CG, tauNL_DG, tauNL_X, tauNL_Y, tau_MAG !< intermediate variables
-  real :: omega_w2s, omega_tau2s, omega_s2x, omega_tau2x, omega_tau2w, omega_s2w !< intermediate angles
+  real :: pi, Cemp_CG, tmp, cos_tmp, sin_tmp  !< constants and dummy variables [nondim]
+  real :: omega_tmp        !< A dummy angle [radians]
+  real :: du, dv           !< Velocity increments [L T-1 ~> m s-1]
+  real :: depth            !< Cumulative layer thicknesses [H ~> m or kg m=2]
+  real :: sigma            !< Fractional depth in the mixed layer [nondim]
+  real :: Wind_x, Wind_y   !< intermediate wind stress componenents [L2 T-2 ~> m2 s-2]
+  real :: taux, tauy, tauxDG, tauyDG, tauxDGup, tauyDGup, ustar2, tauh !< intermediate variables [L2 T-2 ~> m2 s-2]
+  real :: tauNLup, tauNLdn, tauNL_CG, tauNL_DG, tauNL_X, tauNL_Y, tau_MAG !< intermediate variables [L2 T-2 ~> m2 s-2]
+  real :: omega_w2s, omega_tau2s, omega_s2x, omega_tau2x, omega_tau2w, omega_s2w !< intermediate angles [radians]
   integer :: kblmin, kbld, kp1, k, nz !< vertical indices
   integer :: i, j, is, ie, js, je, Isq, Ieq, Jsq, Jeq ! horizontal indices
 
@@ -321,6 +325,7 @@ subroutine vertFPmix(ui, vi, uold, vold, hbl_h, h, forces, dt, G, GV, US, CS, OB
   enddo
 
   if (CS%debug) then
+    !### These checksum calls are missing necessary dimensional scaling factors.
     call uvchksum("surface tau[xy]_[uv] ", taux_u, tauy_v, G%HI, haloshift=1, scalar_pair=.true.)
     call uvchksum("ustar2", ustar2_u, ustar2_v, G%HI, haloshift=0, scalar_pair=.true.)
     call uvchksum(" hbl", hbl_u ,   hbl_v , G%HI, haloshift=0, scalar_pair=.true.)
@@ -427,6 +432,7 @@ subroutine vertFPmix(ui, vi, uold, vold, hbl_h, h, forces, dt, G, GV, US, CS, OB
         kbld  = min( (kbl_u(I,j)) , (nz-2) )
         if ( tau_u(I,j,kbld+2) > tau_u(I,j,kbld+1) ) kbld = kbld + 1
 
+        !### This expression is dimensionally inconsistent.
         tauh  =  tau_u(I,j,kbld+1) + GV%H_subroundoff
         ! surface boundary conditions
         depth   = 0.
@@ -437,6 +443,7 @@ subroutine vertFPmix(ui, vi, uold, vold, hbl_h, h, forces, dt, G, GV, US, CS, OB
 
           ! linear stress mag
           tau_MAG   = (ustar2_u(I,j) * (1.-sigma) )  + (tauh * sigma )
+          !### The following expressions are dimensionally inconsistent.
           cos_tmp   = tauxDG_u(I,j,k+1) / (tau_u(I,j,k+1) + GV%H_subroundoff)
           sin_tmp   = tauyDG_u(I,j,k+1) / (tau_u(I,j,k+1) + GV%H_subroundoff)
 
@@ -457,6 +464,7 @@ subroutine vertFPmix(ui, vi, uold, vold, hbl_h, h, forces, dt, G, GV, US, CS, OB
           tauNLdn  = tauNL_X
 
           ! nonlocal increment and update to uold
+          !### The following expression is dimensionally inconsistent and missing parentheses.
           du = (tauNLup - tauNLdn) * (dt/CS%h_u(I,j,k) + GV%H_subroundoff)
           ui(I,j,k)    = uold(I,j,k)  + du
           uold(I,j,k)  = du
@@ -496,6 +504,7 @@ subroutine vertFPmix(ui, vi, uold, vold, hbl_h, h, forces, dt, G, GV, US, CS, OB
 
           ! linear stress
           tau_MAG   = (ustar2_v(i,J) * (1.-sigma))  + (tauh * sigma)
+          !### The following expressions are dimensionally inconsistent.
           cos_tmp   = tauxDG_v(i,J,k+1) / (tau_v(i,J,k+1)  + GV%H_subroundoff)
           sin_tmp   = tauyDG_v(i,J,k+1) / (tau_v(i,J,k+1)  + GV%H_subroundoff)
 
@@ -514,6 +523,8 @@ subroutine vertFPmix(ui, vi, uold, vold, hbl_h, h, forces, dt, G, GV, US, CS, OB
           tauNL_X  = (tauNL_DG * cos_tmp - tauNL_CG * sin_tmp)
           tauNL_Y  = (tauNL_DG * sin_tmp + tauNL_CG * cos_tmp)
           tauNLdn  = tauNL_Y
+          !### The following expression is dimensionally inconsistent, [L T-1] vs. [L2 H-1 T-1] on the right,
+          !    and it is inconsistent with the counterpart expression for du.
           dv            = (tauNLup - tauNLdn) * (dt/(CS%h_v(i,J,k)) )
           vi(i,J,k)    = vold(i,J,k) + dv
           vold(i,J,k)  = dv
@@ -2634,7 +2645,7 @@ subroutine vertvisc_init(MIS, Time, G, GV, US, param_file, diag, ADp, dirs, &
 # include "version_variable.h"
   character(len=40)  :: mdl = "MOM_vert_friction" ! This module's name.
   character(len=40)  :: thickness_units
-  real :: Kv_mks ! KVML in MKS
+  real :: Kv_mks ! KVML in MKS [m2 s-1]
 
   if (associated(CS)) then
     call MOM_error(WARNING, "vertvisc_init called with an associated "// &

--- a/src/parameterizations/vertical/MOM_vert_friction.F90
+++ b/src/parameterizations/vertical/MOM_vert_friction.F90
@@ -551,12 +551,12 @@ subroutine vertFPmix(ui, vi, uold, vold, hbl_h, h, forces, dt, G, GV, US, CS, OB
 
 end subroutine vertFPmix
 
-!> Returns the empirical shape-function given sigma.
+!> Returns the empirical shape-function given sigma [nondim]
 real function G_sig(sigma)
-  real , intent(in) :: sigma   !< non-dimensional normalized boundary layer depth [m]
+  real , intent(in) :: sigma    !< Normalized boundary layer depth [nondim]
 
   ! local variables
-  real :: p1, c2, c3  !< parameters used to fit and match empirycal shape-functions.
+  real :: p1, c2, c3  !< Parameters used to fit and match empirical shape-functions [nondim]
 
   ! parabola
   p1 = 0.287

--- a/src/tracer/ISOMIP_tracer.F90
+++ b/src/tracer/ISOMIP_tracer.F90
@@ -45,8 +45,8 @@ type, public :: ISOMIP_tracer_CS ; private
   character(len = 200) :: tracer_IC_file !< The full path to the IC file, or " " to initialize internally.
   type(time_type), pointer :: Time !< A pointer to the ocean model's clock.
   type(tracer_registry_type), pointer :: tr_Reg => NULL() !< A pointer to the MOM tracer registry
-  real, pointer :: tr(:,:,:,:) => NULL()   !< The array of tracers used in this package, in g m-3?
-  real :: land_val(NTR) = -1.0 !< The value of tr used where land is masked out.
+  real, pointer :: tr(:,:,:,:) => NULL()   !< The array of tracers used in this package, in [conc] (g m-3)?
+  real :: land_val(NTR) = -1.0 !< The value of tr used where land is masked out [conc].
   logical :: use_sponge    !< If true, sponges may be applied somewhere in the domain.
 
   integer, dimension(NTR) :: ind_tr !< Indices returned by atmos_ocn_coupler_flux
@@ -80,7 +80,7 @@ function register_ISOMIP_tracer(HI, GV, param_file, CS, tr_Reg, restart_CS)
   character(len=200) :: inputdir
   character(len=48)  :: flux_units ! The units for tracer fluxes, usually
                             ! kg(tracer) kg(water)-1 m3 s-1 or kg(tracer) s-1.
-  real, pointer :: tr_ptr(:,:,:) => NULL()
+  real, pointer :: tr_ptr(:,:,:) => NULL() ! The tracer concentration [conc]
   logical :: register_ISOMIP_tracer
   integer :: isd, ied, jsd, jed, nz, m
   isd = HI%isd ; ied = HI%ied ; jsd = HI%jsd ; jed = HI%jed ; nz = GV%ke

--- a/src/tracer/MOM_CFC_cap.F90
+++ b/src/tracer/MOM_CFC_cap.F90
@@ -95,7 +95,7 @@ function register_CFC_cap(HI, GV, param_file, CS, tr_Reg, restart_CS)
   ! This include declares and sets the variable "version".
 # include "version_variable.h"
   character(len=200) :: inputdir ! The directory where NetCDF input files are.
-  real, dimension(:,:,:), pointer :: tr_ptr => NULL()
+  real, dimension(:,:,:), pointer :: tr_ptr => NULL() ! A pointer to a CFC tracer [mol kg-1]
   character(len=200) :: CFC_BC_file           ! filename with cfc11 and cfc12 data
   character(len=30)  :: CFC_BC_var_name       ! varname of field in CFC_BC_file
   character :: m2char
@@ -285,10 +285,11 @@ subroutine init_tracer_CFC(h, tr, name, land_val, IC_val, G, GV, US, CS)
   type(verticalGrid_type),                   intent(in)  :: GV       !< The ocean's vertical grid structure.
   type(unit_scale_type),                     intent(in)  :: US       !< A dimensional unit scaling type
   real, dimension(SZI_(G),SZJ_(G),SZK_(GV)), intent(in)  :: h        !< Layer thicknesses [H ~> m or kg m-2]
-  real, dimension(SZI_(G),SZJ_(G),SZK_(GV)), intent(out) :: tr       !< The tracer concentration array
+  real, dimension(SZI_(G),SZJ_(G),SZK_(GV)), intent(out) :: tr       !< The tracer concentration array [mol kg-1]
   character(len=*),                          intent(in)  :: name     !< The tracer name
-  real,                                      intent(in)  :: land_val !< A value the tracer takes over land
-  real,                                      intent(in)  :: IC_val   !< The initial condition value for the tracer
+  real,                                      intent(in)  :: land_val !< A value the tracer takes over land [mol kg-1]
+  real,                                      intent(in)  :: IC_val   !< The initial condition value for the
+                                                                     !! tracer [mol kg-1]
   type(CFC_cap_CS),                          pointer     :: CS       !< The control structure returned by a
                                                                      !! previous call to register_CFC_cap.
 
@@ -480,10 +481,10 @@ subroutine CFC_cap_set_forcing(sfc_state, fluxes, day_start, day_interval, G, US
                          ! (saturation concentration) [mol kg-1].
     cfc11_atm, &         ! CFC11 atm mole fraction [pico mol/mol]
     cfc12_atm            ! CFC12 atm mole fraction [pico mol/mol]
-  real :: cfc11_atm_nh   ! NH value for cfc11_atm
-  real :: cfc11_atm_sh   ! SH value for cfc11_atm
-  real :: cfc12_atm_nh   ! NH value for cfc12_atm
-  real :: cfc12_atm_sh   ! SH value for cfc12_atm
+  real :: cfc11_atm_nh   ! NH value for cfc11_atm [pico mol/mol]
+  real :: cfc11_atm_sh   ! SH value for cfc11_atm [pico mol/mol]
+  real :: cfc12_atm_nh   ! NH value for cfc12_atm [pico mol/mol]
+  real :: cfc12_atm_sh   ! SH value for cfc12_atm [pico mol/mol]
   real :: ta             ! Absolute sea surface temperature [hectoKelvin]
   real :: sal            ! Surface salinity [PSU].
   real :: alpha_11       ! The solubility of CFC 11 [mol kg-1 atm-1].
@@ -670,7 +671,9 @@ logical function CFC_cap_unit_tests(verbose)
                                  !! information for debugging unit tests
 
   ! Local variables
-  real               :: dummy1, dummy2, ta, sal
+  real :: dummy1, dummy2 ! Test values of Schmidt numbers [nondim] or solubilities [mol kg-1 atm-1] for CFC11 and CFC12
+  real :: ta  ! A test value of temperature [hectoKelvin]
+  real :: sal ! A test value of salinity [ppt]
   character(len=120) :: test_name ! Title of the unit test
 
   CFC_cap_unit_tests = .false.
@@ -716,12 +719,12 @@ end function CFC_cap_unit_tests
 logical function compare_values(verbose, test_name, calc, ans, limit)
   logical,             intent(in) :: verbose   !< If true, write results to stdout
   character(len=80),   intent(in) :: test_name !< Brief description of the unit test
-  real,                intent(in) :: calc      !< computed value
-  real,                intent(in) :: ans       !< correct value
-  real,                intent(in) :: limit     !< value above which test fails
+  real,                intent(in) :: calc      !< computed value in abitrary units [A]
+  real,                intent(in) :: ans       !< correct value [A]
+  real,                intent(in) :: limit     !< value above which test fails [A]
 
   ! Local variables
-  real :: diff
+  real :: diff  ! Difference in values [A]
 
   diff = ans - calc
 

--- a/src/tracer/MOM_CFC_cap.F90
+++ b/src/tracer/MOM_CFC_cap.F90
@@ -361,7 +361,6 @@ subroutine CFC_cap_column_physics(h_old, h_new, ea, eb, fluxes, dt, G, GV, US, C
 
   ! Local variables
   real, dimension(SZI_(G),SZJ_(G),SZK_(GV)) :: h_work ! Used so that h can be modified [H ~> m or kg m-2]
-  real :: flux_scale ! A dimensional rescaling factor for fluxes [H R-1 Z-1 ~> m3 kg-1 or nondim]
   integer :: i, j, k, is, ie, js, je, nz, m
 
   is = G%isc ; ie = G%iec ; js = G%jsc ; je = G%jec ; nz = GV%ke
@@ -371,13 +370,11 @@ subroutine CFC_cap_column_physics(h_old, h_new, ea, eb, fluxes, dt, G, GV, US, C
   ! Compute KPP nonlocal term if necessary
   if (present(KPP_CSp)) then
     if (associated(KPP_CSp) .and. present(nonLocalTrans)) then
-      flux_scale = GV%Z_to_H / GV%rho0
-
       do m=1,NTR
         call KPP_NonLocalTransport(KPP_CSp, G, GV, h_old, nonLocalTrans, &
                                    CS%CFC_data(m)%sfc_flux(:,:), dt, CS%diag, &
                                    CS%CFC_data(m)%tr_ptr, CS%CFC_data(m)%conc(:,:,:), &
-                                   flux_scale=flux_scale)
+                                   flux_scale=GV%RZ_to_H)
       enddo
     endif
   endif

--- a/src/tracer/MOM_OCMIP2_CFC.F90
+++ b/src/tracer/MOM_OCMIP2_CFC.F90
@@ -102,7 +102,7 @@ function register_OCMIP2_CFC(HI, GV, param_file, CS, tr_Reg, restart_CS)
   character(len=200) :: inputdir ! The directory where NetCDF input files are.
   ! This include declares and sets the variable "version".
 # include "version_variable.h"
-  real, dimension(:,:,:), pointer :: tr_ptr => NULL()
+  real, dimension(:,:,:), pointer :: tr_ptr => NULL() ! A pointer to a CFC tracer [mol m-3]
   real :: a11_dflt(4), a12_dflt(4) ! Default values of the various coefficients
   real :: d11_dflt(4), d12_dflt(4) ! in the expressions for the solubility and
   real :: e11_dflt(3), e12_dflt(3) ! Schmidt numbers [various units by element].
@@ -359,10 +359,11 @@ subroutine init_tracer_CFC(h, tr, name, land_val, IC_val, G, GV, US, CS)
   type(verticalGrid_type),                   intent(in)  :: GV   !< The ocean's vertical grid structure.
   type(unit_scale_type),                     intent(in)  :: US   !< A dimensional unit scaling type
   real, dimension(SZI_(G),SZJ_(G),SZK_(GV)), intent(in)  :: h    !< Layer thicknesses [H ~> m or kg m-2]
-  real, dimension(SZI_(G),SZJ_(G),SZK_(GV)), intent(out) :: tr   !< The tracer concentration array
+  real, dimension(SZI_(G),SZJ_(G),SZK_(GV)), intent(out) :: tr   !< The CFC tracer concentration array [mol m-3]
   character(len=*),                          intent(in)  :: name !< The tracer name
-  real,                                      intent(in)  :: land_val !< A value the tracer takes over land
-  real,                                      intent(in)  :: IC_val !< The initial condition value for the tracer
+  real,                                      intent(in)  :: land_val !< A value the tracer takes over land [mol m-3]
+  real,                                      intent(in)  :: IC_val !< The initial condition value for
+                                                                 !! the CRC tracer [mol m-3]
   type(OCMIP2_CFC_CS),                       pointer     :: CS   !< The control structure returned by a
                                                                  !! previous call to register_OCMIP2_CFC.
 
@@ -439,7 +440,7 @@ subroutine OCMIP2_CFC_column_physics(h_old, h_new, ea, eb, fluxes, dt, G, GV, US
   ! Local variables
   real, dimension(SZI_(G),SZJ_(G)) :: &
     CFC11_flux, &    ! The fluxes of CFC11 and CFC12 into the ocean, in unscaled units of
-    CFC12_flux       ! CFC concentrations times meters per second [CU R Z T-1 ~> CU kg m-2 s-1]
+    CFC12_flux       ! CFC concentrations times a vertical mass flux [mol R Z m-3 T-1 ~> mol kg m-3 s-1]
   real, dimension(SZI_(G),SZJ_(G),SZK_(GV)) :: h_work ! Used so that h can be modified [H ~> m or kg m-2]
   integer :: i, j, k, is, ie, js, je, nz, idim(4), jdim(4)
 
@@ -545,8 +546,8 @@ subroutine OCMIP2_CFC_surface_state(sfc_state, h, G, GV, US, CS)
   real :: SST       ! Sea surface temperature [degC].
   real :: alpha_11  ! The solubility of CFC 11 [mol m-3 pptv-1].
   real :: alpha_12  ! The solubility of CFC 12 [mol m-3 pptv-1].
-  real :: sc_11, sc_12 ! The Schmidt numbers of CFC 11 and CFC 12.
-  real :: sc_no_term   ! A term related to the Schmidt number.
+  real :: sc_11, sc_12 ! The Schmidt numbers of CFC 11 and CFC 12 [nondim].
+  real :: sc_no_term   ! A term related to the Schmidt number [nondim].
   integer :: i, j, is, ie, js, je, idim(4), jdim(4)
 
   is = G%isc ; ie = G%iec ; js = G%jsc ; je = G%jec

--- a/src/tracer/MOM_generic_tracer.F90
+++ b/src/tracer/MOM_generic_tracer.F90
@@ -414,7 +414,8 @@ contains
       endif
 
       call g_tracer_get_obc_segment_props(g_tracer,g_tracer_name,obc_has )
-      if(obc_has .and. g_tracer_is_prog(g_tracer)) call fill_obgc_segments(G, GV, OBC, tr_ptr, g_tracer_name)
+      if(obc_has .and. g_tracer_is_prog(g_tracer) .and. .not.restart) &
+             call fill_obgc_segments(G, GV, OBC, tr_ptr, g_tracer_name)
       !traverse the linked list till hit NULL
       call g_tracer_get_next(g_tracer, g_tracer_next)
       if (.NOT. associated(g_tracer_next)) exit

--- a/src/tracer/MOM_neutral_diffusion.F90
+++ b/src/tracer/MOM_neutral_diffusion.F90
@@ -63,9 +63,9 @@ type, public :: neutral_diffusion_CS ; private
   real,    allocatable, dimension(:,:)  :: hbl    !< Boundary layer depth [H ~> m or kg m-2]
   ! Coefficients used to apply tapering from neutral to horizontal direction
   real,    allocatable, dimension(:) :: coeff_l   !< Non-dimensional coefficient in the left column,
-                                                  !! at cell interfaces
+                                                  !! at cell interfaces [nondim]
   real,    allocatable, dimension(:) :: coeff_r   !< Non-dimensional coefficient in the right column,
-                                                  !! at cell interfaces
+                                                  !! at cell interfaces [nondim]
   ! Array used when KhTh_use_ebt_struct is true
   real,    allocatable, dimension(:,:,:) :: Coef_h !< Coef_x and Coef_y averaged at t-points [L2 ~> m2]
   ! Positions of neutral surfaces in both the u, v directions
@@ -84,8 +84,10 @@ type, public :: neutral_diffusion_CS ; private
                                                   !! at a v-point
   real,    allocatable, dimension(:,:,:) :: vHeff !< Effective thickness at v-point [H ~> m or kg m-2]
   ! Coefficients of polynomial reconstructions for temperature and salinity
-  real,    allocatable, dimension(:,:,:,:) :: ppoly_coeffs_T !< Polynomial coefficients for temperature
-  real,    allocatable, dimension(:,:,:,:) :: ppoly_coeffs_S !< Polynomial coefficients for salinity
+  real,    allocatable, dimension(:,:,:,:) :: ppoly_coeffs_T !< Polynomial coefficients of the
+                                                  !! sub-gridscale temperatures [C ~> degC]
+  real,    allocatable, dimension(:,:,:,:) :: ppoly_coeffs_S !< Polynomial coefficients of the
+                                                  !! sub-gridscale salinity [S ~> ppt]
   ! Variables needed for continuous reconstructions
   real,    allocatable, dimension(:,:,:) :: dRdT !< dRho/dT [R C-1 ~> kg m-3 degC-1] at interfaces
   real,    allocatable, dimension(:,:,:) :: dRdS !< dRho/dS [R S-1 ~> kg m-3 ppt-1] at interfaces
@@ -335,7 +337,8 @@ subroutine neutral_diffusion_calc_coeffs(G, GV, US, h, T, S, CS, p_surf)
   integer, dimension(2) :: EOSdom ! The i-computational domain for the equation of state
   integer :: i, j, k
   ! Variables used for reconstructions
-  real, dimension(SZK_(GV),2) :: ppoly_r_S      ! Reconstruction slopes
+  real, dimension(SZK_(GV),2) :: ppoly_r_S  ! Reconstruction slopes that are unused here, in units of a vertical
+                              ! gradient, which for temperature would be [C H-1 ~> degC m-1 or degC m2 kg-1].
   real, dimension(SZI_(G), SZJ_(G)) :: hEff_sum ! Summed effective face thicknesses [H ~> m or kg m-2]
   integer :: iMethod
   real, dimension(SZI_(G)) :: ref_pres ! Reference pressure used to calculate alpha/beta [R L2 T-2 ~> Pa]
@@ -589,24 +592,38 @@ subroutine neutral_diffusion(G, GV, h, Coef_x, Coef_y, dt, Reg, US, CS)
   real, dimension(SZIB_(G),SZJ_(G),SZK_(GV)+1), intent(in)    :: Coef_x !< dt * Kh * dy / dx at u-points [L2 ~> m2]
   real, dimension(SZI_(G),SZJB_(G),SZK_(GV)+1), intent(in)    :: Coef_y !< dt * Kh * dx / dy at v-points [L2 ~> m2]
   real,                                         intent(in)    :: dt     !< Tracer time step * I_numitts [T ~> s]
-                                                                     !! (I_numitts in tracer_hordiff)
+                                                                        !! (I_numitts is in tracer_hordiff)
   type(tracer_registry_type),                   pointer       :: Reg    !< Tracer registry
   type(unit_scale_type),                        intent(in)    :: US     !< A dimensional unit scaling type
   type(neutral_diffusion_CS),                   pointer       :: CS     !< Neutral diffusion control structure
 
   ! Local variables
-  real, dimension(SZIB_(G),SZJ_(G),CS%nsurf-1) :: uFlx        ! Zonal flux of tracer [H conc ~> m conc or conc kg m-2]
-  real, dimension(SZI_(G),SZJB_(G),CS%nsurf-1) :: vFlx        ! Meridional flux of tracer
-                                                              ! [H conc ~> m conc or conc kg m-2]
+  real, dimension(SZIB_(G),SZJ_(G),CS%nsurf-1) :: uFlx        ! Zonal flux of tracer in units that vary between a
+                        ! thickness times a concentration ([C H ~> degC m or degC kg m-2] for temperature) or a
+                        ! volume or mass times a concentration ([C H L2 ~> degC m3 or degC kg] for temperature),
+                        ! depending on the setting of CS%KhTh_use_ebt_struct.
+  real, dimension(SZI_(G),SZJB_(G),CS%nsurf-1) :: vFlx        ! Meridional flux of tracer in units that vary between a
+                        ! thickness times a concentration ([C H ~> degC m or degC kg m-2] for temperature) or a
+                        ! volume or mass times a concentration ([C H L2 ~> degC m3 or degC kg] for temperature),
+                        ! depending on the setting of CS%KhTh_use_ebt_struct.
   real, dimension(SZI_(G),SZJ_(G),SZK_(GV))    :: tendency    ! tendency array for diagnostics
                                                               ! [H conc T-1 ~> m conc s-1 or kg m-2 conc s-1]
-  real, dimension(SZI_(G),SZJ_(G))             :: tendency_2d ! depth integrated content tendency for diagn
-                                                              ! [H conc T-1 ~> m conc s-1 or kg m-2 conc s-1]
-  real, dimension(SZIB_(G),SZJ_(G))            :: trans_x_2d  ! depth integrated diffusive tracer x-transport diagn
-  real, dimension(SZI_(G),SZJB_(G))            :: trans_y_2d  ! depth integrated diffusive tracer y-transport diagn
-  real, dimension(SZK_(GV))                    :: dTracer     ! change in tracer concentration due to ndiffusion
-                                                              ! [H L2 conc ~> m3 conc or kg conc]
-  real :: normalize  ! normalization used for averaging Coef_x and Coef_y to t-points.
+                                                              ! For temperature these units are
+                                                              ! [C H T-1 ~> degC m s-1 or degC kg m-2 s-1].
+  real, dimension(SZI_(G),SZJ_(G))             :: tendency_2d ! Depth integrated content tendency for diagnostics
+                                                              ! [H conc T-1 ~> m conc s-1 or kg m-2 conc s-1].
+                                                              ! For temperature these units are
+                                                              ! [C H T-1 ~> degC m s-1 or degC kg m-2 s-1].
+  real, dimension(SZIB_(G),SZJ_(G))            :: trans_x_2d  ! Depth integrated diffusive tracer x-transport
+                                                              ! diagnostic.  For temperature this has units of
+                                                              ! [C H L2 ~> degC m3 or degC kg].
+  real, dimension(SZI_(G),SZJB_(G))            :: trans_y_2d  ! depth integrated diffusive tracer y-transport
+                                                              ! diagnostic.  For temperature this has units of
+                                                              ! [C H L2 ~> degC m3 or degC kg].
+  real, dimension(SZK_(GV))                    :: dTracer     ! Change in tracer concentration due to neutral diffusion
+                                                              ! [H L2 conc ~> m3 conc or kg conc].  For temperature
+                                                              ! these units are [C H L2 ~> degC m3 or degC kg].
+  real :: normalize  ! normalization used for averaging Coef_x and Coef_y to t-points [nondim].
 
   type(tracer_type), pointer                   :: Tracer => NULL() ! Pointer to the current tracer
 
@@ -950,12 +967,12 @@ subroutine compute_tapering_coeffs(ne, bld_l, bld_r, coeff_l, coeff_r, h_l, h_r)
   ! Local variables
   real :: min_bld, max_bld                       ! Min/Max boundary layer depth in two adjacent columns
   integer :: dummy1                              ! dummy integer
-  real    :: dummy2                              ! dummy real
+  real    :: dummy2                              ! dummy real [nondim]
   integer :: k_min_l, k_min_r, k_max_l, k_max_r  ! Min/max vertical indices in two adjacent columns
-  real    :: zeta_l, zeta_r                      ! dummy variables
+  real    :: zeta_l, zeta_r                      ! dummy variables [nondim]
   integer :: k                                   ! vertical index
 
-  ! initialize coeffs
+  ! Initialize coefficients
   coeff_l(:) = 1.0
   coeff_r(:) = 1.0
 
@@ -996,15 +1013,19 @@ end subroutine compute_tapering_coeffs
 subroutine interface_scalar(nk, h, S, Si, i_method, h_neglect)
   integer,               intent(in)    :: nk       !< Number of levels
   real, dimension(nk),   intent(in)    :: h        !< Layer thickness [H ~> m or kg m-2]
-  real, dimension(nk),   intent(in)    :: S        !< Layer scalar (conc, e.g. ppt)
-  real, dimension(nk+1), intent(inout) :: Si       !< Interface scalar (conc, e.g. ppt)
+  real, dimension(nk),   intent(in)    :: S        !< Layer scalar (or concentrations) in arbitrary
+                                                   !! concentration units (e.g. [C ~> degC] for temperature)
+  real, dimension(nk+1), intent(inout) :: Si       !< Interface scalar (or concentrations) in arbitrary
+                                                   !! concentration units (e.g. [C ~> degC] for temperature)
   integer,               intent(in)    :: i_method !< =1 use average of PLM edges
                                                    !! =2 use continuous PPM edge interpolation
   real,                  intent(in)    :: h_neglect !< A negligibly small thickness [H ~> m or kg m-2]
   ! Local variables
   integer :: k, km2, kp1
-  real, dimension(nk) :: diff
-  real :: Sb, Sa
+  real, dimension(nk) :: diff ! Difference in scalar concentrations between layer centers in arbitrary
+                              ! concentration units (e.g. [C ~> degC] for temperature)
+  real :: Sb, Sa ! Values of scalar concentrations at the upper and lower edges of a layer in arbitrary
+                 ! concentration units (e.g. [C ~> degC] for temperature)
 
   call PLM_diff(nk, h, S, 2, 1, diff)
   Si(1) = S(1) - 0.5 * diff(1)
@@ -1032,18 +1053,24 @@ end subroutine interface_scalar
 !> Returns the PPM quasi-fourth order edge value at k+1/2 following
 !! equation 1.6 in Colella & Woodward, 1984: JCP 54, 174-201.
 real function ppm_edge(hkm1, hk, hkp1, hkp2,  Ak, Akp1, Pk, Pkp1, h_neglect)
-  real, intent(in) :: hkm1 !< Width of cell k-1
-  real, intent(in) :: hk   !< Width of cell k
-  real, intent(in) :: hkp1 !< Width of cell k+1
-  real, intent(in) :: hkp2 !< Width of cell k+2
-  real, intent(in) :: Ak   !< Average scalar value of cell k
-  real, intent(in) :: Akp1 !< Average scalar value of cell k+1
-  real, intent(in) :: Pk   !< PLM slope for cell k
-  real, intent(in) :: Pkp1 !< PLM slope for cell k+1
+  real, intent(in) :: hkm1 !< Width of cell k-1 in [H ~> m or kg m-2] or other units
+  real, intent(in) :: hk   !< Width of cell k in [H ~> m or kg m-2] or other units
+  real, intent(in) :: hkp1 !< Width of cell k+1 in [H ~> m or kg m-2] or other units
+  real, intent(in) :: hkp2 !< Width of cell k+2 in [H ~> m or kg m-2] or other units
+  real, intent(in) :: Ak   !< Average scalar value of cell k in arbitrary concentration
+                           !! units (e.g. [C ~> degC] for temperature)
+  real, intent(in) :: Akp1 !< Average scalar value of cell k+1 in arbitrary concentration
+                           !! units (e.g. [C ~> degC] for temperature)
+  real, intent(in) :: Pk   !< PLM slope for cell k in arbitrary concentration
+                           !! units (e.g. [C ~> degC] for temperature)
+  real, intent(in) :: Pkp1 !< PLM slope for cell k+1 in arbitrary concentration
+                           !! units (e.g. [C ~> degC] for temperature)
   real, intent(in) :: h_neglect !< A negligibly small thickness [H ~> m or kg m-2]
 
   ! Local variables
-  real :: R_hk_hkp1, R_2hk_hkp1, R_hk_2hkp1, f1, f2, f3, f4
+  real :: R_hk_hkp1, R_2hk_hkp1, R_hk_2hkp1 ! Reciprocals of combinations of thicknesses [H-1 ~> m-1 or m2 kg-1]
+  real :: f1 ! A work variable with units of an inverse cell width [H-1 ~> m-1 or m2 kg-1]
+  real :: f2, f3, f4 ! Work variables with units of the cell width [H ~> m or kg m-2]
 
   R_hk_hkp1 = hk + hkp1
   if (R_hk_hkp1 <= 0.) then
@@ -1069,17 +1096,23 @@ real function ppm_edge(hkm1, hk, hkp1, hkp2,  Ak, Akp1, Pk, Pkp1, h_neglect)
 
 end function ppm_edge
 
-!> Returns the average of a PPM reconstruction between two
-!! fractional positions.
+!> Returns the average of a PPM reconstruction between two fractional positions in the same
+!! arbitrary concentration units as aMean (e.g. usually [C ~> degC] for temperature)
 real function ppm_ave(xL, xR, aL, aR, aMean)
-  real, intent(in) :: xL    !< Fraction position of left bound (0,1)
-  real, intent(in) :: xR    !< Fraction position of right bound (0,1)
-  real, intent(in) :: aL    !< Left edge scalar value, at x=0
-  real, intent(in) :: aR    !< Right edge scalar value, at x=1
-  real, intent(in) :: aMean !< Average scalar value of cell
+  real, intent(in) :: xL    !< Fraction position of left bound (0,1) [nondim]
+  real, intent(in) :: xR    !< Fraction position of right bound (0,1) [nondim]
+  real, intent(in) :: aL    !< Left edge scalar value, at x=0, in arbitrary concentration
+                            !! units (e.g. usually [C ~> degC] for temperature)
+  real, intent(in) :: aR    !< Right edge scalar value, at x=1 in arbitrary concentration
+                            !! units (e.g. usually [C ~> degC] for temperature)
+  real, intent(in) :: aMean !< Average scalar value of cell in arbitrary concentration
+                            !! units (e.g. usually [C ~> degC] for temperature)
 
   ! Local variables
-  real :: dx, xave, a6, a6o3
+  real :: dx   ! Distance between the bounds [nondim]
+  real :: xave ! Average fractional position [nondim]
+  real :: a6, a6o3 ! Terms proportional to the normalized scalar curvature in the same arbitrary
+                   ! concentration units as aMean (e.g. usually [C ~> degC] for temperature)
 
   dx = xR - xL
   xave = 0.5 * ( xR + xL )
@@ -1098,9 +1131,10 @@ real function ppm_ave(xL, xR, aL, aR, aMean)
 end function ppm_ave
 
 !> A true signum function that returns either -abs(a), when x<0; or abs(a) when x>0; or 0 when x=0.
+!! The returned units are the same as those of a [arbitrary].
 real function signum(a,x)
-  real, intent(in) :: a !< The magnitude argument
-  real, intent(in) :: x !< The sign (or zero) argument
+  real, intent(in) :: a !< The magnitude argument in arbitrary units [arbitrary]
+  real, intent(in) :: x !< The sign (or zero) argument [arbitrary]
 
   signum = sign(a,x)
   if (x==0.) signum = 0.
@@ -1111,11 +1145,13 @@ end function signum
 !! The limiting follows equation 1.8 in Colella & Woodward, 1984: JCP 54, 174-201.
 subroutine PLM_diff(nk, h, S, c_method, b_method, diff)
   integer,             intent(in)    :: nk       !< Number of levels
-  real, dimension(nk), intent(in)    :: h        !< Layer thickness [H ~> m or kg m-2]
-  real, dimension(nk), intent(in)    :: S        !< Layer salinity (conc, e.g. ppt)
+  real, dimension(nk), intent(in)    :: h        !< Layer thickness [H ~> m or kg m-2] or other units
+  real, dimension(nk), intent(in)    :: S        !< Layer salinity (conc, e.g. ppt) or other tracer
+                                                 !! concentration in arbitrary units [A ~> a]
   integer,             intent(in)    :: c_method !< Method to use for the centered difference
   integer,             intent(in)    :: b_method !< =1, use PCM in first/last cell, =2 uses linear extrapolation
   real, dimension(nk), intent(inout) :: diff     !< Scalar difference across layer (conc, e.g. ppt)
+                                                 !! in the same arbitrary units as S [A ~> a],
                                                  !! determined by the following values for c_method:
                                                  !!   1. Second order finite difference (not recommended)
                                                  !!   2. Second order finite volume (used in original PPM)
@@ -1125,7 +1161,9 @@ subroutine PLM_diff(nk, h, S, c_method, b_method, diff)
 
   ! Local variables
   integer :: k
-  real :: hkm1, hk, hkp1, Skm1, Sk, Skp1, diff_l, diff_r, diff_c
+  real :: hkm1, hk, hkp1  ! Successive layer thicknesses [H ~> m or kg m-2] or other units
+  real :: Skm1, Sk, Skp1  ! Successive layer tracer concentrations in the same arbitrary units as S [A ~> a]
+  real :: diff_l, diff_r, diff_c ! Differences in tracer concentrations in arbitrary units [A ~> a]
 
   do k = 2, nk-1
     hkm1 = h(k-1)
@@ -1144,7 +1182,7 @@ subroutine PLM_diff(nk, h, S, c_method, b_method, diff)
           diff_c = 0.
         endif
       elseif (c_method==2) then
-        ! Second order accurate centered FV slope (from Colella and Woodward, JCP 1984)
+        ! Second order accurate centered finite-volume slope (from Colella and Woodward, JCP 1984)
         diff_c = fv_diff(hkm1, hk, hkp1, Skm1, Sk, Skp1)
       elseif (c_method==3) then
         ! Second order accurate finite-volume least squares slope
@@ -1177,15 +1215,19 @@ end subroutine PLM_diff
 !! as a difference across the central cell (i.e. units of scalar S).
 !! Discretization follows equation 1.7 in Colella & Woodward, 1984: JCP 54, 174-201.
 real function fv_diff(hkm1, hk, hkp1, Skm1, Sk, Skp1)
-  real, intent(in) :: hkm1 !< Left cell width
-  real, intent(in) :: hk   !< Center cell width
-  real, intent(in) :: hkp1 !< Right cell width
-  real, intent(in) :: Skm1 !< Left cell average value
-  real, intent(in) :: Sk   !< Center cell average value
-  real, intent(in) :: Skp1 !< Right cell average value
+  real, intent(in) :: hkm1 !< Left cell width [H ~> m or kg m-2] or other arbitrary units
+  real, intent(in) :: hk   !< Center cell width [H ~> m or kg m-2] or other arbitrary units
+  real, intent(in) :: hkp1 !< Right cell width [H ~> m or kg m-2] or other arbitrary units
+  real, intent(in) :: Skm1 !< Left cell average value in arbitrary concentration
+                           !! units (e.g. [C ~> degC] for temperature)
+  real, intent(in) :: Sk   !< Center cell average value in arbitrary concentration
+                           !! units (e.g. [C ~> degC] for temperature)
+  real, intent(in) :: Skp1 !< Right cell average value in arbitrary concentration
+                           !! units (e.g. [C ~> degC] for temperature)
 
   ! Local variables
-  real :: h_sum, hp, hm
+  real :: h_sum, hp, hm ! At first sums of thicknesses [H ~> m or kg m-2], then changed into
+                        ! their reciprocals [H-1 ~> m-1 or m2 kg-1]
 
   h_sum = ( hkm1 + hkp1 ) + hk
   if (h_sum /= 0.) h_sum = 1./ h_sum
@@ -1200,19 +1242,30 @@ end function fv_diff
 
 
 !> Returns the cell-centered second-order weighted least squares slope
-!! using three consecutive cell widths and average values. Slope is returned
-!! as a gradient (i.e. units of scalar S over width units).
+!! using three consecutive cell widths and average values.  Slope is returned
+!! as a gradient (i.e. units of scalar S over width units).  For example, for temperature
+!! fvlsq_slope would usually be returned in units of [C H-1 ~> degC m-1 or degC m2 kg-1].
 real function fvlsq_slope(hkm1, hk, hkp1, Skm1, Sk, Skp1)
-  real, intent(in) :: hkm1 !< Left cell width
-  real, intent(in) :: hk   !< Center cell width
-  real, intent(in) :: hkp1 !< Right cell width
-  real, intent(in) :: Skm1 !< Left cell average value
-  real, intent(in) :: Sk   !< Center cell average value
-  real, intent(in) :: Skp1 !< Right cell average value
+  real, intent(in) :: hkm1 !< Left cell width [H ~> m or kg m-2] or other arbitrary units
+  real, intent(in) :: hk   !< Center cell width [H ~> m or kg m-2] or other arbitrary units
+  real, intent(in) :: hkp1 !< Right cell width [H ~> m or kg m-2] or other arbitrary units
+  real, intent(in) :: Skm1 !< Left cell average value in arbitrary concentration
+                           !! units (e.g. [C ~> degC] for temperature)
+  real, intent(in) :: Sk   !< Center cell average value often in arbitrary concentration
+                           !! units (e.g. [C ~> degC] for temperature)
+  real, intent(in) :: Skp1 !< Right cell average value often in arbitrary concentration
+                           !! units (e.g. [C ~> degC] for temperature)
 
   ! Local variables
-  real :: xkm1, xkp1
-  real :: h_sum, hx_sum, hxsq_sum, hxy_sum, hy_sum, det
+  real :: xkm1, xkp1  ! Distances between layer centers [H ~> m or kg m-2] or other arbitrary units
+  real :: h_sum       ! Sum of the successive cell widths [H ~> m or kg m-2] or other arbitrary units
+  real :: hx_sum      ! Thicknesses times distances [H2 ~> m2 or kg2 m-4]
+  real :: hxsq_sum    ! Thicknesses times squared distances [H3 ~> m3 or kg3 m-6]
+  real :: det         ! The denominator in the weighted slope calculation [H4 ~> m4 or kg4 m-8]
+  real :: hxy_sum     ! Sum of layer concentrations times thicknesses and distances in units that
+                      ! depend on those of Sk (e.g. [C H2 ~> degC m2 or degC kg2 m-4] for temperature)
+  real :: hy_sum      ! Sum of layer concentrations times thicknesses in units that depend on
+                      ! those of Sk (e.g. [C H ~> degC m or degC kg m-2] for temperature)
 
   xkm1 = -0.5 * ( hk + hkm1 )
   xkp1 = 0.5 * ( hk + hkp1 )
@@ -1255,8 +1308,8 @@ subroutine find_neutral_surface_positions_continuous(nk, Pl, Tl, Sl, dRdTl, dRdS
                                                      !! [R L2 T-2 ~> Pa] or other units following Pl and Pr.
   integer, optional,          intent(in)    :: bl_kl !< Layer index of the boundary layer (left)
   integer, optional,          intent(in)    :: bl_kr !< Layer index of the boundary layer (right)
-  real, optional,             intent(in)    :: bl_zl !< Nondimensional position of the boundary layer (left)
-  real, optional,             intent(in)    :: bl_zr !< Nondimensional position of the boundary layer (right)
+  real, optional,             intent(in)    :: bl_zl !< Fractional position of the boundary layer (left) [nondim]
+  real, optional,             intent(in)    :: bl_zr !< Fractional position of the boundary layer (right) [nondim]
 
   ! Local variables
   integer :: ns                     ! Number of neutral surfaces
@@ -2161,7 +2214,7 @@ function absolute_positions(n,ns,Pint,Karr,NParr)
   integer, intent(in) :: ns        !< Number of neutral surfaces
   real,    intent(in) :: Pint(n+1) !< Position of interface [R L2 T-2 ~> Pa] or other units
   integer, intent(in) :: Karr(ns)  !< Indexes of interfaces about positions
-  real,    intent(in) :: NParr(ns) !< Non-dimensional positions within layers Karr(:)
+  real,    intent(in) :: NParr(ns) !< Non-dimensional positions within layers Karr(:) [nondim]
 
   real,  dimension(ns) :: absolute_positions !< Absolute positions [R L2 T-2 ~> Pa]
                                    !! or other units following Pint
@@ -2184,47 +2237,83 @@ subroutine neutral_surface_flux(nk, nsurf, deg, hl, hr, Tl, Tr, PiL, PiR, KoL, K
   integer,                      intent(in)    :: deg   !< Degree of polynomial reconstructions
   real, dimension(nk),          intent(in)    :: hl    !< Left-column layer thickness [H ~> m or kg m-2]
   real, dimension(nk),          intent(in)    :: hr    !< Right-column layer thickness [H ~> m or kg m-2]
-  real, dimension(nk),          intent(in)    :: Tl    !< Left-column layer tracer (conc, e.g. degC)
-  real, dimension(nk),          intent(in)    :: Tr    !< Right-column layer tracer (conc, e.g. degC)
+  real, dimension(nk),          intent(in)    :: Tl    !< Left-column layer tracer in arbitrary concentration
+                                                       !! units (e.g. [C ~> degC] for temperature)
+  real, dimension(nk),          intent(in)    :: Tr    !< Right-column layer tracer in arbitrary concentration
+                                                       !! units (e.g. [C ~> degC] for temperature)
   real, dimension(nsurf),       intent(in)    :: PiL   !< Fractional position of neutral surface
-                                                       !! within layer KoL of left column
+                                                       !! within layer KoL of left column [nondim]
   real, dimension(nsurf),       intent(in)    :: PiR   !< Fractional position of neutral surface
-                                                       !! within layer KoR of right column
+                                                       !! within layer KoR of right column [nondim]
   integer, dimension(nsurf),    intent(in)    :: KoL   !< Index of first left interface above neutral surface
   integer, dimension(nsurf),    intent(in)    :: KoR   !< Index of first right interface above neutral surface
   real, dimension(nsurf-1),     intent(in)    :: hEff  !< Effective thickness between two neutral
                                                        !! surfaces [H ~> m or kg m-2]
   real, dimension(nsurf-1),     intent(inout) :: Flx   !< Flux of tracer between pairs of neutral layers
-                                                       !! (conc H or conc H L2)
+                                                       !! in units  (conc H or conc H L2) that depend on
+                                                       !! the presence and units of coeff_l and coeff_r.
+                                                       !! If the tracer is temperature, this could have
+                                                       !! units of [C H ~> degC m or degC kg m-2] or
+                                                       !! [C H L2 ~> degC m3 or degC kg] if coeff_l has
+                                                       !! units of [L2 ~> m2]
   logical,                      intent(in)    :: continuous !< True if using continuous reconstruction
-  real,                         intent(in)    :: h_neglect !< A negligibly small width for the
-                                             !! purpose of cell reconstructions [H ~> m or kg m-2]
+  real,                         intent(in)    :: h_neglect !< A negligibly small width for the purpose
+                                                       !! of cell reconstructions [H ~> m or kg m-2]
   type(remapping_CS), optional, intent(in)    :: remap_CS !< Remapping control structure used
-                                             !! to create sublayers
-  real,               optional, intent(in)    :: h_neglect_edge !< A negligibly small width used for
-                                             !! edge value calculations if continuous is false [H ~> m or kg m-2]
-  real, dimension(nk+1), optional, intent(in) :: coeff_l !< Left-column diffusivity  [L2 ~> m2 or nondim]
-  real, dimension(nk+1), optional, intent(in) :: coeff_r !< Right-column diffusivity [L2 ~> m2 or nondim]
+                                                       !! to create sublayers
+  real,               optional, intent(in)    :: h_neglect_edge !< A negligibly small width used for edge value
+                                                       !! calculations if continuous is false [H ~> m or kg m-2]
+  real, dimension(nk+1), optional, intent(in) :: coeff_l !< Left-column diffusivity  [L2 ~> m2] or [nondim]
+  real, dimension(nk+1), optional, intent(in) :: coeff_r !< Right-column diffusivity [L2 ~> m2] or [nondim]
 
   ! Local variables
   integer :: k_sublayer, klb, klt, krb, krt
-  real :: T_right_top, T_right_bottom, T_right_layer, T_right_sub, T_right_top_int, T_right_bot_int
-  real :: T_left_top, T_left_bottom, T_left_layer, T_left_sub, T_left_top_int, T_left_bot_int
-  real :: dT_top, dT_bottom, dT_layer, dT_ave, dT_sublayer, dT_top_int, dT_bot_int, khtr_ave
-  real, dimension(nk+1) :: Til !< Left-column interface tracer (conc, e.g. degC)
-  real, dimension(nk+1) :: Tir !< Right-column interface tracer (conc, e.g. degC)
-  real, dimension(nk) :: aL_l !< Left-column left edge value of tracer (conc, e.g. degC)
-  real, dimension(nk) :: aR_l !< Left-column right edge value of tracer (conc, e.g. degC)
-  real, dimension(nk) :: aL_r !< Right-column left edge value of tracer (conc, e.g. degC)
-  real, dimension(nk) :: aR_r !< Right-column right edge value of tracer (conc, e.g. degC)
+  real :: T_right_sub, T_left_sub ! Tracer concentrations averaged over sub-intervals in the right and left
+                                  ! columns in arbitrary concentration units (e.g. [C ~> degC] for temperature).
+  real :: T_right_layer, T_left_layer ! Tracer concentrations averaged over layers in the right and left
+                                  ! columns in arbitrary concentration units (e.g. [C ~> degC] for temperature).
+  real :: T_right_top, T_right_bottom, T_right_top_int, T_right_bot_int ! Tracer concentrations
+                        ! at various positions in the right column in arbitrary
+                        ! concentration units (e.g. [C ~> degC] for temperature).
+  real :: T_left_top, T_left_bottom, T_left_top_int, T_left_bot_int ! Tracer concentrations
+                        ! at various positions in the left column in arbitrary
+                        ! concentration units (e.g. [C ~> degC] for temperature).
+  real :: dT_layer, dT_ave, dT_sublayer ! Differences in vertically averaged tracer concentrations
+                        ! over various portions of the right and left columns in arbitrary
+                        ! concentration units (e.g. [C ~> degC] for temperature).
+  real :: dT_top, dT_bottom, dT_top_int, dT_bot_int ! Differences in tracer concentrations
+                        ! at various positions between the right and left columns in arbitrary
+                        ! concentration units (e.g. [C ~> degC] for temperature).
+  real :: khtr_ave ! An averaged diffusivity in normalized units [nondim] if coeff_l and coeff_r are
+                   ! absent or in units copied from coeff_l and coeff_r [L2 ~> m2] or [nondim]
+  real, dimension(nk+1) :: Til !< Left-column interface tracer in arbitrary concentration
+                              !! units (e.g. [C ~> degC] for temperature)
+  real, dimension(nk+1) :: Tir !< Right-column interface tracer in arbitrary concentration
+                              !! units (e.g. [C ~> degC] for temperature)
+  real, dimension(nk) :: aL_l !< Left-column left edge value of tracer in arbitrary concentration
+                              !! units (e.g. [C ~> degC] for temperature)
+  real, dimension(nk) :: aR_l !< Left-column right edge value of tracer in arbitrary concentration
+                              !! units (e.g. [C ~> degC] for temperature)
+  real, dimension(nk) :: aL_r !< Right-column left edge value of tracer in arbitrary concentration
+                              !! units (e.g. [C ~> degC] for temperature)
+  real, dimension(nk) :: aR_r !< Right-column right edge value of tracer in arbitrary concentration
+                              !! units (e.g. [C ~> degC] for temperature)
   ! Discontinuous reconstruction
   integer               :: iMethod
-  real, dimension(nk,2) :: Tid_l !< Left-column interface tracer (conc, e.g. degC)
-  real, dimension(nk,2) :: Tid_r !< Right-column interface tracer (conc, e.g. degC)
-  real, dimension(nk,deg+1) :: ppoly_r_coeffs_l
-  real, dimension(nk,deg+1) :: ppoly_r_coeffs_r
-  real, dimension(nk,deg+1) :: ppoly_r_S_l
-  real, dimension(nk,deg+1) :: ppoly_r_S_r
+  real, dimension(nk,2) :: Tid_l !< Left-column interface tracer in arbitrary concentration
+                              !! units (e.g. [C ~> degC] for temperature)
+  real, dimension(nk,2) :: Tid_r !< Right-column interface tracer in arbitrary concentration
+                              !! units (e.g. [C ~> degC] for temperature)
+  real, dimension(nk,deg+1) :: ppoly_r_coeffs_l  ! Coefficients of the polynomial descriptions of
+                              ! sub-gridscale tracer concentrations in the left column, in arbitrary
+                              ! concentration units (e.g. [C ~> degC] for temperature)
+  real, dimension(nk,deg+1) :: ppoly_r_coeffs_r  ! Coefficients of the polynomial descriptions of
+                              ! sub-gridscale tracer concentrations in the right column, in arbitrary
+                              ! concentration units (e.g. [C ~> degC] for temperature)
+  real, dimension(nk,deg+1) :: ppoly_r_S_l   ! Reconstruction slopes that are unused here, in units of a vertical
+                              ! gradient, which for temperature would be [C H-1 ~> degC m-1 or degC m2 kg-1].
+  real, dimension(nk,deg+1) :: ppoly_r_S_r   ! Reconstruction slopes that are unused here, in units of a vertical
+                              ! gradient, which for temperature would be [C H-1 ~> degC m-1 or degC m2 kg-1].
   logical :: down_flux, tapering
 
   tapering = .false.
@@ -2327,18 +2416,28 @@ subroutine neutral_surface_T_eval(nk, ns, k_sub, Ks, Ps, T_mean, T_int, deg, iMe
   integer,                   intent(in   ) :: ns        !< Number of neutral surfaces
   integer,                   intent(in   ) :: k_sub     !< Index of current neutral layer
   integer, dimension(ns),    intent(in   ) :: Ks        !< List of the layers associated with each neutral surface
-  real, dimension(ns),       intent(in   ) :: Ps        !< List of the positions within a layer of each surface
-  real, dimension(nk),       intent(in   ) :: T_mean    !< Cell average of tracer
-  real, dimension(nk,2),     intent(in   ) :: T_int     !< Cell interface values of tracer from reconstruction
+  real, dimension(ns),       intent(in   ) :: Ps        !< List of the positions within a layer of each surface [nondim]
+  real, dimension(nk),       intent(in   ) :: T_mean    !< Layer average of tracer in arbitrary concentration
+                                                        !! units (e.g. [C ~> degC] for temperature)
+  real, dimension(nk,2),     intent(in   ) :: T_int     !< Layer interface values of tracer from reconstruction
+                                                        !! in concentration units (e.g. [C ~> degC] for temperature)
   integer,                   intent(in   ) :: deg       !< Degree of reconstruction polynomial (e.g. 1 is linear)
   integer,                   intent(in   ) :: iMethod   !< Method of integration to use
-  real, dimension(nk,deg+1), intent(in   ) :: T_poly    !< Coefficients of polynomial reconstructions
-  real,                      intent(  out) :: T_top     !< Tracer value at top (across discontinuity if necessary)
+  real, dimension(nk,deg+1), intent(in   ) :: T_poly    !< Coefficients of polynomial reconstructions in arbitrary
+                                                        !! concentration units (e.g. [C ~> degC] for temperature)
+  real,                      intent(  out) :: T_top     !< Tracer value at top (across discontinuity if necessary) in
+                                                        !! concentration units (e.g. [C ~> degC] for temperature)
   real,                      intent(  out) :: T_bot     !< Tracer value at bottom (across discontinuity if necessary)
-  real,                      intent(  out) :: T_sub     !< Average of the tracer value over the sublayer
-  real,                      intent(  out) :: T_top_int !< Tracer value at top interface of neutral layer
-  real,                      intent(  out) :: T_bot_int !< Tracer value at bottom interface of neutral layer
-  real,                      intent(  out) :: T_layer   !< Cell-average that the reconstruction belongs to
+                                                        !! in concentration units (e.g. [C ~> degC] for temperature)
+  real,                      intent(  out) :: T_sub     !< Average of the tracer value over the sublayer in arbitrary
+                                                        !! concentration units (e.g. [C ~> degC] for temperature)
+  real,                      intent(  out) :: T_top_int !< Tracer value at the top interface of a neutral layer in
+                                                        !! concentration units (e.g. [C ~> degC] for temperature)
+  real,                      intent(  out) :: T_bot_int !< Tracer value at the bottom interface of a neutral layer in
+                                                        !! concentration units (e.g. [C ~> degC] for temperature)
+  real,                      intent(  out) :: T_layer   !< Cell-average tracer concentration in a layer that
+                                                        !! the reconstruction belongs to in concentration
+                                                        !! units (e.g. [C ~> degC] for temperature)
 
   integer :: kl, ks_top, ks_bot
 
@@ -2376,10 +2475,12 @@ end subroutine neutral_surface_T_eval
 !> Discontinuous PPM reconstructions of the left/right edge values within a cell
 subroutine ppm_left_right_edge_values(nk, Tl, Ti, aL, aR)
   integer,                    intent(in)    :: nk !< Number of levels
-  real, dimension(nk),        intent(in)    :: Tl !< Layer tracer (conc, e.g. degC)
-  real, dimension(nk+1),      intent(in)    :: Ti !< Interface tracer (conc, e.g. degC)
+  real, dimension(nk),        intent(in)    :: Tl !< Layer tracer (conc, e.g. degC) in arbitrary units [A ~> a]
+  real, dimension(nk+1),      intent(in)    :: Ti !< Interface tracer (conc, e.g. degC) in arbitrary units [A ~> a]
   real, dimension(nk),        intent(inout) :: aL !< Left edge value of tracer (conc, e.g. degC)
+                                                  !! in the same arbitrary units as Tl and Ti [A ~> a]
   real, dimension(nk),        intent(inout) :: aR !< Right edge value of tracer (conc, e.g. degC)
+                                                  !! in the same arbitrary units as Tl and Ti [A ~> a]
 
   integer :: k
   ! Setup reconstruction edge values
@@ -2411,13 +2512,13 @@ logical function ndiff_unit_tests_continuous(verbose)
   logical, intent(in) :: verbose !< If true, write results to stdout
   ! Local variables
   integer, parameter         :: nk = 4
-  real, dimension(nk+1)      :: Tio           ! Test interface temperatures
-  real, dimension(2*nk+2)    :: PiLRo, PiRLo  ! Test positions
+  real, dimension(nk+1)      :: Tio           ! Test interface temperatures [degC]
+  real, dimension(2*nk+2)    :: PiLRo, PiRLo  ! Fractional test positions [nondim]
   integer, dimension(2*nk+2) :: KoL, KoR      ! Test indexes
-  real, dimension(2*nk+1)    :: hEff          ! Test positions
-  real, dimension(2*nk+1)    :: Flx           ! Test flux
+  real, dimension(2*nk+1)    :: hEff          ! Test positions in arbitrary units [arbitrary]
+  real, dimension(2*nk+1)    :: Flx           ! Test flux in the arbitrary units of hEff times [degC]
   logical :: v
-  real :: h_neglect
+  real :: h_neglect  ! A negligible thickness in arbitrary units [arbitrary]
 
   h_neglect = 1.0e-30
 
@@ -2674,12 +2775,16 @@ logical function ndiff_unit_tests_discontinuous(verbose)
   integer, parameter          :: nk = 3
   integer, parameter          :: ns = nk*4
   real, dimension(nk)         :: Sl, Sr    ! Salinities [ppt] and temperatures [degC]
-  real, dimension(nk)         :: hl, hr    ! Thicknesses in pressure units [R L2 T-2 ~> Pa]
+  real, dimension(nk)         :: hl, hr    ! Thicknesses in pressure units [R L2 T-2 ~> Pa] or other
+                                           ! arbitrary units [arbitrary]
   real, dimension(nk,2)       :: TiL, SiL, TiR, SiR ! Cell edge salinities [ppt] and temperatures [degC]
   real, dimension(nk,2)       :: Pres_l, Pres_r ! Interface pressures [R L2 T-2 ~> Pa]
-  integer, dimension(ns)      :: KoL, KoR
-  real, dimension(ns)         :: PoL, PoR
-  real, dimension(ns-1)       :: hEff
+  integer, dimension(ns)      :: KoL, KoR  ! Index of the layer where the interface is found in the
+                                           ! left and right columns
+  real, dimension(ns)         :: PoL, PoR  ! Fractional position of neutral surface within layer KoL
+                                           ! of the left column or KoR of the right column [nondim]
+  real, dimension(ns-1)       :: hEff      ! Effective thickness between two neutral surfaces
+                                           ! in the same units as hl and hr [arbitrary]
   type(neutral_diffusion_CS)  :: CS        !< Neutral diffusion control structure
   real, dimension(nk,2)       :: ppoly_T_l, ppoly_T_r ! Linear reconstruction for T [degC]
   real, dimension(nk,2)       :: ppoly_S_l, ppoly_S_r ! Linear reconstruction for S [ppt]
@@ -2921,15 +3026,15 @@ logical function test_fv_diff(verbose, hkm1, hk, hkp1, Skm1, Sk, Skp1, Ptrue, ti
   real,             intent(in) :: hkm1  !< Left cell width [nondim]
   real,             intent(in) :: hk    !< Center cell width [nondim]
   real,             intent(in) :: hkp1  !< Right cell width [nondim]
-  real,             intent(in) :: Skm1  !< Left cell average value
-  real,             intent(in) :: Sk    !< Center cell average value
-  real,             intent(in) :: Skp1  !< Right cell average value
-  real,             intent(in) :: Ptrue !< True answer [nondim]
+  real,             intent(in) :: Skm1  !< Left cell average value in arbitrary units [arbitrary]
+  real,             intent(in) :: Sk    !< Center cell average value in arbitrary units [arbitrary]
+  real,             intent(in) :: Skp1  !< Right cell average value in arbitrary units [arbitrary]
+  real,             intent(in) :: Ptrue !< True answer in arbitrary units [arbitrary]
   character(len=*), intent(in) :: title !< Title for messages
 
   ! Local variables
   integer :: stdunit
-  real :: Pret
+  real :: Pret ! Returned normalized gradient in arbitrary units [arbitrary]
 
   Pret = fv_diff(hkm1, hk, hkp1, Skm1, Sk, Skp1)
   test_fv_diff = (Pret /= Ptrue)
@@ -2950,18 +3055,18 @@ end function test_fv_diff
 !> Returns true if a test of fvlsq_slope() fails, and conditionally writes results to stream
 logical function test_fvlsq_slope(verbose, hkm1, hk, hkp1, Skm1, Sk, Skp1, Ptrue, title)
   logical,          intent(in) :: verbose !< If true, write results to stdout
-  real,             intent(in) :: hkm1  !< Left cell width
-  real,             intent(in) :: hk    !< Center cell width
-  real,             intent(in) :: hkp1  !< Right cell width
-  real,             intent(in) :: Skm1  !< Left cell average value
-  real,             intent(in) :: Sk    !< Center cell average value
-  real,             intent(in) :: Skp1  !< Right cell average value
-  real,             intent(in) :: Ptrue !< True answer
+  real,             intent(in) :: hkm1  !< Left cell width in arbitrary units [B ~> b]
+  real,             intent(in) :: hk    !< Center cell width in arbitrary units [B ~> b]
+  real,             intent(in) :: hkp1  !< Right cell width in arbitrary units [B ~> b]
+  real,             intent(in) :: Skm1  !< Left cell average value in arbitrary units [A ~> a]
+  real,             intent(in) :: Sk    !< Center cell average value in arbitrary units [A ~> a]
+  real,             intent(in) :: Skp1  !< Right cell average value in arbitrary units [A ~> a]
+  real,             intent(in) :: Ptrue !< True answer in arbitrary units [A B-1 ~> a b-1]
   character(len=*), intent(in) :: title !< Title for messages
 
   ! Local variables
   integer :: stdunit
-  real :: Pret
+  real :: Pret  ! Returned slope value [A B-1 ~> a b-1]
 
   Pret = fvlsq_slope(hkm1, hk, hkp1, Skm1, Sk, Skp1)
   test_fvlsq_slope = (Pret /= Ptrue)
@@ -2991,7 +3096,7 @@ logical function test_ifndp(verbose, rhoNeg, Pneg, rhoPos, Ppos, Ptrue, title)
 
   ! Local variables
   integer :: stdunit
-  real :: Pret
+  real :: Pret ! Interpolated fractional position [nondim]
 
   Pret = interpolate_for_nondim_position(rhoNeg, Pneg, rhoPos, Ppos)
   test_ifndp = (Pret /= Ptrue)
@@ -3015,8 +3120,8 @@ end function test_ifndp
 logical function test_data1d(verbose, nk, Po, Ptrue, title)
   logical,             intent(in) :: verbose !< If true, write results to stdout
   integer,             intent(in) :: nk    !< Number of layers
-  real, dimension(nk), intent(in) :: Po    !< Calculated answer
-  real, dimension(nk), intent(in) :: Ptrue !< True answer
+  real, dimension(nk), intent(in) :: Po    !< Calculated answer [arbitrary]
+  real, dimension(nk), intent(in) :: Ptrue !< True answer [arbitrary]
   character(len=*),    intent(in) :: title !< Title for messages
 
   ! Local variables
@@ -3050,8 +3155,8 @@ end function test_data1d
 logical function test_data1di(verbose, nk, Po, Ptrue, title)
   logical,                intent(in) :: verbose !< If true, write results to stdout
   integer,                intent(in) :: nk    !< Number of layers
-  integer, dimension(nk), intent(in) :: Po    !< Calculated answer
-  integer, dimension(nk), intent(in) :: Ptrue !< True answer
+  integer, dimension(nk), intent(in) :: Po    !< Calculated answer [arbitrary]
+  integer, dimension(nk), intent(in) :: Ptrue !< True answer [arbitrary]
   character(len=*),       intent(in) :: title !< Title for messages
 
   ! Local variables
@@ -3086,14 +3191,16 @@ logical function test_nsp(verbose, ns, KoL, KoR, pL, pR, hEff, KoL0, KoR0, pL0, 
   integer,                intent(in) :: ns    !< Number of surfaces
   integer, dimension(ns), intent(in) :: KoL   !< Index of first left interface above neutral surface
   integer, dimension(ns), intent(in) :: KoR   !< Index of first right interface above neutral surface
-  real, dimension(ns),    intent(in) :: pL    !< Fractional position of neutral surface within layer KoL of left column
-  real, dimension(ns),    intent(in) :: pR    !< Fractional position of neutral surface within layer KoR of right column
+  real, dimension(ns),    intent(in) :: pL    !< Fractional position of neutral surface within layer
+                                              !! KoL of left column [nondim]
+  real, dimension(ns),    intent(in) :: pR    !< Fractional position of neutral surface within layer
+                                              !! KoR of right column [nondim]
   real, dimension(ns-1),  intent(in) :: hEff  !< Effective thickness between two neutral surfaces [R L2 T-2 ~> Pa]
   integer, dimension(ns), intent(in) :: KoL0  !< Correct value for KoL
   integer, dimension(ns), intent(in) :: KoR0  !< Correct value for KoR
-  real, dimension(ns),    intent(in) :: pL0   !< Correct value for pL
-  real, dimension(ns),    intent(in) :: pR0   !< Correct value for pR
-  real, dimension(ns-1),  intent(in) :: hEff0 !< Correct value for hEff
+  real, dimension(ns),    intent(in) :: pL0   !< Correct value for pL [nondim]
+  real, dimension(ns),    intent(in) :: pR0   !< Correct value for pR [nondim]
+  real, dimension(ns-1),  intent(in) :: hEff0 !< Correct value for hEff [R L2 T-2 ~> Pa]
   character(len=*),       intent(in) :: title !< Title for messages
 
   ! Local variables
@@ -3138,12 +3245,12 @@ end function test_nsp
 logical function compare_nsp_row(KoL, KoR, pL, pR, KoL0, KoR0, pL0, pR0)
   integer,  intent(in) :: KoL   !< Index of first left interface above neutral surface
   integer,  intent(in) :: KoR   !< Index of first right interface above neutral surface
-  real,     intent(in) :: pL    !< Fractional position of neutral surface within layer KoL of left column
-  real,     intent(in) :: pR    !< Fractional position of neutral surface within layer KoR of right column
+  real,     intent(in) :: pL    !< Fractional position of neutral surface within layer KoL of left column [nondim]
+  real,     intent(in) :: pR    !< Fractional position of neutral surface within layer KoR of right column [nondim]
   integer,  intent(in) :: KoL0  !< Correct value for KoL
   integer,  intent(in) :: KoR0  !< Correct value for KoR
-  real,     intent(in) :: pL0   !< Correct value for pL
-  real,     intent(in) :: pR0   !< Correct value for pR
+  real,     intent(in) :: pL0   !< Correct value for pL [nondim]
+  real,     intent(in) :: pR0   !< Correct value for pR [nondim]
 
   compare_nsp_row = .false.
   if (KoL /= KoL0) compare_nsp_row = .true.
@@ -3154,8 +3261,8 @@ end function compare_nsp_row
 
 !> Compares output position from refine_nondim_position with an expected value
 logical function test_rnp(expected_pos, test_pos, title)
-  real,             intent(in) :: expected_pos !< The expected position
-  real,             intent(in) :: test_pos !< The position returned by the code
+  real,             intent(in) :: expected_pos !< The expected position [arbitrary]
+  real,             intent(in) :: test_pos !< The position returned by the code [arbitrary]
   character(len=*), intent(in) :: title    !< A label for this test
   ! Local variables
   integer :: stdunit
@@ -3168,6 +3275,7 @@ logical function test_rnp(expected_pos, test_pos, title)
     write(stdunit,'(A, f20.16, " ==  ", f20.16)') title, expected_pos, test_pos
   endif
 end function test_rnp
+
 !> Deallocates neutral_diffusion control structure
 subroutine neutral_diffusion_end(CS)
   type(neutral_diffusion_CS), pointer :: CS  !< Neutral diffusion control structure

--- a/src/tracer/MOM_neutral_diffusion.F90
+++ b/src/tracer/MOM_neutral_diffusion.F90
@@ -10,7 +10,7 @@ use MOM_diag_mediator,         only : diag_ctrl, time_type
 use MOM_diag_mediator,         only : post_data, register_diag_field
 use MOM_EOS,                   only : EOS_type, EOS_manual_init, EOS_domain
 use MOM_EOS,                   only : calculate_density, calculate_density_derivs
-use MOM_EOS,                   only : extract_member_EOS, EOS_LINEAR, EOS_TEOS10, EOS_WRIGHT
+use MOM_EOS,                   only : EOS_LINEAR
 use MOM_error_handler,         only : MOM_error, FATAL, WARNING, MOM_mesg, is_root_pe
 use MOM_file_parser,           only : get_param, log_version, param_file_type
 use MOM_file_parser,           only : openParameterBlock, closeParameterBlock

--- a/src/tracer/MOM_neutral_diffusion.F90
+++ b/src/tracer/MOM_neutral_diffusion.F90
@@ -1023,7 +1023,8 @@ subroutine compute_tapering_coeffs(ne, bld_l, bld_r, coeff_l, coeff_r, h_l, h_r)
   real, dimension(ne),   intent(inout) :: coeff_r  !< Tapering coefficient, right column           [nondim]
 
   ! Local variables
-  real :: min_bld, max_bld                       ! Min/Max boundary layer depth in two adjacent columns
+  real :: min_bld         ! Minimum of the boundary layer depth in two adjacent columns [H ~> m or kg m-2]
+  real :: max_bld         ! Maximum of the boundary layer depth in two adjacent columns [H ~> m or kg m-2]
   integer :: dummy1                              ! dummy integer
   real    :: dummy2                              ! dummy real [nondim]
   integer :: k_min_l, k_min_r, k_max_l, k_max_r  ! Min/max vertical indices in two adjacent columns

--- a/src/tracer/MOM_offline_aux.F90
+++ b/src/tracer/MOM_offline_aux.F90
@@ -783,7 +783,7 @@ subroutine update_offline_from_arrays(G, GV, nk_input, ridx_sum, mean_file, sum_
   real, dimension(:,:,:,:), allocatable,     intent(inout) :: salt_all  !< Salinity array [S ~> ppt]
 
   integer :: i, j, k, is, ie, js, je, nz
-  real, parameter :: fill_value = 0.
+  real, parameter :: fill_value = 0. ! The fill value for input arrays [various]
   is = G%isc ; ie = G%iec ; js = G%jsc ; je = G%jec ; nz = GV%ke
 
   ! Check that all fields are allocated (this is a redundant check)

--- a/src/tracer/MOM_offline_main.F90
+++ b/src/tracer/MOM_offline_main.F90
@@ -872,10 +872,8 @@ subroutine offline_advection_layer(fluxes, Time_start, time_interval, G, GV, US,
 
   ! Local variables
 
-  ! Remaining zonal mass transports [H L2 ~> m3 or kg]
-  real, dimension(SZIB_(G),SZJ_(G),SZK_(GV))   :: uhtr_sub
-  ! Remaining meridional mass transports [H L2 ~> m3 or kg]
-  real, dimension(SZI_(G),SZJB_(G),SZK_(GV))   :: vhtr_sub
+  real, dimension(SZIB_(G),SZJ_(G),SZK_(GV)) :: uhtr_sub ! Remaining zonal mass transports [H L2 ~> m3 or kg]
+  real, dimension(SZI_(G),SZJB_(G),SZK_(GV)) :: vhtr_sub ! Remaining meridional mass transports [H L2 ~> m3 or kg]
 
   real, dimension(SZI_(G),SZJB_(G)) :: rem_col_flux ! The summed absolute value of the remaining
                          ! fluxes through the faces of a column or within a column, in mks units [kg]

--- a/src/tracer/MOM_tracer_Z_init.F90
+++ b/src/tracer/MOM_tracer_Z_init.F90
@@ -628,16 +628,16 @@ subroutine determine_temperature(temp, salt, R_tgt, EOS, p_ref, niter, k_start, 
                  units="degC", default=31.0, scale=US%degC_to_C, do_not_log=just_read)
   call get_param(PF, mdl, "DETERMINE_TEMP_S_MIN", S_min, &
                  "The minimum salinity that can be found by determine_temperature.", &
-                 units="1e-3", default=0.5, scale=US%ppt_to_S, do_not_log=just_read)
+                 units="ppt", default=0.5, scale=US%ppt_to_S, do_not_log=just_read)
   call get_param(PF, mdl, "DETERMINE_TEMP_S_MAX", S_max, &
                  "The maximum salinity that can be found by determine_temperature.", &
-                 units="1e-3", default=65.0, scale=US%ppt_to_S, do_not_log=just_read)
+                 units="ppt", default=65.0, scale=US%ppt_to_S, do_not_log=just_read)
   call get_param(PF, mdl, "DETERMINE_TEMP_T_TOLERANCE", tol_T, &
                  "The convergence tolerance for temperature in determine_temperature.", &
                  units="degC", default=1.0e-4, scale=US%degC_to_C, do_not_log=just_read)
   call get_param(PF, mdl, "DETERMINE_TEMP_S_TOLERANCE", tol_S, &
                  "The convergence tolerance for temperature in determine_temperature.", &
-                 units="1e-3", default=1.0e-4, scale=US%ppt_to_S, do_not_log=just_read)
+                 units="ppt", default=1.0e-4, scale=US%ppt_to_S, do_not_log=just_read)
   call get_param(PF, mdl, "DETERMINE_TEMP_RHO_TOLERANCE", tol_rho, &
                  "The convergence tolerance for density in determine_temperature.", &
                  units="kg m-3", default=1.0e-4, scale=US%kg_m3_to_R, do_not_log=just_read)
@@ -645,10 +645,10 @@ subroutine determine_temperature(temp, salt, R_tgt, EOS, p_ref, niter, k_start, 
     ! By default 10 degC is weighted equivalently to 1 ppt when minimizing changes.
     call get_param(PF, mdl, "DETERMINE_TEMP_DT_DS_WEIGHT", dT_dS_gauge, &
                  "When extrapolating T & S to match the layer target densities, this "//&
-                 "factor (in deg C / PSU) is combined with the derivatives of density "//&
+                 "factor (in degC / ppt) is combined with the derivatives of density "//&
                  "with T & S to determine what direction is orthogonal to density contours.  "//&
                  "It could be based on a typical value of (dR/dS) / (dR/dT) in oceanic profiles.", &
-                 units="degC PSU-1", default=10.0, scale=US%degC_to_C*US%S_to_ppt)
+                 units="degC ppt-1", default=10.0, scale=US%degC_to_C*US%S_to_ppt)
   else
     call get_param(PF, mdl, "DETERMINE_TEMP_T_ADJ_RANGE", max_t_adj, &
                  "The maximum amount by which the initial layer temperatures can be "//&
@@ -657,7 +657,7 @@ subroutine determine_temperature(temp, salt, R_tgt, EOS, p_ref, niter, k_start, 
     call get_param(PF, mdl, "DETERMINE_TEMP_S_ADJ_RANGE", max_S_adj, &
                  "The maximum amount by which the initial layer salinities can be "//&
                  "modified in determine_temperature.", &
-                 units="1e-3", default=0.5, scale=US%ppt_to_S, do_not_log=just_read)
+                 units="ppt", default=0.5, scale=US%ppt_to_S, do_not_log=just_read)
   endif
 
   if (just_read) return ! All run-time parameters have been read, so return.

--- a/src/tracer/MOM_tracer_Z_init.F90
+++ b/src/tracer/MOM_tracer_Z_init.F90
@@ -27,49 +27,57 @@ contains
 
 !>   This function initializes a tracer by reading a Z-space file, returning
 !! .true. if this appears to have been successful, and false otherwise.
-function tracer_Z_init(tr, h, filename, tr_name, G, GV, US, missing_val, land_val)
+function tracer_Z_init(tr, h, filename, tr_name, G, GV, US, missing_val, land_val, scale)
   logical :: tracer_Z_init !< A return code indicating if the initialization has been successful
   type(ocean_grid_type), intent(in)    :: G    !< The ocean's grid structure
   type(verticalGrid_type), intent(in)  :: GV   !< The ocean's vertical grid structure.
   type(unit_scale_type), intent(in)    :: US   !< A dimensional unit scaling type
   real, dimension(SZI_(G),SZJ_(G),SZK_(GV)), &
-                         intent(out)   :: tr   !< The tracer to initialize
+                         intent(out)   :: tr   !< The tracer to initialize [CU ~> conc]
   real, dimension(SZI_(G),SZJ_(G),SZK_(GV)), &
-                         intent(in)    :: h    !< Layer thicknesses [H ~> m or kg m-2]
-  character(len=*),      intent(in)    :: filename !< The name of the file to read from
-  character(len=*),      intent(in)    :: tr_name !< The name of the tracer in the file
-  real,        optional, intent(in)    :: missing_val !< The missing value for the tracer
-  real,        optional, intent(in)    :: land_val !< A value to use to fill in land points
+                         intent(in)    :: h    !< Layer thicknesses [H ~> m or kg m-2] or other
+                                               !! arbitrary units such as [Z ~> m]
+  character(len=*),      intent(in)    :: filename  !< The name of the file to read from
+  character(len=*),      intent(in)    :: tr_name   !< The name of the tracer in the file
+  real,        optional, intent(in)    :: missing_val !< The missing value for the tracer [CU ~> conc]
+  real,        optional, intent(in)    :: land_val  !< A value to use to fill in land points [CU ~> conc]
+  real,        optional, intent(in)    :: scale     !< A factor by which to scale the output tracers from the
+                                                    !! their units in the file [CU conc-1 ~> 1]
 
-! This include declares and sets the variable "version".
-# include "version_variable.h"
-
+  ! Local variables
   real, allocatable, dimension(:,:,:) :: &
-    tr_in   ! The z-space array of tracer concentrations that is read in.
+    tr_in   ! The z-space array of tracer concentrations that is read in [CU ~> conc]
   real, allocatable, dimension(:) :: &
     z_edges, &  ! The depths of the cell edges or cell centers (depending on
                 ! the value of has_edges) in the input z* data [Z ~> m].
-    tr_1d, &    ! A copy of the input tracer concentrations in a column.
+    tr_1d, &    ! A copy of the input tracer concentrations in a column [CU ~> conc]
     wt, &   ! The fractional weight for each layer in the range between
-            ! k_top and k_bot, nondim.
-    z1, &   ! z1 and z2 are the depths of the top and bottom limits of the part
-    z2      ! of a z-cell that contributes to a layer, relative to the cell
-            ! center and normalized by the cell thickness, nondim.
+            ! k_top and k_bot [nondim]
+    z1, z2  ! z1 and z2 are the depths of the top and bottom limits of the part
+            ! of a z-cell that contributes to a layer, relative to the cell
+            ! center and normalized by the cell thickness [nondim].
             ! Note that -1/2 <= z1 <= z2 <= 1/2.
   real    :: e(SZK_(GV)+1)  ! The z-star interface heights [Z ~> m].
-  real    :: landval    ! The tracer value to use in land points.
+  real    :: landval    ! The tracer value to use in land points [CU ~> conc]
   real    :: sl_tr      ! The normalized slope of the tracer
-                        ! within the cell, in tracer units.
+                        ! within the cell, in tracer units [CU ~> conc]
   real    :: htot(SZI_(G)) ! The vertical sum of h [H ~> m or kg m-2].
   real    :: dilate     ! The amount by which the thicknesses are dilated to
-                        ! create a z-star coordinate, nondim or in m3 kg-1.
-  real    :: missing    ! The missing value for the tracer.
-
+                        ! create a z-star coordinate [Z H-1 ~> nondim or m3 kg-1]
+                        ! or other units reflecting those of h
+  real    :: missing    ! The missing value for the tracer [CU ~> conc]
+  real    :: scale_fac  ! A factor by which to scale the output tracers from the units in the
+                        ! input file [CU conc-1 ~> 1]
+  ! This include declares and sets the variable "version".
+# include "version_variable.h"
   logical :: has_edges, use_missing, zero_surface
   character(len=80) :: loc_msg
   integer :: k_top, k_bot, k_bot_prev, k_start
   integer :: i, j, k, kz, is, ie, js, je, nz, nz_in
+
   is = G%isc ; ie = G%iec ; js = G%jsc ; je = G%jec ; nz = GV%ke
+
+  scale_fac = 1.0 ; if (present(scale)) then ; scale_fac = scale ; endif
 
   landval = 0.0 ; if (present(land_val)) landval = land_val
 
@@ -83,7 +91,7 @@ function tracer_Z_init(tr, h, filename, tr_name, G, GV, US, missing_val, land_va
   ! Find out the number of input levels and read the depth of the edges,
   ! also modifying their sign convention to be monotonically decreasing.
   call read_Z_edges(filename, tr_name, z_edges, nz_in, has_edges, use_missing, &
-                    missing, scale=US%m_to_Z)
+                    missing, scale=US%m_to_Z, missing_scale=scale_fac)
   if (nz_in < 1) then
     tracer_Z_init = .false.
     return
@@ -91,7 +99,7 @@ function tracer_Z_init(tr, h, filename, tr_name, G, GV, US, missing_val, land_va
 
   allocate(tr_in(G%isd:G%ied,G%jsd:G%jed,nz_in), source=0.0)
   allocate(tr_1d(nz_in), source=0.0)
-  call MOM_read_data(filename, tr_name, tr_in(:,:,:), G%Domain)
+  call MOM_read_data(filename, tr_name, tr_in(:,:,:), G%Domain, scale=scale_fac)
 
   ! Fill missing values from above?  Use a "close" test to avoid problems
   ! from type-conversion rounoff.
@@ -297,9 +305,10 @@ subroutine tracer_z_init_array(tr_in, z_edges, nk_data, e, land_fill, G, nlay, n
   real :: e_1d(nlay+1)   ! A 1-d column of interface heights, in the same units as e [Z ~> m] or [m]
   real :: sl_tr          ! The tracer concentration slope times the layer thickness, in tracer units [B]
   real :: wt(nk_data)    ! The fractional weight for each layer in the range between z1 and z2 [nondim]
-  real :: z1(nk_data)    ! z1 and z2 are the fractional depths of the top and bottom
-  real :: z2(nk_data)    ! limits of the part of a z-cell that contributes to a layer, relative
-                         ! to the cell center and normalized by the cell thickness [nondim].
+  real :: z1(nk_data)    ! The fractional depth of the top limit of the part of a z-cell that contributes to
+                         ! a layer, relative to the cell center and normalized by the cell thickness [nondim].
+  real :: z2(nk_data)    ! The fractional depth of the bottom limit of the part of a z-cell that contributes to
+                         ! a layer, relative to the cell center and normalized by the cell thickness [nondim].
                          ! Note that -1/2 <= z1 <= z2 <= 1/2.
   real :: scale_fac      ! A factor by which to scale the output tracers from the input tracers [B A-1 ~> 1]
   integer :: k_top, k_bot, k_bot_prev, kstart
@@ -380,18 +389,21 @@ end subroutine tracer_z_init_array
 !> This subroutine reads the vertical coordinate data for a field from a NetCDF file.
 !! It also might read the missing value attribute for that same field.
 subroutine read_Z_edges(filename, tr_name, z_edges, nz_out, has_edges, &
-                        use_missing, missing, scale)
+                        use_missing, missing, scale, missing_scale)
   character(len=*), intent(in)    :: filename !< The name of the file to read from.
   character(len=*), intent(in)    :: tr_name !< The name of the tracer in the file.
   real, dimension(:), allocatable, &
-                    intent(out)   :: z_edges !< The depths of the vertical edges of the tracer array
+                    intent(out)   :: z_edges !< The depths of the vertical edges of the tracer array [Z ~> m]
   integer,          intent(out)   :: nz_out  !< The number of vertical layers in the tracer array
   logical,          intent(out)   :: has_edges !< If true the values in z_edges are the edges of the
                                              !! tracer cells, otherwise they are the cell centers
   logical,          intent(inout) :: use_missing !< If false on input, see whether the tracer has a
                                              !! missing value, and if so return true
-  real,             intent(inout) :: missing !< The missing value, if one has been found
-  real,             intent(in)    :: scale   !< A scaling factor for z_edges into new units.
+  real,             intent(inout) :: missing !< The missing value, if one has been found [CU ~> conc]
+  real,             intent(in)    :: scale   !< A scaling factor for z_edges into new units [Z m-1 ~> 1]
+  real,             intent(in)    :: missing_scale  !< A scaling factor to use to convert the
+                                             !! tracers and their missing value from the units in
+                                             !! the file into their internal units [CU conc-1 ~> 1]
 
   !   This subroutine reads the vertical coordinate data for a field from a
   ! NetCDF file.  It also might read the missing value attribute for that same field.
@@ -419,6 +431,7 @@ subroutine read_Z_edges(filename, tr_name, z_edges, nz_out, has_edges, &
 
   if (.not.use_missing) then  ! Try to find the missing value from the dataset.
     call read_attribute(filename, "missing_value", missing, varname=tr_name, found=use_missing, ncid_in=ncid)
+    if (use_missing) missing = missing * missing_scale
   endif
   ! Find out if the Z-axis has an edges attribute
   call read_attribute(filename, "edges", edge_name, varname=dim_names(3), found=has_edges, ncid_in=ncid)
@@ -475,8 +488,12 @@ subroutine find_overlap(e, Z_top, Z_bot, k_max, k_start, k_top, k_bot, wt, z1, z
   real, dimension(:), intent(out)   :: z2     !< Depths of the bottom limit of the part of
        !! a layer that contributes to a depth level, relative to the cell center and normalized
        !! by the cell thickness [nondim].  Note that -1/2 <= z1 < z2 <= 1/2.
+
   ! Local variables
-  real    :: Ih, e_c, tot_wt, I_totwt
+  real    :: Ih   ! The inverse of the vertical distance across a layer, in the inverse of the units of e [Z-1 ~> m-1]
+  real    :: e_c  ! The height of the layer center, in the units of e [Z ~> m]
+  real    :: tot_wt  ! The sum of the thicknesses contributing to a layer [Z ~> m]
+  real    :: I_totwt ! The Adcroft reciprocal of tot_wt [Z-1 ~> m-1]
   integer :: k
 
   wt(:) = 0.0 ; z1(:) = 0.0 ; z2(:) = 0.0 ; k_bot = k_max
@@ -494,6 +511,7 @@ subroutine find_overlap(e, Z_top, Z_bot, k_max, k_start, k_top, k_bot, wt, z1, z
     z1(k) = (e_c - MIN(e(K), Z_top)) * Ih
     z2(k) = (e_c - Z_bot) * Ih
   else
+    ! Note that in theis branch, wt temporarily has units of [Z ~> m]
     wt(k) = MIN(e(K),Z_top) - e(K+1) ; tot_wt = wt(k) ! These are always > 0.
     if (e(K) /= e(K+1)) then
       z1(k) = (0.5*(e(K)+e(K+1)) - MIN(e(K), Z_top)) / (e(K)-e(K+1))
@@ -515,6 +533,7 @@ subroutine find_overlap(e, Z_top, Z_bot, k_max, k_start, k_top, k_bot, wt, z1, z
     enddo
 
     I_totwt = 0.0 ; if (tot_wt > 0.0) I_totwt = 1.0 / tot_wt
+    ! This loop changes the units of wt from [Z ~> m] to [nondim].
     do k=k_top,k_bot ; wt(k) = I_totwt*wt(k) ; enddo
   endif
 
@@ -523,13 +542,13 @@ end subroutine find_overlap
 !> This subroutine determines a limited slope for val to be advected with
 !! a piecewise limited scheme.
 function find_limited_slope(val, e, k) result(slope)
-  real, dimension(:), intent(in) :: val !< An column the values that are being interpolated.
+  real, dimension(:), intent(in) :: val !< A column of the values that are being interpolated, in arbitrary units [A]
   real, dimension(:), intent(in) :: e   !< A column's interface heights [Z ~> m] or other units.
   integer,            intent(in) :: k   !< The layer whose slope is being determined.
-  real :: slope !< The normalized slope in the intracell distribution of val.
+  real :: slope !< The normalized slope in the intracell distribution of val [A]
   ! Local variables
-  real :: amn, cmn
-  real :: d1, d2
+  real :: amn, cmn ! Limited differences and curvatures in the values [A]
+  real :: d1, d2   ! Layer thicknesses, in the units of e [Z ~> m]
 
   if ((val(k)-val(k-1)) * (val(k)-val(k+1)) >= 0.0) then
     slope = 0.0 ! ; curvature = 0.0

--- a/src/tracer/MOM_tracer_advect.F90
+++ b/src/tracer/MOM_tracer_advect.F90
@@ -380,7 +380,7 @@ subroutine advect_x(Tr, hprev, uhr, uh_neglect, OBC, domore_u, ntr, Idt, &
   real :: dA            ! Difference between the reconstruction tracer edge values [conc]
   real :: mA            ! Average of the reconstruction tracer edge values [conc]
   real :: a6            ! Curvature of the reconstruction tracer values [conc]
-  logical :: do_i(SZIB_(G),SZJ_(G))     ! If true, work on given points.
+  logical :: do_i(SZI_(G),SZJ_(G))     ! If true, work on given points.
   logical :: usePLMslope
   integer :: i, j, m, n, i_up, stencil, ntr_id
   type(OBC_segment_type), pointer :: segment=>NULL()
@@ -659,7 +659,7 @@ subroutine advect_x(Tr, hprev, uhr, uh_neglect, OBC, domore_u, ntr, Idt, &
       enddo
 
       ! diagnostics
-      if (associated(Tr(m)%ad_x)) then ; do I=is-1,ie ; if (do_i(i,j)) then
+      if (associated(Tr(m)%ad_x)) then ; do I=is-1,ie ; if (do_i(i,j) .or. do_i(i+1,j)) then
         Tr(m)%ad_x(I,j,k) = Tr(m)%ad_x(I,j,k) + flux_x(I,j,m)*Idt
       endif ; enddo ; endif
 
@@ -688,7 +688,7 @@ subroutine advect_x(Tr, hprev, uhr, uh_neglect, OBC, domore_u, ntr, Idt, &
   !$OMP ordered
   do m=1,ntr ; if (associated(Tr(m)%ad2d_x)) then
     do j=js,je ; if (domore_u_initial(j,k)) then
-      do I=is-1,ie ; if (do_i(i,j)) then
+      do I=is-1,ie ; if (do_i(i,j) .or. do_i(i+1,j)) then
         Tr(m)%ad2d_x(I,j) = Tr(m)%ad2d_x(I,j) + flux_x(I,j,m)*Idt
       endif ; enddo
     endif ; enddo
@@ -756,7 +756,7 @@ subroutine advect_y(Tr, hprev, vhr, vh_neglect, OBC, domore_v, ntr, Idt, &
   real :: mA            ! Average of the reconstruction tracer edge values [conc]
   real :: a6            ! Curvature of the reconstruction tracer values [conc]
   logical :: do_j_tr(SZJ_(G))   ! If true, calculate the tracer profiles.
-  logical :: do_i(SZIB_(G), SZJ_(G))     ! If true, work on given points.
+  logical :: do_i(SZI_(G), SZJ_(G))     ! If true, work on given points.
   logical :: usePLMslope
   integer :: i, j, j2, m, n, j_up, stencil, ntr_id
   type(OBC_segment_type), pointer :: segment=>NULL()
@@ -1066,8 +1066,7 @@ subroutine advect_y(Tr, hprev, vhr, vh_neglect, OBC, domore_v, ntr, Idt, &
   !$OMP ordered
   do m=1,ntr ; if (associated(Tr(m)%ad_y)) then
     do J=js-1,je ; if (domore_v_initial(J)) then
-      ! (The logical test could be "do_i(i,j) .or. do_i(i+1,j)" to be clearer, but not needed)
-      do i=is,ie ; if (do_i(i,j)) then
+      do i=is,ie ; if (do_i(i,j) .or. do_i(i,j+1)) then
         Tr(m)%ad_y(i,J,k) = Tr(m)%ad_y(i,J,k) + flux_y(i,m,J)*Idt
       endif ; enddo
     endif ; enddo
@@ -1075,7 +1074,7 @@ subroutine advect_y(Tr, hprev, vhr, vh_neglect, OBC, domore_v, ntr, Idt, &
 
   do m=1,ntr ; if (associated(Tr(m)%ad2d_y)) then
     do J=js-1,je ; if (domore_v_initial(J)) then
-      do i=is,ie ; if (do_i(i,j)) then
+      do i=is,ie ; if (do_i(i,j) .or. do_i(i,j+1)) then
         Tr(m)%ad2d_y(i,J) = Tr(m)%ad2d_y(i,J) + flux_y(i,m,J)*Idt
       endif ; enddo
     endif ; enddo

--- a/src/tracer/MOM_tracer_advect.F90
+++ b/src/tracer/MOM_tracer_advect.F90
@@ -123,7 +123,8 @@ subroutine advect_tracer(h_end, uhtr, vhtr, OBC, dt, G, GV, US, CS, Reg, x_first
   x_first = (MOD(G%first_direction,2) == 0)
 
   ! increase stencil size for Colella & Woodward PPM
-  if (CS%usePPM .and. .not. CS%useHuynh) stencil = 3
+! if (CS%usePPM .and. .not. CS%useHuynh) stencil = 3
+  if (CS%usePPM) stencil = 3
 
   ntr = Reg%ntr
   Idt = 1.0 / dt

--- a/src/tracer/MOM_tracer_flow_control.F90
+++ b/src/tracer/MOM_tracer_flow_control.F90
@@ -11,6 +11,7 @@ use MOM_forcing_type,  only : forcing, optics_type
 use MOM_get_input,     only : Get_MOM_input
 use MOM_grid,          only : ocean_grid_type
 use MOM_hor_index,     only : hor_index_type
+use MOM_interface_heights, only : convert_MLD_to_ML_thickness
 use MOM_CVMix_KPP,     only : KPP_CS
 use MOM_open_boundary, only : ocean_OBC_type
 use MOM_restart,       only : MOM_restart_CS
@@ -427,7 +428,7 @@ subroutine call_tracer_set_forcing(sfc_state, fluxes, day_start, day_interval, G
 end subroutine call_tracer_set_forcing
 
 !> This subroutine calls all registered tracer column physics subroutines.
-subroutine call_tracer_column_fns(h_old, h_new, ea, eb, fluxes, Hml, dt, G, GV, US, tv, optics, CS, &
+subroutine call_tracer_column_fns(h_old, h_new, ea, eb, fluxes, mld, dt, G, GV, US, tv, optics, CS, &
                                   debug, KPP_CSp, nonLocalTrans, evap_CFL_limit, minimum_forcing_depth)
   type(ocean_grid_type),                 intent(in) :: G      !< The ocean's grid structure.
   type(verticalGrid_type),               intent(in) :: GV     !< The ocean's vertical grid structure.
@@ -444,7 +445,7 @@ subroutine call_tracer_column_fns(h_old, h_new, ea, eb, fluxes, Hml, dt, G, GV, 
   type(forcing),                         intent(in) :: fluxes !< A structure containing pointers to
                                                               !! any possible forcing fields.
                                                               !! Unused fields have NULL ptrs.
-  real, dimension(SZI_(G),SZJ_(G)),      intent(in) :: Hml    !< Mixed layer depth [Z ~> m]
+  real, dimension(SZI_(G),SZJ_(G)),      intent(in) :: mld    !< Mixed layer depth [Z ~> m]
   real,                                  intent(in) :: dt     !< The amount of time covered by this
                                                               !! call [T ~> s]
   type(unit_scale_type),                 intent(in) :: US     !< A dimensional unit scaling type
@@ -463,6 +464,9 @@ subroutine call_tracer_column_fns(h_old, h_new, ea, eb, fluxes, Hml, dt, G, GV, 
                                                               !! of the top layer in a timestep [nondim]
   real,                        optional, intent(in) :: minimum_forcing_depth !< The smallest depth over
                                                               !! which fluxes can be applied [H ~> m or kg m-2]
+
+  ! Local variables
+  real :: Hbl(SZI_(G),SZJ_(G))    !< Boundary layer thickness [H ~> m or kg m-2]
 
   if (.not. associated(CS)) call MOM_error(FATAL, "call_tracer_column_fns: "// &
          "Module must be initialized via call_tracer_register before it is used.")
@@ -488,12 +492,13 @@ subroutine call_tracer_column_fns(h_old, h_new, ea, eb, fluxes, Hml, dt, G, GV, 
                                         G, GV, US, CS%RGC_tracer_CSp, &
                                         evap_CFL_limit=evap_CFL_limit, &
                                         minimum_forcing_depth=minimum_forcing_depth)
-    if (CS%use_ideal_age) &
+    if (CS%use_ideal_age) then
+      call convert_MLD_to_ML_thickness(mld, h_new, Hbl, tv, G, GV)
       call ideal_age_tracer_column_physics(h_old, h_new, ea, eb, fluxes, dt, &
-                                           G, GV, US, tv, CS%ideal_age_tracer_CSp, &
+                                           G, GV, US, CS%ideal_age_tracer_CSp, &
                                            evap_CFL_limit=evap_CFL_limit, &
-                                           minimum_forcing_depth=minimum_forcing_depth, &
-                                           Hbl=Hml)
+                                           minimum_forcing_depth=minimum_forcing_depth, Hbl=Hbl)
+    endif
     if (CS%use_regional_dyes) &
       call dye_tracer_column_physics(h_old, h_new, ea, eb, fluxes, dt, &
                                      G, GV, US, tv, CS%dye_tracer_CSp, &
@@ -526,7 +531,7 @@ subroutine call_tracer_column_fns(h_old, h_new, ea, eb, fluxes, Hml, dt, G, GV, 
       if (US%QRZ_T_to_W_m2 /= 1.0) call MOM_error(FATAL, "MOM_generic_tracer_column_physics "//&
             "has not been written to permit dimensionsal rescaling.  Set all 4 of the "//&
             "[QRZT]_RESCALE_POWER parameters to 0.")
-      call MOM_generic_tracer_column_physics(h_old, h_new, ea, eb, fluxes, Hml, dt, &
+      call MOM_generic_tracer_column_physics(h_old, h_new, ea, eb, fluxes, mld, dt, &
                                              G, GV, US, CS%MOM_generic_tracer_CSp, tv, optics, &
                                              evap_CFL_limit=evap_CFL_limit, &
                                              minimum_forcing_depth=minimum_forcing_depth)
@@ -567,9 +572,11 @@ subroutine call_tracer_column_fns(h_old, h_new, ea, eb, fluxes, Hml, dt, G, GV, 
     if (CS%use_RGC_tracer) &
       call RGC_tracer_column_physics(h_old, h_new, ea, eb, fluxes, dt, &
                                       G, GV, US, CS%RGC_tracer_CSp)
-    if (CS%use_ideal_age) &
+    if (CS%use_ideal_age) then
+      call convert_MLD_to_ML_thickness(mld, h_new, Hbl, tv, G, GV)
       call ideal_age_tracer_column_physics(h_old, h_new, ea, eb, fluxes, dt, &
-                                           G, GV, US, tv, CS%ideal_age_tracer_CSp, Hbl=Hml)
+                                           G, GV, US, CS%ideal_age_tracer_CSp, Hbl=Hbl)
+    endif
     if (CS%use_regional_dyes) &
       call dye_tracer_column_physics(h_old, h_new, ea, eb, fluxes, dt, &
                                            G, GV, US, tv, CS%dye_tracer_CSp)
@@ -591,7 +598,7 @@ subroutine call_tracer_column_fns(h_old, h_new, ea, eb, fluxes, Hml, dt, G, GV, 
       if (US%QRZ_T_to_W_m2 /= 1.0) call MOM_error(FATAL, "MOM_generic_tracer_column_physics "//&
             "has not been written to permit dimensionsal rescaling.  Set all 4 of the "//&
             "[QRZT]_RESCALE_POWER parameters to 0.")
-      call MOM_generic_tracer_column_physics(h_old, h_new, ea, eb, fluxes, Hml, dt, &
+      call MOM_generic_tracer_column_physics(h_old, h_new, ea, eb, fluxes, mld, dt, &
                                      G, GV, US, CS%MOM_generic_tracer_CSp, tv, optics)
     endif
     if (CS%use_pseudo_salt_tracer) &

--- a/src/tracer/MOM_tracer_flow_control.F90
+++ b/src/tracer/MOM_tracer_flow_control.F90
@@ -340,7 +340,7 @@ subroutine tracer_flow_control_init(restart, day, G, GV, US, h, param_file, diag
     call initialize_CFC_cap(restart, day, G, GV, US, h, diag, OBC, CS%CFC_cap_CSp)
 
   if (CS%use_MOM_generic_tracer) &
-    call initialize_MOM_generic_tracer(restart, day, G, GV, US, h, param_file, diag, OBC, &
+    call initialize_MOM_generic_tracer(restart, day, G, GV, US, h, tv, param_file, diag, OBC, &
                                 CS%MOM_generic_tracer_CSp, sponge_CSp, ALE_sponge_CSp)
   if (CS%use_pseudo_salt_tracer) &
     call initialize_pseudo_salt_tracer(restart, day, G, GV, US, h, diag, OBC, CS%pseudo_salt_tracer_CSp, &

--- a/src/tracer/MOM_tracer_hor_diff.F90
+++ b/src/tracer/MOM_tracer_hor_diff.F90
@@ -65,6 +65,14 @@ type, public :: tracer_hor_diff_CS ; private
                                    !! tracer_hor_diff.
   logical :: recalc_neutral_surf   !< If true, recalculate the neutral surfaces if CFL has been
                                    !! exceeded
+  logical :: limit_bug             !< If true and the answer date is 20240330 or below, use a
+                                   !! rotational symmetry breaking bug when limiting the tracer
+                                   !! properties in tracer_epipycnal_ML_diff.
+  integer :: answer_date           !< The vintage of the order of arithmetic to use for the tracer
+                                   !! diffusion.  Values of 20240330 or below recover the answers
+                                   !! from the original form of this code, while higher values use
+                                   !! mathematically equivalent expressions that recover rotational symmetry
+                                   !! when DIFFUSE_ML_TO_INTERIOR is true.
   type(neutral_diffusion_CS), pointer :: neutral_diffusion_CSp => NULL() !< Control structure for neutral diffusion.
   type(hbd_CS), pointer    :: hor_bnd_diffusion_CSp => NULL() !< Control structure for
                                                               !! horizontal boundary diffusion.
@@ -678,7 +686,7 @@ subroutine tracer_epipycnal_ML_diff(h, dt, Tr, ntr, khdt_epi_x, khdt_epi_y, G, &
   real, dimension(SZI_(G),SZJB_(G)),        intent(in)    :: khdt_epi_y !< Meridional epipycnal diffusivity times
                                                            !! a time step and the ratio of the open face width over
                                                            !! the distance between adjacent tracer points [L2 ~> m2]
-  type(unit_scale_type),                    intent(in)    :: US !< A dimensional unit scaling type
+  type(unit_scale_type),                    intent(in)    :: US         !< A dimensional unit scaling type
   type(tracer_hor_diff_CS),                 intent(inout) :: CS         !< module control structure
   type(thermo_var_ptrs),                    intent(in)    :: tv         !< thermodynamic structure
   integer,                                  intent(in)    :: num_itts   !< number of iterations (usually=1)
@@ -706,13 +714,16 @@ subroutine tracer_epipycnal_ML_diff(h, dt, Tr, ntr, khdt_epi_x, khdt_epi_y, G, &
     k0b_Lv, k0a_Lv, &  ! The original k-indices of the layers that participate
     k0b_Rv, k0a_Rv     ! in each pair of mixing at v-faces.
 
-  !### Accumulating the converge into this array one face at a time may lead to a lack of rotational symmetry.
-  real, dimension(SZI_(G), SZJ_(G), SZK_(GV)) :: &
-    tr_flux_conv  ! The flux convergence of tracers [conc H L2 ~> conc m3 or conc kg]
+  real, dimension(SZI_(G),SZJ_(G),SZK_(GV)) :: &
+    tr_flux_N, &      ! The tracer flux through the northern face [conc H L2 ~> conc m3 or conc kg]
+    tr_flux_S, &      ! The tracer flux through the southern face [conc H L2 ~> conc m3 or conc kg]
+    tr_flux_E, &      ! The tracer flux through the eastern face [conc H L2 ~> conc m3 or conc kg]
+    tr_flux_W, &      ! The tracer flux through the western face [conc H L2 ~> conc m3 or conc kg]
+    tr_flux_conv      ! The flux convergence of tracers [conc H L2 ~> conc m3 or conc kg]
 
   ! The following 3-d arrays were created in 2014 in MOM6 PR#12 to facilitate openMP threading
-  ! on an i-loop, which might have been ill advised.  The k-size extents here might also be problematic.
-  real, dimension(SZI_(G),SZJB_(G),SZK_(GV)) :: &
+  ! on an i-loop, which might have been ill advised.
+  real, dimension(SZI_(G),SZJB_(G),SZK_(GV)*2) :: &
     Tr_flux_3d, &     ! The tracer flux through pairings at meridional faces [conc H L2 ~> conc m3 or conc kg]
     Tr_adj_vert_L, &  ! Vertical adjustments to which layer the fluxes go into in the southern
                       ! columns at meridional face [conc H L2 ~> conc m3 or conc kg]
@@ -815,6 +826,7 @@ subroutine tracer_epipycnal_ML_diff(h, dt, Tr, ntr, khdt_epi_x, khdt_epi_y, G, &
   do k=2,nkmb ; do j=js-2,je+2 ; do i=is-2,ie+2
     if (Rml_max(i,j) < rho_coord(i,j,k)) Rml_max(i,j) = rho_coord(i,j,k)
   enddo ; enddo ; enddo
+
   !   Use bracketing and bisection to find the k-level that the densest of the
   ! mixed and buffer layer corresponds to, such that:
   !     GV%Rlay(max_kRho-1) < Rml_max <= GV%Rlay(max_kRho)
@@ -1191,12 +1203,7 @@ subroutine tracer_epipycnal_ML_diff(h, dt, Tr, ntr, khdt_epi_x, khdt_epi_y, G, &
 
   endif ; enddo ; enddo ! i- & j- loops over meridional faces.
 
-! The tracer-specific calculations start here.
-
-  ! Zero out tracer tendencies.
-  do k=1,PEmax_kRho ; do j=js-1,je+1 ; do i=is-1,ie+1
-    tr_flux_conv(i,j,k) = 0.0
-  enddo ; enddo ; enddo
+  ! The tracer-specific calculations start here.
 
   do itt=1,max_itt
 
@@ -1205,12 +1212,19 @@ subroutine tracer_epipycnal_ML_diff(h, dt, Tr, ntr, khdt_epi_x, khdt_epi_y, G, &
     endif
 
     do m=1,ntr
-!$OMP parallel do default(none) shared(is,ie,js,je,G,Tr,nkmb,nPu,m,max_kRho,nz,h,h_exclude, &
-!$OMP                                  k0b_Lu,k0b_Ru,deep_wt_Lu,k0a_Lu,deep_wt_Ru,k0a_Ru,   &
-!$OMP                                  hP_Lu,hP_Ru,I_maxitt,khdt_epi_x,tr_flux_conv,Idt) &
-!$OMP                          private(Tr_min_face,Tr_max_face,kLa,kLb,kRa,kRb,Tr_La, &
-!$OMP                                     Tr_Lb,Tr_Ra,Tr_Rb,Tr_av_L,wt_b,Tr_av_R,h_L,h_R, &
-!$OMP                                     Tr_flux,Tr_adj_vert,wt_a,vol)
+      ! Zero out tracer tendencies.
+      if (CS%answer_date <= 20240330) then
+        tr_flux_conv(:,:,:) = 0.0
+      else
+        tr_flux_N(:,:,:) = 0.0 ; tr_flux_S(:,:,:) = 0.0
+        tr_flux_E(:,:,:) = 0.0 ; tr_flux_W(:,:,:) = 0.0
+      endif
+      tr_flux_3d(:,:,:) = 0.0
+      tr_adj_vert_R(:,:,:) = 0.0 ; tr_adj_vert_L(:,:,:) = 0.0
+
+      !$OMP parallel do default(shared) private(Tr_min_face,Tr_max_face,kLa,kLb,kRa,kRb,Tr_La, &
+      !$OMP                                     Tr_Lb,Tr_Ra,Tr_Rb,Tr_av_L,wt_b,Tr_av_R,h_L,h_R, &
+      !$OMP                                     Tr_flux,Tr_adj_vert,wt_a,vol)
       do j=js,je ; do I=is-1,ie ; if (G%mask2dCu(I,j) > 0.0) then
         ! Determine the fluxes through the zonal faces.
 
@@ -1230,7 +1244,11 @@ subroutine tracer_epipycnal_ML_diff(h, dt, Tr, ntr, khdt_epi_x, khdt_epi_y, G, &
           kRb = kRa ; if (max_kRho(i+1,j) < nz) kRb = max_kRho(i+1,j)+1
           Tr_La = Tr_min_face ; Tr_Lb = Tr_La ; Tr_Ra = Tr_La ; Tr_Rb = Tr_La
           if (h(i,j,kLa) > h_exclude) Tr_La = Tr(m)%t(i,j,kLa)
-          if (h(i,j,kLb) > h_exclude) Tr_La = Tr(m)%t(i,j,kLb)
+          if ((CS%answer_date <= 20240330) .and. CS%limit_bug) then
+            if (h(i,j,kLb) > h_exclude) Tr_La = Tr(m)%t(i,j,kLb)
+          else
+            if (h(i,j,kLb) > h_exclude) Tr_Lb = Tr(m)%t(i,j,kLb)
+          endif
           if (h(i+1,j,kRa) > h_exclude) Tr_Ra = Tr(m)%t(i+1,j,kRa)
           if (h(i+1,j,kRb) > h_exclude) Tr_Rb = Tr(m)%t(i+1,j,kRb)
           Tr_min_face = min(Tr_min_face, Tr_La, Tr_Lb, Tr_Ra, Tr_Rb)
@@ -1264,12 +1282,20 @@ subroutine tracer_epipycnal_ML_diff(h, dt, Tr, ntr, khdt_epi_x, khdt_epi_y, G, &
           endif
 
           h_L = hP_Lu(j)%p(I,k) ; h_R = hP_Ru(j)%p(I,k)
-          Tr_flux = I_maxitt * khdt_epi_x(I,j) * (Tr_av_L - Tr_av_R) * &
-            ((2.0 * h_L * h_R) / (h_L + h_R))
-
+          if (CS%answer_date <= 20240330) then
+            Tr_flux = I_maxitt * khdt_epi_x(I,j) * (Tr_av_L - Tr_av_R) * &
+                      ((2.0 * h_L * h_R) / (h_L + h_R))
+          else
+            Tr_flux = I_maxitt * ((2.0 * h_L * h_R) / (h_L + h_R)) * &
+                      khdt_epi_x(I,j) * (Tr_av_L - Tr_av_R)
+          endif
 
           if (deep_wt_Lu(j)%p(I,k) >= 1.0) then
-            tr_flux_conv(i,j,kLb) = tr_flux_conv(i,j,kLb) - Tr_flux
+            if (CS%answer_date <= 20240330) then
+              tr_flux_conv(i,j,kLb) = tr_flux_conv(i,j,kLb) - Tr_flux
+            else
+              tr_flux_E(i,j,kLb) = tr_flux_E(i,j,kLb) + Tr_flux
+            endif
           else
             Tr_adj_vert = 0.0
             wt_b = deep_wt_Lu(j)%p(I,k) ; wt_a = 1.0 - wt_b
@@ -1299,12 +1325,21 @@ subroutine tracer_epipycnal_ML_diff(h, dt, Tr, ntr, khdt_epi_x, khdt_epi_y, G, &
               endif
             endif
 
-            tr_flux_conv(i,j,kLa) = tr_flux_conv(i,j,kLa) - (wt_a*Tr_flux + Tr_adj_vert)
-            tr_flux_conv(i,j,kLb) = tr_flux_conv(i,j,kLb) - (wt_b*Tr_flux - Tr_adj_vert)
+            if (CS%answer_date <= 20240330) then
+              tr_flux_conv(i,j,kLa) = tr_flux_conv(i,j,kLa) - (wt_a*Tr_flux + Tr_adj_vert)
+              tr_flux_conv(i,j,kLb) = tr_flux_conv(i,j,kLb) - (wt_b*Tr_flux - Tr_adj_vert)
+            else
+              tr_flux_E(i,j,kLa) = tr_flux_E(i,j,kLa) + (wt_a*Tr_flux + Tr_adj_vert)
+              tr_flux_E(i,j,kLb) = tr_flux_E(i,j,kLb) + (wt_b*Tr_flux - Tr_adj_vert)
+            endif
           endif
 
           if (deep_wt_Ru(j)%p(I,k) >= 1.0) then
-            tr_flux_conv(i+1,j,kRb) = tr_flux_conv(i+1,j,kRb) + Tr_flux
+            if (CS%answer_date <= 20240330) then
+              tr_flux_conv(i+1,j,kRb) = tr_flux_conv(i+1,j,kRb) + Tr_flux
+            else
+              tr_flux_W(i+1,j,kRb) = tr_flux_W(i+1,j,kRb) + Tr_flux
+            endif
           else
             Tr_adj_vert = 0.0
             wt_b = deep_wt_Ru(j)%p(I,k) ; wt_a = 1.0 - wt_b
@@ -1334,23 +1369,22 @@ subroutine tracer_epipycnal_ML_diff(h, dt, Tr, ntr, khdt_epi_x, khdt_epi_y, G, &
               endif
             endif
 
-            tr_flux_conv(i+1,j,kRa) = tr_flux_conv(i+1,j,kRa) + &
-                                            (wt_a*Tr_flux - Tr_adj_vert)
-            tr_flux_conv(i+1,j,kRb) = tr_flux_conv(i+1,j,kRb) + &
-                                            (wt_b*Tr_flux + Tr_adj_vert)
+            if (CS%answer_date <= 20240330) then
+              tr_flux_conv(i+1,j,kRa) = tr_flux_conv(i+1,j,kRa) + (wt_a*Tr_flux - Tr_adj_vert)
+              tr_flux_conv(i+1,j,kRb) = tr_flux_conv(i+1,j,kRb) + (wt_b*Tr_flux + Tr_adj_vert)
+            else
+              tr_flux_W(i+1,j,kRa) = tr_flux_W(i+1,j,kRa) + (wt_a*Tr_flux - Tr_adj_vert)
+              tr_flux_W(i+1,j,kRb) = tr_flux_W(i+1,j,kRb) + (wt_b*Tr_flux + Tr_adj_vert)
+            endif
           endif
           if (associated(Tr(m)%df2d_x)) &
             Tr(m)%df2d_x(I,j) = Tr(m)%df2d_x(I,j) + Tr_flux * Idt
         enddo ! Loop over pairings at faces.
       endif ; enddo ; enddo ! i- & j- loops over zonal faces.
 
-!$OMP parallel do default(none) shared(is,ie,js,je,G,Tr,nkmb,nPv,m,max_kRho,nz,h,h_exclude, &
-!$OMP                                  k0b_Lv,k0b_Rv,deep_wt_Lv,k0a_Lv,deep_wt_Rv,k0a_Rv,   &
-!$OMP                                  hP_Lv,hP_Rv,I_maxitt,khdt_epi_y,Tr_flux_3d,          &
-!$OMP                                  Tr_adj_vert_L,Tr_adj_vert_R,Idt)                     &
-!$OMP                          private(Tr_min_face,Tr_max_face,kLa,kLb,kRa,kRb,             &
-!$OMP                                  Tr_La,Tr_Lb,Tr_Ra,Tr_Rb,Tr_av_L,wt_b,Tr_av_R,        &
-!$OMP                                  h_L,h_R,Tr_flux,Tr_adj_vert,wt_a,vol)
+      !$OMP parallel do default(shared) private(Tr_min_face,Tr_max_face,kLa,kLb,kRa,kRb,             &
+      !$OMP                                  Tr_La,Tr_Lb,Tr_Ra,Tr_Rb,Tr_av_L,wt_b,Tr_av_R,        &
+      !$OMP                                  h_L,h_R,Tr_flux,Tr_adj_vert,wt_a,vol)
       do J=js-1,je ; do i=is,ie ; if (G%mask2dCv(i,J) > 0.0) then
         ! Determine the fluxes through the meridional faces.
 
@@ -1370,7 +1404,11 @@ subroutine tracer_epipycnal_ML_diff(h, dt, Tr, ntr, khdt_epi_x, khdt_epi_y, G, &
           kRb = kRa ; if (max_kRho(i,j+1) < nz) kRb = max_kRho(i,j+1)+1
           Tr_La = Tr_min_face ; Tr_Lb = Tr_La ; Tr_Ra = Tr_La ; Tr_Rb = Tr_La
           if (h(i,j,kLa) > h_exclude) Tr_La = Tr(m)%t(i,j,kLa)
-          if (h(i,j,kLb) > h_exclude) Tr_La = Tr(m)%t(i,j,kLb)
+          if ((CS%answer_date <= 20240330) .and. CS%limit_bug) then
+            if (h(i,j,kLb) > h_exclude) Tr_La = Tr(m)%t(i,j,kLb)
+          else
+            if (h(i,j,kLb) > h_exclude) Tr_Lb = Tr(m)%t(i,j,kLb)
+          endif
           if (h(i,j+1,kRa) > h_exclude) Tr_Ra = Tr(m)%t(i,j+1,kRa)
           if (h(i,j+1,kRb) > h_exclude) Tr_Rb = Tr(m)%t(i,j+1,kRb)
           Tr_min_face = min(Tr_min_face, Tr_La, Tr_Lb, Tr_Ra, Tr_Rb)
@@ -1464,42 +1502,69 @@ subroutine tracer_epipycnal_ML_diff(h, dt, Tr, ntr, khdt_epi_x, khdt_epi_y, G, &
             Tr(m)%df2d_y(i,J) = Tr(m)%df2d_y(i,J) + Tr_flux * Idt
         enddo ! Loop over pairings at faces.
       endif ; enddo ; enddo ! i- & j- loops over meridional faces.
-!$OMP parallel do default(none) shared(is,ie,js,je,G,nPv,k0b_Lv,k0b_Rv,deep_wt_Lv,  &
-!$OMP                                  tr_flux_conv,Tr_flux_3d,k0a_Lv,Tr_adj_vert_L,&
-!$OMP                                  deep_wt_Rv,k0a_Rv,Tr_adj_vert_R) &
-!$OMP                          private(kLa,kLb,kRa,kRb,wt_b,wt_a)
-      do i=is,ie ; do J=js-1,je ; if (G%mask2dCv(i,J) > 0.0) then
+
+      !$OMP parallel do default(shared) private(kLa,kLb,kRa,kRb,wt_b,wt_a)
+      do J=js-1,je ; do i=is,ie ; if (G%mask2dCv(i,J) > 0.0) then
         ! The non-stride-1 loop order here is to facilitate openMP threading. However, it might be
         ! suboptimal when openMP threading is not used, at which point it might be better to fuse
-        ! these loope with those that precede it and thereby eliminate the need for three 3-d arrays.
-        do k=1,nPv(i,J)
-          kLb = k0b_Lv(J)%p(i,k); kRb = k0b_Rv(J)%p(i,k)
-          if (deep_wt_Lv(J)%p(i,k) >= 1.0) then
-            tr_flux_conv(i,j,kLb) = tr_flux_conv(i,j,kLb) - Tr_flux_3d(i,J,k)
-          else
-            kLa = k0a_Lv(J)%p(i,k)
-            wt_b = deep_wt_Lv(J)%p(i,k) ; wt_a = 1.0 - wt_b
-            tr_flux_conv(i,j,kLa) = tr_flux_conv(i,j,kLa) - (wt_a*Tr_flux_3d(i,J,k) + Tr_adj_vert_L(i,J,k))
-            tr_flux_conv(i,j,kLb) = tr_flux_conv(i,j,kLb) - (wt_b*Tr_flux_3d(i,J,k) - Tr_adj_vert_L(i,J,k))
-          endif
-          if (deep_wt_Rv(J)%p(i,k) >= 1.0) then
-            tr_flux_conv(i,j+1,kRb) = tr_flux_conv(i,j+1,kRb) + Tr_flux_3d(i,J,k)
-          else
-            kRa = k0a_Rv(J)%p(i,k)
-            wt_b = deep_wt_Rv(J)%p(i,k) ; wt_a = 1.0 - wt_b
-            tr_flux_conv(i,j+1,kRa) = tr_flux_conv(i,j+1,kRa) + &
-                                            (wt_a*Tr_flux_3d(i,J,k) - Tr_adj_vert_R(i,J,k))
-            tr_flux_conv(i,j+1,kRb) = tr_flux_conv(i,j+1,kRb) + &
-                                            (wt_b*Tr_flux_3d(i,J,k) + Tr_adj_vert_R(i,J,k))
-          endif
-        enddo
+        ! this loop with those that precede it and thereby eliminate the need for three 3-d arrays.
+        if (CS%answer_date <= 20240330) then
+          do k=1,nPv(i,J)
+            kLb = k0b_Lv(J)%p(i,k); kRb = k0b_Rv(J)%p(i,k)
+            if (deep_wt_Lv(J)%p(i,k) >= 1.0) then
+              tr_flux_conv(i,j,kLb) = tr_flux_conv(i,j,kLb) - Tr_flux_3d(i,J,k)
+            else
+              kLa = k0a_Lv(J)%p(i,k)
+              wt_b = deep_wt_Lv(J)%p(i,k) ; wt_a = 1.0 - wt_b
+              tr_flux_conv(i,j,kLa) = tr_flux_conv(i,j,kLa) - (wt_a*Tr_flux_3d(i,J,k) + Tr_adj_vert_L(i,J,k))
+              tr_flux_conv(i,j,kLb) = tr_flux_conv(i,j,kLb) - (wt_b*Tr_flux_3d(i,J,k) - Tr_adj_vert_L(i,J,k))
+            endif
+            if (deep_wt_Rv(J)%p(i,k) >= 1.0) then
+              tr_flux_conv(i,j+1,kRb) = tr_flux_conv(i,j+1,kRb) + Tr_flux_3d(i,J,k)
+            else
+              kRa = k0a_Rv(J)%p(i,k)
+              wt_b = deep_wt_Rv(J)%p(i,k) ; wt_a = 1.0 - wt_b
+              tr_flux_conv(i,j+1,kRa) = tr_flux_conv(i,j+1,kRa) + &
+                                              (wt_a*Tr_flux_3d(i,J,k) - Tr_adj_vert_R(i,J,k))
+              tr_flux_conv(i,j+1,kRb) = tr_flux_conv(i,j+1,kRb) + &
+                                              (wt_b*Tr_flux_3d(i,J,k) + Tr_adj_vert_R(i,J,k))
+            endif
+          enddo
+        else
+          do k=1,nPv(i,J)
+            kLb = k0b_Lv(J)%p(i,k); kRb = k0b_Rv(J)%p(i,k)
+            if (deep_wt_Lv(J)%p(i,k) >= 1.0) then
+              tr_flux_N(i,j,kLb) = tr_flux_N(i,j,kLb) + Tr_flux_3d(i,J,k)
+            else
+              kLa = k0a_Lv(J)%p(i,k)
+              wt_b = deep_wt_Lv(J)%p(i,k) ; wt_a = 1.0 - wt_b
+              tr_flux_N(i,j,kLa) = tr_flux_N(i,j,kLa) + (wt_a*Tr_flux_3d(i,J,k) + Tr_adj_vert_L(i,J,k))
+              tr_flux_N(i,j,kLb) = tr_flux_N(i,j,kLb) + (wt_b*Tr_flux_3d(i,J,k) - Tr_adj_vert_L(i,J,k))
+            endif
+            if (deep_wt_Rv(J)%p(i,k) >= 1.0) then
+              tr_flux_S(i,j+1,kRb) = tr_flux_S(i,j+1,kRb) + Tr_flux_3d(i,J,k)
+            else
+              kRa = k0a_Rv(J)%p(i,k)
+              wt_b = deep_wt_Rv(J)%p(i,k) ; wt_a = 1.0 - wt_b
+              tr_flux_S(i,j+1,kRa) = tr_flux_S(i,j+1,kRa) + (wt_a*Tr_flux_3d(i,J,k) - Tr_adj_vert_R(i,J,k))
+              tr_flux_S(i,j+1,kRb) = tr_flux_S(i,j+1,kRb) + (wt_b*Tr_flux_3d(i,J,k) + Tr_adj_vert_R(i,J,k))
+            endif
+          enddo
+        endif
       endif ; enddo ; enddo
+
+      if (CS%answer_date >= 20240331) then
+        !$OMP parallel do default(shared)
+        do k=1,PEmax_kRho ; do j=js,je ; do i=is,ie
+          tr_flux_conv(i,j,k) = ((tr_flux_W(i,j,k) - tr_flux_E(i,j,k)) + &
+                                 (tr_flux_S(i,j,k) - tr_flux_N(i,j,k)))
+        enddo ; enddo ; enddo
+      endif
+
       !$OMP parallel do default(shared)
       do k=1,PEmax_kRho ; do j=js,je ; do i=is,ie
         if ((G%mask2dT(i,j) > 0.0) .and. (h(i,j,k) > 0.0)) then
-          Tr(m)%t(i,j,k) = Tr(m)%t(i,j,k) + tr_flux_conv(i,j,k) / &
-                                            (h(i,j,k)*G%areaT(i,j))
-          tr_flux_conv(i,j,k) = 0.0
+          Tr(m)%t(i,j,k) = Tr(m)%t(i,j,k) + tr_flux_conv(i,j,k) / (h(i,j,k)*G%areaT(i,j))
         endif
       enddo ; enddo ; enddo
 
@@ -1546,6 +1611,7 @@ subroutine tracer_hor_diff_init(Time, G, GV, US, param_file, diag, EOS, diabatic
   ! This include declares and sets the variable "version".
 # include "version_variable.h"
   character(len=40)  :: mdl = "MOM_tracer_hor_diff" ! This module's name.
+  integer :: default_answer_date
 
   if (associated(CS)) then
     call MOM_error(WARNING, "tracer_hor_diff_init called with associated control structure.")
@@ -1604,6 +1670,21 @@ subroutine tracer_hor_diff_init(Time, G, GV, US, param_file, diag, EOS, diabatic
                  "If true, then recalculate the neutral surfaces if the \n"//&
                  "diffusive CFL is exceeded. If false, assume that the  \n"//&
                  "positions of the surfaces do not change \n", default=.false.)
+  call get_param(param_file, mdl, "DEFAULT_ANSWER_DATE", default_answer_date, &
+                 "This sets the default value for the various _ANSWER_DATE parameters.", &
+                 default=99991231, do_not_log=.true.)
+  call get_param(param_file, mdl, "HOR_DIFF_ANSWER_DATE", CS%answer_date, &
+                 "The vintage of the order of arithmetic to use for the tracer diffusion.  "//&
+                 "Values of 20240330 or below recover the answers from the original form of the "//&
+                 "along-isopycnal mixed layer to interior mixing code, while higher values use "//&
+                 "mathematically equivalent expressions that recover rotational symmetry "//&
+                 "when DIFFUSE_ML_TO_INTERIOR is true.", &
+                 default=20240101, do_not_log=.not.CS%Diffuse_ML_interior)
+                 !### Change the default later to default_answer_date.
+  call get_param(param_file, mdl, "HOR_DIFF_LIMIT_BUG", CS%limit_bug, &
+                 "If true and the answer date is 20240330 or below, use a rotational symmetry "//&
+                 "breaking bug when limiting the tracer properties in tracer_epipycnal_ML_diff.", &
+                 default=.true., do_not_log=((.not.CS%Diffuse_ML_interior).or.(CS%answer_date>=20240331)))
   CS%ML_KhTR_scale = 1.0
   if (CS%Diffuse_ML_interior) then
     call get_param(param_file, mdl, "ML_KHTR_SCALE", CS%ML_KhTR_scale, &

--- a/src/tracer/MOM_tracer_registry.F90
+++ b/src/tracer/MOM_tracer_registry.F90
@@ -786,14 +786,16 @@ subroutine tracer_array_chkinv(mesg, G, GV, h, Tr, ntr)
   integer,                                   intent(in) :: ntr  !< number of registered tracers
 
   ! Local variables
-  real :: vol_scale ! The dimensional scaling factor to convert volumes to m3 [m3 H-1 L-2 ~> 1 or m3 kg-1]
-  real, dimension(SZI_(G),SZJ_(G),SZK_(GV)) :: tr_inv ! Volumetric tracer inventory in each cell [conc m3]
-  real :: total_inv ! The total amount of tracer [conc m3]
+  real :: vol_scale ! The dimensional scaling factor to convert volumes to m3 [m3 H-1 L-2 ~> 1] or cell
+                    ! masses to kg [kg H-1 L-2 ~> 1], depending on whether the Boussinesq approximation is used
+  real :: tr_inv(SZI_(G),SZJ_(G),SZK_(GV)) ! Volumetric or mass-based tracer inventory in
+                    ! each cell [conc m3] or [conc kg]
+  real :: total_inv ! The total amount of tracer [conc m3] or [conc kg]
   integer :: is, ie, js, je, nz
   integer :: i, j, k, m
 
   is = G%isc ; ie = G%iec ; js = G%jsc ; je = G%jec ; nz = GV%ke
-  vol_scale = GV%H_to_m*G%US%L_to_m**2
+  vol_scale = GV%H_to_MKS*G%US%L_to_m**2
   do m=1,ntr
     do k=1,nz ; do j=js,je ; do i=is,ie
       tr_inv(i,j,k) = Tr(m)%conc_scale*Tr(m)%t(i,j,k) * (vol_scale * h(i,j,k) * G%areaT(i,j)*G%mask2dT(i,j))
@@ -814,16 +816,18 @@ subroutine tracer_Reg_chkinv(mesg, G, GV, h, Reg)
   real, dimension(SZI_(G),SZJ_(G),SZK_(GV)), intent(in) :: h    !< Layer thicknesses [H ~> m or kg m-2]
 
   ! Local variables
-  real :: vol_scale ! The dimensional scaling factor to convert volumes to m3 [m3 H-1 L-2 ~> 1 or m3 kg-1]
-  real, dimension(SZI_(G),SZJ_(G),SZK_(GV)) :: tr_inv ! Volumetric tracer inventory in each cell [conc m3]
-  real :: total_inv ! The total amount of tracer [conc m3]
+  real :: vol_scale ! The dimensional scaling factor to convert volumes to m3 [m3 H-1 L-2 ~> 1] or cell
+                    ! masses to kg [kg H-1 L-2 ~> 1], depending on whether the Boussinesq approximation is used
+  real :: tr_inv(SZI_(G),SZJ_(G),SZK_(GV)) ! Volumetric or mass-based tracer inventory in
+                    ! each cell [conc m3] or [conc kg]
+  real :: total_inv ! The total amount of tracer [conc m3] or [conc kg]
   integer :: is, ie, js, je, nz
   integer :: i, j, k, m
 
   if (.not.associated(Reg)) return
 
   is = G%isc ; ie = G%iec ; js = G%jsc ; je = G%jec ; nz = GV%ke
-  vol_scale = GV%H_to_m*G%US%L_to_m**2
+  vol_scale = GV%H_to_MKS*G%US%L_to_m**2
   do m=1,Reg%ntr
     do k=1,nz ; do j=js,je ; do i=is,ie
       tr_inv(i,j,k) = Reg%Tr(m)%conc_scale*Reg%Tr(m)%t(i,j,k) * (vol_scale * h(i,j,k) * G%areaT(i,j)*G%mask2dT(i,j))

--- a/src/tracer/MOM_tracer_registry.F90
+++ b/src/tracer/MOM_tracer_registry.F90
@@ -74,11 +74,11 @@ subroutine register_tracer(tr_ptr, Reg, param_file, HI, GV, name, longname, unit
   type(vardesc),        optional, intent(in)    :: tr_desc      !< A structure with metadata about the tracer
 
   real,                 optional, intent(in)    :: OBC_inflow   !< the tracer for all inflows via OBC for which OBC_in_u
-                                                                !! or OBC_in_v are not specified (units of tracer CONC)
+                                                                !! or OBC_in_v are not specified [CU ~> conc]
   real, dimension(:,:,:), optional, pointer     :: OBC_in_u     !< tracer at inflows through u-faces of
-                                                                !! tracer cells (units of tracer CONC)
+                                                                !! tracer cells [CU ~> conc]
   real, dimension(:,:,:), optional, pointer     :: OBC_in_v     !< tracer at inflows through v-faces of
-                                                                !! tracer cells (units of tracer CONC)
+                                                                !! tracer cells [CU ~> conc]
 
   ! The following are probably not necessary if registry_diags is present and true.
   real, dimension(:,:,:), optional, pointer     :: ad_x         !< diagnostic x-advective flux
@@ -99,21 +99,24 @@ subroutine register_tracer(tr_ptr, Reg, param_file, HI, GV, name, longname, unit
                                                                 !! [CU H L2 T-1 ~> conc m3 s-1 or conc kg s-1]
 
   real, dimension(:,:,:), optional, pointer     :: advection_xy !< convergence of lateral advective tracer fluxes
+                                                                !! [CU H T-1 ~> conc m s-1 or conc kg m-2 s-1]
   logical,              optional, intent(in)    :: registry_diags !< If present and true, use the registry for
                                                                 !! the diagnostics of this tracer.
   real,                 optional, intent(in)    :: conc_scale   !< A scaling factor used to convert the concentration
-                                                                !! of this tracer to its desired units.
+                                                                !! of this tracer to its desired units [conc CU-1 ~> 1]
   character(len=*),     optional, intent(in)    :: flux_nameroot !< Short tracer name snippet used construct the
                                                                 !! names of flux diagnostics.
   character(len=*),     optional, intent(in)    :: flux_longname !< A word or phrase used construct the long
                                                                 !! names of flux diagnostics.
   character(len=*),     optional, intent(in)    :: flux_units   !< The units for the fluxes of this tracer.
   real,                 optional, intent(in)    :: flux_scale   !< A scaling factor used to convert the fluxes
-                                                                !! of this tracer to its desired units.
+                                                                !! of this tracer to its desired units
+                                                                !! [conc m CU-1 H-1 ~> 1] or [conc kg m-2 CU-1 H-1 ~> 1]
   character(len=*),     optional, intent(in)    :: convergence_units !< The units for the flux convergence of
                                                                 !! this tracer.
   real,                 optional, intent(in)    :: convergence_scale !< A scaling factor used to convert the flux
                                                                 !! convergence of this tracer to its desired units.
+                                                                !! [conc m CU-1 H-1 ~> 1] or [conc kg m-2 CU-1 H-1 ~> 1]
   character(len=*),     optional, intent(in)    :: cmor_tendprefix !< The CMOR name for the layer-integrated
                                                                 !! tendencies of this tracer.
   integer,              optional, intent(in)    :: diag_form    !< An integer (1 or 2, 1 by default) indicating the
@@ -296,7 +299,7 @@ subroutine register_tracer_diagnostics(Reg, h, Time, diag, G, GV, US, use_ALE, u
   character(len=120) :: cmor_longname ! The CMOR long name of that variable.
   character(len=120) :: var_lname      ! A temporary longname for a diagnostic.
   character(len=120) :: cmor_var_lname ! The temporary CMOR long name for a diagnostic
-  real :: conversion ! Temporary term while we address a bug
+  real :: conversion ! Temporary term while we address a bug [conc m CU-1 H-1 ~> 1] or [conc kg m-2 CU-1 H-1 ~> 1]
   type(tracer_type), pointer :: Tr=>NULL()
   integer :: i, j, k, is, ie, js, je, nz, m, m2, nTr_in
   integer :: isd, ied, jsd, jed, IsdB, IedB, JsdB, JedB
@@ -633,7 +636,7 @@ subroutine postALE_tracer_diagnostics(Reg, G, GV, diag, dt)
   type(diag_ctrl),            intent(in) :: diag !< regulates diagnostic output
   real,                       intent(in) :: dt   !< total time interval for these diagnostics [T ~> s]
 
-  real    :: work(SZI_(G),SZJ_(G),SZK_(GV))
+  real    :: work(SZI_(G),SZJ_(G),SZK_(GV)) ! Variance decay [CU2 T-1 ~> conc2 s-1]
   real    :: Idt ! The inverse of the time step [T-1 ~> s-1]
   integer :: i, j, k, is, ie, js, je, nz, m, m2
   is = G%isc ; ie = G%iec ; js = G%jsc ; je = G%jec ; nz = GV%ke
@@ -665,8 +668,9 @@ subroutine post_tracer_diagnostics_at_sync(Reg, h, diag_prev, diag, G, GV, dt)
   type(diag_ctrl),            intent(inout) :: diag !< structure to regulate diagnostic output
   real,                       intent(in) :: dt   !< total time step for tracer updates [T ~> s]
 
-  real    :: work3d(SZI_(G),SZJ_(G),SZK_(GV))
-  real    :: work2d(SZI_(G),SZJ_(G))
+  real    :: work3d(SZI_(G),SZJ_(G),SZK_(GV)) ! The time tendency of a diagnostic [CU T-1 ~> conc s-1]
+  real    :: work2d(SZI_(G),SZJ_(G)) ! The vertically integrated time tendency of a diagnostic
+                                     ! in [CU H T-1 ~> conc m s-1 or conc kg m-2 s-1]
   real    :: Idt ! The inverse of the time step [T-1 ~> s-1]
   type(tracer_type), pointer :: Tr=>NULL()
   integer :: i, j, k, is, ie, js, je, nz, m
@@ -717,7 +721,8 @@ subroutine post_tracer_transport_diagnostics(G, GV, Reg, h_diag, diag)
   type(diag_ctrl),            intent(in) :: diag !< structure to regulate diagnostic output
 
   integer :: i, j, k, is, ie, js, je, nz, m
-  real    :: work2d(SZI_(G),SZJ_(G))
+  real    :: work2d(SZI_(G),SZJ_(G))      ! The vertically integrated convergence of lateral advective
+                                          ! tracer fluxes [CU H T-1 ~> conc m s-1 or conc kg m-2 s-1]
   type(tracer_type), pointer :: Tr=>NULL()
 
   is = G%isc ; ie = G%iec ; js = G%jsc ; je = G%jec ; nz = GV%ke

--- a/src/tracer/MOM_tracer_types.F90
+++ b/src/tracer/MOM_tracer_types.F90
@@ -68,7 +68,7 @@ type, public :: tracer_type
   real                            :: conc_underflow = 0.0     !< A magnitude of tracer concentrations below
                                                               !! which values should be set to 0. [CU ~> conc]
   real                            :: conc_scale = 1.0         !< A scaling factor used to convert the concentrations
-                                                              !! of this tracer to its desired units.
+                                                              !! of this tracer to its desired units [conc CU ~> 1]
   character(len=64)               :: cmor_name                !< CMOR name of this tracer
   character(len=64)               :: cmor_units               !< CMOR physical dimensions of the tracer
   character(len=240)              :: cmor_longname            !< CMOR long name of the tracer
@@ -79,11 +79,13 @@ type, public :: tracer_type
   real                            :: flux_scale = 1.0         !< A scaling factor used to convert the fluxes
                                                               !! of this tracer to its desired units,
                                                               !! including a factor compensating for H scaling.
+                                                              !! [conc m CU-1 H-1 ~> 1] or [conc kg m-2 CU-1 H-1 ~> 1]
   character(len=48)               :: flux_units = ""          !< The units for fluxes of this variable.
   character(len=48)               :: conv_units = ""          !< The units for the flux convergence of this tracer.
   real                            :: conv_scale = 1.0         !< A scaling factor used to convert the flux
                                                               !! convergence of this tracer to its desired units,
                                                               !! including a factor compensating for H scaling.
+                                                              !! [conc m CU-1 H-1 ~> 1] or [conc kg m-2 CU-1 H-1 ~> 1]
   character(len=48)               :: cmor_tendprefix = ""     !< The CMOR variable prefix for tendencies of this
                                                               !! tracer, required because CMOR does not follow any
                                                               !! discernable pattern for these names.

--- a/src/tracer/boundary_impulse_tracer.F90
+++ b/src/tracer/boundary_impulse_tracer.F90
@@ -41,13 +41,13 @@ type, public :: boundary_impulse_tracer_CS ; private
   logical :: coupled_tracers = .false. !< These tracers are not offered to the  coupler.
   type(time_type), pointer :: Time => NULL() !< A pointer to the ocean model's clock.
   type(tracer_registry_type), pointer :: tr_Reg => NULL() !< A pointer to the tracer registry
-  real, pointer :: tr(:,:,:,:) => NULL() !< The array of tracers used in this subroutine, in g m-3?
+  real, pointer :: tr(:,:,:,:) => NULL() !< The array of tracers used in this subroutine, in [CU ~> conc] (g m-3)?
   logical :: tracers_may_reinit  !< If true, boundary_impulse can be initialized if not found in restart file
   integer, dimension(NTR_MAX) :: ind_tr  !< Indices returned by atmos_ocn_coupler_flux if it is used and the
                                          !! surface tracer concentrations are to be provided to the coupler.
 
   integer :: nkml !< Number of layers in mixed layer
-  real, dimension(NTR_MAX)  :: land_val = -1.0 !< A value to use to fill in tracers over land
+  real, dimension(NTR_MAX)  :: land_val = -1.0 !< A value to use to fill in tracers over land [CU ~> conc]
   real :: remaining_source_time !< How much longer (same units as the timestep) to
                                 !! inject the tracer at the surface [T ~> s]
 
@@ -80,8 +80,8 @@ function register_boundary_impulse_tracer(HI, GV, US, param_file, CS, tr_Reg, re
                             ! kg(tracer) kg(water)-1 m3 s-1 or kg(tracer) s-1.
   ! This include declares and sets the variable "version".
 # include "version_variable.h"
-  real, pointer :: tr_ptr(:,:,:) => NULL()
-  real, pointer :: rem_time_ptr => NULL()
+  real, pointer :: tr_ptr(:,:,:) => NULL() ! The tracer concentration [CU ~> conc]
+  real, pointer :: rem_time_ptr => NULL() ! The ramaining injection time [T ~> s]
   logical :: register_boundary_impulse_tracer
   integer :: isd, ied, jsd, jed, nz, m
   isd = HI%isd ; ied = HI%ied ; jsd = HI%jsd ; jed = HI%jed ; nz = GV%ke
@@ -235,7 +235,7 @@ subroutine boundary_impulse_tracer_column_physics(h_old, h_new, ea, eb, fluxes, 
 
   ! Local variables
   integer :: i, j, k, is, ie, js, je, nz, m
-  real, dimension(SZI_(G),SZJ_(G),SZK_(GV)) :: h_work ! Used so that h can be modified
+  real, dimension(SZI_(G),SZJ_(G),SZK_(GV)) :: h_work ! Used so that h can be modified [H ~> m or kg m-2]
 
   is = G%isc ; ie = G%iec ; js = G%jsc ; je = G%jec ; nz = GV%ke
 

--- a/src/tracer/dyed_obc_tracer.F90
+++ b/src/tracer/dyed_obc_tracer.F90
@@ -34,7 +34,7 @@ type, public :: dyed_obc_tracer_CS ; private
   character(len=200) :: tracer_IC_file !< The full path to the IC file, or " " to initialize internally.
   type(time_type), pointer :: Time => NULL() !< A pointer to the ocean model's clock.
   type(tracer_registry_type), pointer :: tr_Reg => NULL() !< A pointer to the tracer registry
-  real, pointer :: tr(:,:,:,:) => NULL()   !< The array of tracers used in this subroutine, in g m-3?
+  real, pointer :: tr(:,:,:,:) => NULL()   !< The array of tracers used in this subroutine in [conc]
 
   integer, allocatable, dimension(:) :: ind_tr !< Indices returned by atmos_ocn_coupler_flux if it is used and the
                                                !! surface tracer concentrations are to be provided to the coupler.
@@ -66,7 +66,7 @@ function register_dyed_obc_tracer(HI, GV, param_file, CS, tr_Reg, restart_CS)
   character(len=200) :: inputdir
   character(len=48)  :: flux_units ! The units for tracer fluxes, usually
                             ! kg(tracer) kg(water)-1 m3 s-1 or kg(tracer) s-1.
-  real, pointer :: tr_ptr(:,:,:) => NULL()
+  real, pointer :: tr_ptr(:,:,:) => NULL() ! The tracer concentration [conc]
   logical :: register_dyed_obc_tracer
   integer :: isd, ied, jsd, jed, nz, m
   isd = HI%isd ; ied = HI%ied ; jsd = HI%jsd ; jed = HI%jed ; nz = GV%ke

--- a/src/tracer/ideal_age_example.F90
+++ b/src/tracer/ideal_age_example.F90
@@ -91,7 +91,7 @@ function register_ideal_age_tracer(HI, GV, param_file, CS, tr_Reg, restart_CS)
   character(len=40)  :: mdl = "ideal_age_example" ! This module's name.
   character(len=200) :: inputdir ! The directory where the input files are.
   character(len=48)  :: var_name ! The variable's name.
-  real, pointer :: tr_ptr(:,:,:) => NULL()
+  real, pointer :: tr_ptr(:,:,:) => NULL() ! The tracer concentration [years]
   logical :: register_ideal_age_tracer
   logical :: do_ideal_age, do_vintage, do_ideal_age_dated, do_BL_residence
   integer :: isd, ied, jsd, jed, nz, m

--- a/src/tracer/ideal_age_example.F90
+++ b/src/tracer/ideal_age_example.F90
@@ -12,7 +12,6 @@ use MOM_forcing_type, only : forcing
 use MOM_grid, only : ocean_grid_type
 use MOM_hor_index, only : hor_index_type
 use MOM_io, only : file_exists, MOM_read_data, slasher, vardesc, var_desc, query_vardesc
-use MOM_interface_heights, only : thickness_to_dz
 use MOM_open_boundary, only : ocean_OBC_type
 use MOM_restart, only : query_initialized, set_initialized, MOM_restart_CS
 use MOM_spatial_means, only : global_mass_int_EFP
@@ -22,7 +21,7 @@ use MOM_tracer_registry, only : register_tracer, tracer_registry_type
 use MOM_tracer_diabatic, only : tracer_vertdiff, applyTracerBoundaryFluxesInOut
 use MOM_tracer_Z_init, only : tracer_Z_init
 use MOM_unit_scaling, only : unit_scale_type
-use MOM_variables, only : surface, thermo_var_ptrs
+use MOM_variables, only : surface
 use MOM_verticalGrid, only : verticalGrid_type
 
 implicit none ; private
@@ -297,7 +296,7 @@ subroutine initialize_ideal_age_tracer(restart, day, G, GV, US, h, diag, OBC, CS
 end subroutine initialize_ideal_age_tracer
 
 !> Applies diapycnal diffusion, aging and regeneration at the surface to the ideal age tracers
-subroutine ideal_age_tracer_column_physics(h_old, h_new, ea, eb, fluxes, dt, G, GV, US, tv, CS, &
+subroutine ideal_age_tracer_column_physics(h_old, h_new, ea, eb, fluxes, dt, G, GV, US, CS, &
               evap_CFL_limit, minimum_forcing_depth, Hbl)
   type(ocean_grid_type),   intent(in) :: G    !< The ocean's grid structure
   type(verticalGrid_type), intent(in) :: GV   !< The ocean's vertical grid structure
@@ -317,14 +316,13 @@ subroutine ideal_age_tracer_column_physics(h_old, h_new, ea, eb, fluxes, dt, G, 
                                               !! and tracer forcing fields.  Unused fields have NULL ptrs.
   real,                    intent(in) :: dt   !< The amount of time covered by this call [T ~> s]
   type(unit_scale_type),   intent(in) :: US   !< A dimensional unit scaling type
-  type(thermo_var_ptrs),   intent(in) :: tv   !< A structure pointing to various thermodynamic variables
   type(ideal_age_tracer_CS), pointer  :: CS   !< The control structure returned by a previous
                                               !! call to register_ideal_age_tracer.
   real,          optional, intent(in) :: evap_CFL_limit !< Limit on the fraction of the water that can
                                               !! be fluxed out of the top layer in a timestep [nondim]
   real,          optional, intent(in) :: minimum_forcing_depth !< The smallest depth over which
                                               !! fluxes can be applied [H ~> m or kg m-2]
-  real, dimension(SZI_(G),SZJ_(G)), optional, intent(in) :: Hbl !< Boundary layer depth [Z ~> m]
+  real, dimension(SZI_(G),SZJ_(G)), optional, intent(in) :: Hbl !< Boundary layer thickness [H ~> m or kg m-2]
 
 !   This subroutine applies diapycnal diffusion and any other column
 ! tracer physics or chemistry to the tracers from this file.
@@ -349,7 +347,7 @@ subroutine ideal_age_tracer_column_physics(h_old, h_new, ea, eb, fluxes, dt, G, 
   endif
 
   if (CS%use_real_BL_depth .and. present(Hbl)) then
-    call count_BL_layers(G, GV, h_old, Hbl, tv, BL_layers)
+    call count_BL_layers(G, GV, h_old, Hbl, BL_layers)
   endif
 
   if (.not.associated(CS)) return
@@ -578,30 +576,27 @@ subroutine ideal_age_example_end(CS)
   endif
 end subroutine ideal_age_example_end
 
-subroutine count_BL_layers(G, GV, h, Hbl, tv, BL_layers)
-  type(ocean_grid_type),   intent(in) :: G    !< The ocean's grid structure
-  type(verticalGrid_type), intent(in) :: GV   !< The ocean's vertical grid structure
+subroutine count_BL_layers(G, GV, h, Hbl, BL_layers)
+  type(ocean_grid_type),            intent(in) :: G    !< The ocean's grid structure
+  type(verticalGrid_type),          intent(in) :: GV   !< The ocean's vertical grid structure
   real, dimension(SZI_(G),SZJ_(G),SZK_(GV)), &
-                           intent(in) :: h    !< Layer thicknesses [H ~> m or kg m-2].
-  real, dimension(SZI_(G),SZJ_(G)), intent(in) :: Hbl !< Boundary layer depth [Z ~> m]
-  type(thermo_var_ptrs),   intent(in) :: tv   !< A structure pointing to various thermodynamic variables
+                                    intent(in) :: h    !< Layer thicknesses [H ~> m or kg m-2].
+  real, dimension(SZI_(G),SZJ_(G)), intent(in) :: Hbl  !< Boundary layer thickness [H ~> m or kg m-2]
   real, dimension(SZI_(G),SZJ_(G)), intent(out) :: BL_layers !< Number of model layers in the boundary layer [nondim]
 
-  real :: dz(SZI_(G),SZK_(GV)) ! Height change across layers [Z ~> m]
-  real :: current_depth  ! Distance from the free surface [Z ~> m]
+  real :: current_depth  ! Distance from the free surface [H ~> m or kg m-2]
   integer :: i, j, k, is, ie, js, je, nz, m, nk
   character(len=255) :: msg
   is = G%isc ; ie = G%iec ; js = G%jsc ; je = G%jec ; nz = GV%ke
 
   BL_layers(:,:) = 0.
   do j=js,je
-    call thickness_to_dz(h, tv, dz, j, G, GV)
     do i=is,ie
       current_depth = 0.
       do k=1,nz
-        current_depth = current_depth + dz(i,k)
+        current_depth = current_depth + h(i,j,k)
         if (Hbl(i,j) <= current_depth) then
-          BL_layers(i,j) = BL_layers(i,j) + (1.0 - (current_depth - Hbl(i,j)) / dz(i,k))
+          BL_layers(i,j) = BL_layers(i,j) + (1.0 - (current_depth - Hbl(i,j)) / h(i,j,k))
           exit
         else
           BL_layers(i,j) = BL_layers(i,j) + 1.0

--- a/src/tracer/nw2_tracers.F90
+++ b/src/tracer/nw2_tracers.F90
@@ -33,7 +33,7 @@ type, public :: nw2_tracers_CS ; private
   integer :: ntr = 0  !< The number of tracers that are actually used.
   type(time_type), pointer :: Time => NULL() !< A pointer to the ocean model's clock.
   type(tracer_registry_type), pointer :: tr_Reg => NULL() !< A pointer to the tracer registry
-  real, pointer :: tr(:,:,:,:) => NULL()   !< The array of tracers used in this package, in g m-3?
+  real, pointer :: tr(:,:,:,:) => NULL()   !< The array of tracers used in this package, in [conc] (g m-3)?
   real, allocatable , dimension(:) :: restore_rate !< The rate at which the tracer is damped toward
                                              !! its target profile [T-1 ~> s-1]
   type(diag_ctrl), pointer :: diag => NULL() !< A structure that is used to
@@ -60,7 +60,7 @@ logical function register_nw2_tracers(HI, GV, US, param_file, CS, tr_Reg, restar
 # include "version_variable.h"
   character(len=40)  :: mdl = "nw2_tracers" ! This module's name.
   character(len=8)  :: var_name ! The variable's name.
-  real, pointer :: tr_ptr(:,:,:) => NULL()
+  real, pointer :: tr_ptr(:,:,:) => NULL() ! The tracer concentration [conc]
   integer :: isd, ied, jsd, jed, nz, m, ig
   integer :: n_groups ! Number of groups of three tracers (i.e. # tracers/3)
   real, allocatable, dimension(:) :: timescale_in_days ! Damping timescale [days]
@@ -216,7 +216,7 @@ subroutine nw2_tracer_column_physics(h_old, h_new, ea, eb, fluxes, dt, G, GV, US
   integer :: i, j, k, m
   real :: dt_x_rate ! dt * restoring rate [nondim]
   real :: rscl ! z* scaling factor [nondim]
-  real :: target_value ! tracer value
+  real :: target_value ! tracer target value for damping [conc]
 
 ! if (.not.associated(CS)) return
 

--- a/src/tracer/oil_tracer.F90
+++ b/src/tracer/oil_tracer.F90
@@ -92,7 +92,7 @@ function register_oil_tracer(HI, GV, US, param_file, CS, tr_Reg, restart_CS)
   character(len=3)   :: name_tag ! String for creating identifying oils
   character(len=48) :: flux_units ! The units for tracer fluxes, here
                             ! kg(oil) s-1 or kg(oil) m-3 kg(water) s-1.
-  real, pointer :: tr_ptr(:,:,:) => NULL()
+  real, pointer :: tr_ptr(:,:,:) => NULL() ! The tracer concentration [kg m-3]
   logical :: register_oil_tracer
   integer :: isd, ied, jsd, jed, nz, m
   isd = HI%isd ; ied = HI%ied ; jsd = HI%jsd ; jed = HI%jed ; nz = GV%ke

--- a/src/tracer/oil_tracer.F90
+++ b/src/tracer/oil_tracer.F90
@@ -373,21 +373,21 @@ subroutine oil_tracer_column_physics(h_old, h_new, ea, eb, fluxes, dt, G, GV, US
   ! Add oil at the source location
   if (year>=CS%oil_start_year .and. year<=CS%oil_end_year .and. &
       CS%oil_source_i>-999 .and. CS%oil_source_j>-999) then
-    i=CS%oil_source_i ; j=CS%oil_source_j
-    k_max=nz ; h_total=0.
+    i = CS%oil_source_i ; j = CS%oil_source_j
+    k_max = nz ; h_total = 0.
     vol_scale = GV%H_to_m * US%L_to_m**2
     do k=nz, 2, -1
       h_total = h_total + h_new(i,j,k)
-      if (h_total<10.) k_max=k-1 ! Find bottom most interface that is 10 m above bottom
+      if (h_total < 10.*GV%m_to_H) k_max=k-1 ! Find bottom most interface that is 10 m above bottom
     enddo
     do m=1,CS%ntr
-      k=CS%oil_source_k(m)
+      k = CS%oil_source_k(m)
       if (k>0) then
-        k=min(k,k_max) ! Only insert k or first layer with interface 10 m above bottom
+        k = min(k,k_max) ! Only insert k or first layer with interface 10 m above bottom
         CS%tr(i,j,k,m) = CS%tr(i,j,k,m) + CS%oil_source_rate*dt / &
                 (vol_scale * (h_new(i,j,k)+GV%H_subroundoff) * G%areaT(i,j) )
       elseif (k<0) then
-        h_total=GV%H_subroundoff
+        h_total = GV%H_subroundoff
         do k=1, nz
           h_total = h_total + h_new(i,j,k)
         enddo

--- a/src/tracer/pseudo_salt_tracer.F90
+++ b/src/tracer/pseudo_salt_tracer.F90
@@ -73,7 +73,7 @@ function register_pseudo_salt_tracer(HI, GV, param_file, CS, tr_Reg, restart_CS)
   character(len=48)  :: var_name ! The variable's name.
   ! This include declares and sets the variable "version".
 # include "version_variable.h"
-  real, pointer :: tr_ptr(:,:,:) => NULL()
+  real, pointer :: tr_ptr(:,:,:) => NULL() ! The tracer concentration [ppt]
   logical :: register_pseudo_salt_tracer
   integer :: isd, ied, jsd, jed, nz
   isd = HI%isd ; ied = HI%ied ; jsd = HI%jsd ; jed = HI%jed ; nz = GV%ke

--- a/src/tracer/pseudo_salt_tracer.F90
+++ b/src/tracer/pseudo_salt_tracer.F90
@@ -196,6 +196,8 @@ subroutine pseudo_salt_tracer_column_physics(h_old, h_new, ea, eb, fluxes, dt, G
   !     h_new(k) = h_old(k) + ea(k) - eb(k-1) + eb(k) - ea(k+1)
 
   ! Local variables
+  real :: net_salt_rate(SZI_(G),SZJ_(G)) ! Net salt flux into the ocean
+                              ! [ppt H T-1 ~> ppt m s-1 or ppt kg m-2 s-1]
   real :: net_salt(SZI_(G),SZJ_(G)) ! Net salt flux into the ocean integrated over
                               ! a timestep [ppt H ~> ppt m or ppt kg m-2]
   real :: htot(SZI_(G))       ! Total ocean depth [H ~> m or kg m-2]
@@ -216,11 +218,27 @@ subroutine pseudo_salt_tracer_column_physics(h_old, h_new, ea, eb, fluxes, dt, G
     call hchksum(CS%ps,"pseudo_salt pre pseudo-salt vertdiff", G%HI)
   endif
 
+  FluxRescaleDepth = max( GV%Angstrom_H, 1.e-30*GV%m_to_H )
+  Ih_limit  = 0.0 ; if (FluxRescaleDepth > 0.0) Ih_limit  = 1.0 / FluxRescaleDepth
+
   ! Compute KPP nonlocal term if necessary
   if (present(KPP_CSp)) then
-    if (associated(KPP_CSp) .and. present(nonLocalTrans)) &
-      call KPP_NonLocalTransport(KPP_CSp, G, GV, h_old, nonLocalTrans, fluxes%KPP_salt_flux(:,:), &
+    if (associated(KPP_CSp) .and. present(nonLocalTrans)) then
+      ! Determine the salt flux, including limiting for small total ocean depths.
+      net_salt_rate(:,:) = 0.0
+      if (associated(fluxes%salt_flux)) then
+        do j=js,je
+          do i=is,ie ; htot(i) = h_old(i,j,1) ; enddo
+          do k=2,nz ; do i=is,ie ; htot(i) = htot(i) + h_old(i,j,k) ; enddo ; enddo
+          do i=is,ie
+            scale = 1.0 ; if ((Ih_limit > 0.0) .and. (htot(i)*Ih_limit < 1.0)) scale = htot(i)*Ih_limit
+            net_salt_rate(i,j) = (scale * (1000.0 * fluxes%salt_flux(i,j))) * GV%RZ_to_H
+          enddo
+        enddo
+      endif
+      call KPP_NonLocalTransport(KPP_CSp, G, GV, h_old, nonLocalTrans, net_salt_rate, &
                                  dt, CS%diag, CS%tr_ptr, CS%ps(:,:,:))
+    endif
   endif
 
   ! This uses applyTracerBoundaryFluxesInOut, usually in ALE mode
@@ -229,8 +247,6 @@ subroutine pseudo_salt_tracer_column_physics(h_old, h_new, ea, eb, fluxes, dt, G
 
     ! Determine the time-integrated salt flux, including limiting for small total ocean depths.
     net_Salt(:,:) = 0.0
-    FluxRescaleDepth = max( GV%Angstrom_H, 1.e-30*GV%m_to_H )
-    Ih_limit  = 0.0 ; if (FluxRescaleDepth > 0.0) Ih_limit  = 1.0 / FluxRescaleDepth
     do j=js,je
       do i=is,ie ; htot(i) = h_old(i,j,1) ; enddo
       do k=2,nz ; do i=is,ie ; htot(i) = htot(i) + h_old(i,j,k) ; enddo ; enddo

--- a/src/user/DOME2d_initialization.F90
+++ b/src/user/DOME2d_initialization.F90
@@ -261,15 +261,15 @@ subroutine DOME2d_initialize_temperature_salinity ( T, S, h, G, GV, US, param_fi
   call get_param(param_file, mdl, "DOME2D_SHELF_DEPTH", dome2d_depth_bay, &
                  units="nondim", default=0.2, do_not_log=.true.)
   call get_param(param_file, mdl, "S_REF", S_ref, 'Reference salinity', &
-                 units='1e-3', default=35.0, scale=US%ppt_to_S, do_not_log=just_read)
+                 units="ppt", default=35.0, scale=US%ppt_to_S, do_not_log=just_read)
   call get_param(param_file, mdl, "T_REF", T_ref, 'Reference temperature', &
                  units='degC', scale=US%degC_to_C, fail_if_missing=.not.just_read, do_not_log=just_read)
   call get_param(param_file, mdl, "S_RANGE", S_range,' Initial salinity range', &
-                 units='1e-3', default=2.0, scale=US%ppt_to_S, do_not_log=just_read)
+                 units="ppt", default=2.0, scale=US%ppt_to_S, do_not_log=just_read)
   call get_param(param_file, mdl, "T_RANGE", T_range, 'Initial temperature range', &
                  units='degC', default=0.0, scale=US%degC_to_C, do_not_log=just_read)
   call get_param(param_file, mdl, "INITIAL_SSS", S_surf, "Initial surface salinity", &
-                 units="1e-3", default=34.0, scale=US%ppt_to_S, do_not_log=just_read)
+                 units="ppt", default=34.0, scale=US%ppt_to_S, do_not_log=just_read)
   call get_param(param_file, mdl, "DOME2D_T_BAY", T_bay, &
                  "Temperature in the inflow embayment in the DOME2d test case", &
                  units="degC", default=1.0, scale=US%degC_to_C, do_not_log=just_read)
@@ -440,10 +440,10 @@ subroutine DOME2d_initialize_sponges(G, GV, US, tv, depth_tot, param_file, use_A
   call get_param(param_file, mdl, "S_RANGE", S_range, units="ppt", default=2.0, scale=US%ppt_to_S)
   call get_param(param_file, mdl, "T_RANGE", T_range, units="degC", default=0.0, scale=US%degC_to_C)
   call get_param(param_file, mdl, "INITIAL_SSS", S_surf, "Initial surface salinity", &
-                 units="1e-3", default=34.0, scale=US%ppt_to_S, do_not_log=.true.)
+                 units="ppt", default=34.0, scale=US%ppt_to_S, do_not_log=.true.)
   call get_param(param_file, mdl, "DOME2D_EAST_SPONGE_S_RANGE", S_range_sponge, &
                  "Range of salinities in the eastern sponge region in the DOME2D configuration", &
-                 units="1e-3", default=1.0, scale=US%ppt_to_S)
+                 units="ppt", default=1.0, scale=US%ppt_to_S)
 
   ! Set the sponge damping rate as a function of position
   Idamp(:,:) = 0.0

--- a/src/user/ISOMIP_initialization.F90
+++ b/src/user/ISOMIP_initialization.F90
@@ -348,7 +348,7 @@ subroutine ISOMIP_initialize_temperature_salinity ( T, S, h, depth_tot, G, GV, U
                   default=.false., do_not_log=just_read)
       call get_param(param_file, mdl, "DRHO_DS", drho_dS1, &
                   "Partial derivative of density with salinity.", &
-                  units="kg m-3 PSU-1", scale=US%kg_m3_to_R*US%S_to_ppt, &
+                  units="kg m-3 ppt-1", scale=US%kg_m3_to_R*US%S_to_ppt, &
                   fail_if_missing=.not.just_read, do_not_log=just_read)
       call get_param(param_file, mdl, "DRHO_DT", drho_dT1, &
                   "Partial derivative of density with temperature.", &
@@ -359,7 +359,7 @@ subroutine ISOMIP_initialize_temperature_salinity ( T, S, h, depth_tot, G, GV, U
                   units="degC", scale=US%degC_to_C, fail_if_missing=.not.just_read, do_not_log=just_read)
       call get_param(param_file, mdl, "S_REF", S_Ref, &
                   "A reference salinity used in initialization.", &
-                  units="PSU", default=35.0, scale=US%ppt_to_S, do_not_log=just_read)
+                  units="ppt", default=35.0, scale=US%ppt_to_S, do_not_log=just_read)
       if (just_read) return ! All run-time parameters have been read, so return.
 
       ! write(mesg,*) 'read drho_dS, drho_dT', drho_dS1, drho_dT1

--- a/src/user/MOM_wave_interface.F90
+++ b/src/user/MOM_wave_interface.F90
@@ -717,8 +717,8 @@ subroutine Update_Surface_Waves(G, GV, US, Time_present, dt, CS, forces)
         do i=G%isc,G%iec
           !CS%Omega_w2x(i,j)   = forces%omega_w2x(i,j)
           do b=1,CS%NumBands
-            CS%UStk_Hb(i,j,b) = US%m_s_to_L_T*forces%UStkb(i,j,b)
-            CS%VStk_Hb(i,j,b) = US%m_s_to_L_T*forces%VStkb(i,j,b)
+            CS%UStk_Hb(i,j,b) = forces%UStkb(i,j,b)
+            CS%VStk_Hb(i,j,b) = forces%VStkb(i,j,b)
           enddo
         enddo
       enddo

--- a/src/user/MOM_wave_interface.F90
+++ b/src/user/MOM_wave_interface.F90
@@ -673,7 +673,7 @@ subroutine Update_Surface_Waves(G, GV, US, Time_present, dt, CS, forces)
   type(mech_forcing),      intent(in), optional  :: forces !< MOM_forcing_type
   ! Local variables
   type(time_type) :: Stokes_Time
-  integer :: ii, jj, b
+  integer :: i, j, b
 
   if (CS%WaveMethod == TESTPROF) then
     ! Do nothing
@@ -701,37 +701,37 @@ subroutine Update_Surface_Waves(G, GV, US, Time_present, dt, CS, forces)
       do b=1,CS%NumBands
         CS%WaveNum_Cen(b) = forces%stk_wavenumbers(b)
         !Interpolate from a grid to c grid
-        do jj=G%jsc,G%jec
-          do II=G%iscB,G%iecB
-            CS%STKx0(II,jj,b) = 0.5*(forces%UStkb(ii,jj,b)+forces%UStkb(ii+1,jj,b))
+        do j=G%jsc,G%jec
+          do I=G%iscB,G%iecB
+            CS%STKx0(I,j,b) = 0.5*(forces%UStkb(i,j,b)+forces%UStkb(i+1,j,b))
           enddo
         enddo
-        do JJ=G%jscB, G%jecB
-          do ii=G%isc,G%iec
-            CS%STKY0(ii,JJ,b) = 0.5*(forces%VStkb(ii,jj,b)+forces%VStkb(ii,jj+1,b))
+        do J=G%jscB,G%jecB
+          do i=G%isc,G%iec
+            CS%STKY0(i,J,b) = 0.5*(forces%VStkb(i,j,b)+forces%VStkb(i,j+1,b))
           enddo
         enddo
         call pass_vector(CS%STKx0(:,:,b),CS%STKy0(:,:,b), G%Domain)
       enddo
-      do jj=G%jsc,G%jec
-        do ii=G%isc,G%iec
-          !CS%Omega_w2x(ii,jj)   = forces%omega_w2x(ii,jj)
+      do j=G%jsc,G%jec
+        do i=G%isc,G%iec
+          !CS%Omega_w2x(i,j)   = forces%omega_w2x(i,j)
           do b=1,CS%NumBands
-            CS%UStk_Hb(ii,jj,b) = US%m_s_to_L_T*forces%UStkb(ii,jj,b)
-            CS%VStk_Hb(ii,jj,b) = US%m_s_to_L_T*forces%VStkb(ii,jj,b)
+            CS%UStk_Hb(i,j,b) = US%m_s_to_L_T*forces%UStkb(i,j,b)
+            CS%VStk_Hb(i,j,b) = US%m_s_to_L_T*forces%VStkb(i,j,b)
           enddo
         enddo
       enddo
     elseif (CS%DataSource == INPUT) then
       do b=1,CS%NumBands
-        do jj=G%jsd,G%jed
-          do II=G%isdB,G%iedB
-            CS%STKx0(II,jj,b) = CS%PrescribedSurfStkX(b)
+        do j=G%jsd,G%jed
+          do I=G%isdB,G%iedB
+            CS%STKx0(I,j,b) = CS%PrescribedSurfStkX(b)
           enddo
         enddo
-        do JJ=G%jsdB, G%jedB
-          do ii=G%isd,G%ied
-            CS%STKY0(ii,JJ,b) = CS%PrescribedSurfStkY(b)
+        do J=G%jsdB, G%jedB
+          do i=G%isd,G%ied
+            CS%STKY0(i,J,b) = CS%PrescribedSurfStkY(b)
           enddo
         enddo
       enddo
@@ -763,7 +763,7 @@ subroutine Update_Stokes_Drift(G, GV, US, CS, dz, ustar, dt, dynamics_step)
   real    :: UStokes  ! A Stokes drift velocity [L T-1 ~> m s-1]
   real    :: PI       ! 3.1415926535... [nondim]
   real    :: La       ! The local Langmuir number [nondim]
-  integer :: ii, jj, kk, b, iim1, jjm1
+  integer :: i, j, k, b
   real    :: I_dt     ! The inverse of the time step [T-1 ~> s-1]
 
   if (CS%WaveMethod==EFACTOR) return
@@ -777,29 +777,27 @@ subroutine Update_Stokes_Drift(G, GV, US, CS, dz, ustar, dt, dynamics_step)
   if (CS%WaveMethod==TESTPROF) then
     PI = 4.0*atan(1.0)
     DecayScale = 4.*PI / CS%TP_WVL !4pi
-    do jj = G%jsc,G%jec
-      do II = G%iscB,G%iecB
-        IIm1 = max(1,II-1)
+    do j=G%jsc,G%jec
+      do I=G%iscB,G%iecB
         Bottom = 0.0
         MidPoint = 0.0
-        do kk = 1,GV%ke
+        do k = 1,GV%ke
           Top = Bottom
-          MidPoint = Bottom - 0.25*(dz(II,jj,kk)+dz(IIm1,jj,kk))
-          Bottom = Bottom - 0.5*(dz(II,jj,kk)+dz(IIm1,jj,kk))
-          CS%Us_x(II,jj,kk) = CS%TP_STKX0*exp(MidPoint*DecayScale)
+          MidPoint = Bottom - 0.25*(dz(I,j,k)+dz(I-1,j,k))
+          Bottom = Bottom - 0.5*(dz(I,j,k)+dz(I-1,j,k))
+          CS%Us_x(I,j,k) = CS%TP_STKX0*exp(MidPoint*DecayScale)
         enddo
       enddo
     enddo
-    do JJ = G%jscB,G%jecB
-      do ii = G%isc,G%iec
-        JJm1 = max(1,JJ-1)
+    do J=G%jscB,G%jecB
+      do i=G%isc,G%iec
         Bottom = 0.0
         MidPoint = 0.0
-        do kk = 1,GV%ke
+        do k = 1,GV%ke
           Top = Bottom
-          MidPoint = Bottom - 0.25*(dz(ii,JJ,kk)+dz(ii,JJm1,kk))
-          Bottom = Bottom - 0.5*(dz(ii,JJ,kk)+dz(ii,JJm1,kk))
-          CS%Us_y(ii,JJ,kk) = CS%TP_STKY0*exp(MidPoint*DecayScale)
+          MidPoint = Bottom - 0.25*(dz(i,J,k)+dz(i,J-1,k))
+          Bottom = Bottom - 0.5*(dz(i,J,k)+dz(i,J-1,k))
+          CS%Us_y(i,J,k) = CS%TP_STKY0*exp(MidPoint*DecayScale)
         enddo
       enddo
     enddo
@@ -813,19 +811,18 @@ subroutine Update_Stokes_Drift(G, GV, US, CS, dz, ustar, dt, dynamics_step)
     CS%Us0_x(:,:) = 0.0
     CS%Us0_y(:,:) = 0.0
     ! Computing X direction Stokes drift
-    do jj = G%jsc,G%jec
-      do II = G%iscB,G%iecB
+    do j=G%jsc,G%jec
+      do I=G%iscB,G%iecB
         ! 1. First compute the surface Stokes drift
         !    by summing over the partitions.
         do b = 1,CS%NumBands
-          CS%US0_x(II,jj) = CS%US0_x(II,jj) + CS%STKx0(II,jj,b)
+          CS%US0_x(I,j) = CS%US0_x(I,j) + CS%STKx0(I,j,b)
         enddo
         ! 2. Second compute the level averaged Stokes drift
         bottom = 0.0
-        do kk = 1,GV%ke
+        do k = 1,GV%ke
           Top = Bottom
-          IIm1 = max(II-1,1)
-          level_thick = 0.5*(dz(II,jj,kk)+dz(IIm1,jj,kk))
+          level_thick = 0.5*(dz(I,j,k)+dz(I-1,j,k))
           MidPoint = Top - 0.5*level_thick
           Bottom = Top - level_thick
 
@@ -840,7 +837,7 @@ subroutine Update_Stokes_Drift(G, GV, US, CS, dz, ustar, dt, dynamics_step)
                 WN = CS%Freq_Cen(b)**2 * CS%I_g_Earth
                 CMN_FAC = exp(2.*WN*Top) * one_minus_exp_x(2.*WN*level_thick)
               endif
-              CS%US_x(II,jj,kk) = CS%US_x(II,jj,kk) + CS%STKx0(II,jj,b)*CMN_FAC
+              CS%US_x(I,j,k) = CS%US_x(I,j,k) + CS%STKx0(I,j,b)*CMN_FAC
             enddo
 
           elseif (level_thick > CS%Stokes_min_thick_avg) then
@@ -855,7 +852,7 @@ subroutine Update_Stokes_Drift(G, GV, US, CS, dz, ustar, dt, dynamics_step)
                 WN = CS%Freq_Cen(b)**2 / CS%g_Earth !bgr bug-fix missing g
                 CMN_FAC = (exp(2.*WN*Top)-exp(2.*WN*Bottom)) / (2.*WN*(Top-Bottom))
               endif
-              CS%US_x(II,jj,kk) = CS%US_x(II,jj,kk) + CS%STKx0(II,jj,b)*CMN_FAC
+              CS%US_x(I,j,k) = CS%US_x(I,j,k) + CS%STKx0(I,j,b)*CMN_FAC
             enddo
           else ! Take the value at the midpoint
             do b = 1,CS%NumBands
@@ -864,7 +861,7 @@ subroutine Update_Stokes_Drift(G, GV, US, CS, dz, ustar, dt, dynamics_step)
               else
                 CMN_FAC = exp(MidPoint * 2. * CS%Freq_Cen(b)**2 / CS%g_Earth)
               endif
-              CS%US_x(II,jj,kk) = CS%US_x(II,jj,kk) + CS%STKx0(II,jj,b)*CMN_FAC
+              CS%US_x(I,j,k) = CS%US_x(I,j,k) + CS%STKx0(I,j,b)*CMN_FAC
             enddo
           endif
         enddo
@@ -872,18 +869,17 @@ subroutine Update_Stokes_Drift(G, GV, US, CS, dz, ustar, dt, dynamics_step)
     enddo
 
     ! Computing Y direction Stokes drift
-    do JJ = G%jscB,G%jecB
-      do ii = G%isc,G%iec
+    do J=G%jscB,G%jecB
+      do i=G%isc,G%iec
         ! Set the surface value to that at z=0
         do b = 1,CS%NumBands
-          CS%US0_y(ii,JJ) = CS%US0_y(ii,JJ) + CS%STKy0(ii,JJ,b)
+          CS%US0_y(i,J) = CS%US0_y(i,J) + CS%STKy0(i,J,b)
         enddo
         ! Compute the level averages.
         bottom = 0.0
-        do kk = 1,GV%ke
+        do k = 1,GV%ke
           Top = Bottom
-          JJm1 = max(JJ-1,1)
-          level_thick = 0.5*(dz(ii,JJ,kk)+dz(ii,JJm1,kk))
+          level_thick = 0.5*(dz(i,J,k)+dz(i,J-1,k))
           MidPoint = Top - 0.5*level_thick
           Bottom = Top - level_thick
 
@@ -898,7 +894,7 @@ subroutine Update_Stokes_Drift(G, GV, US, CS, dz, ustar, dt, dynamics_step)
                 WN = CS%Freq_Cen(b)**2 * CS%I_g_Earth
                 CMN_FAC = exp(2.*WN*Top) * one_minus_exp_x(2.*WN*level_thick)
               endif
-              CS%US_y(ii,JJ,kk) = CS%US_y(ii,JJ,kk) + CS%STKy0(ii,JJ,b)*CMN_FAC
+              CS%US_y(i,J,k) = CS%US_y(i,J,k) + CS%STKy0(i,J,b)*CMN_FAC
             enddo
           elseif (level_thick > CS%Stokes_min_thick_avg) then
             ! -> Stokes drift in thin layers not averaged.
@@ -912,7 +908,7 @@ subroutine Update_Stokes_Drift(G, GV, US, CS, dz, ustar, dt, dynamics_step)
                 WN = CS%Freq_Cen(b)**2 / CS%g_Earth !bgr bug-fix missing g
                 CMN_FAC = (exp(2.*WN*Top)-exp(2.*WN*Bottom)) / (2.*WN*(Top-Bottom))
               endif
-              CS%US_y(ii,JJ,kk) = CS%US_y(ii,JJ,kk) + CS%STKy0(ii,JJ,b)*CMN_FAC
+              CS%US_y(i,J,k) = CS%US_y(i,J,k) + CS%STKy0(i,J,b)*CMN_FAC
             enddo
           else ! Take the value at the midpoint
             do b = 1,CS%NumBands
@@ -921,7 +917,7 @@ subroutine Update_Stokes_Drift(G, GV, US, CS, dz, ustar, dt, dynamics_step)
               else
                 CMN_FAC = exp(MidPoint * 2. * CS%Freq_Cen(b)**2 / CS%g_Earth)
               endif
-              CS%US_y(ii,JJ,kk) = CS%US_y(ii,JJ,kk) + CS%STKy0(ii,JJ,b)*CMN_FAC
+              CS%US_y(i,J,k) = CS%US_y(i,J,k) + CS%STKy0(i,J,b)*CMN_FAC
             enddo
           endif
         enddo
@@ -931,39 +927,37 @@ subroutine Update_Stokes_Drift(G, GV, US, CS, dz, ustar, dt, dynamics_step)
     call pass_vector(CS%Us0_x(:,:),CS%Us0_y(:,:), G%Domain)
   elseif (CS%WaveMethod == DHH85) then
     if (.not.(CS%StaticWaves .and. CS%DHH85_is_set)) then
-      do jj = G%jsc,G%jec
-        do II = G%iscB,G%iecB
+      do j=G%jsc,G%jec
+        do I=G%iscB,G%iecB
           bottom = 0.0
-          do kk = 1,GV%ke
+          do k = 1,GV%ke
             Top = Bottom
-            IIm1 = max(II-1,1)
-            MidPoint = Top - 0.25*(dz(II,jj,kk)+dz(IIm1,jj,kk))
-            Bottom = Top - 0.5*(dz(II,jj,kk)+dz(IIm1,jj,kk))
-            !bgr note that this is using a u-point ii on h-point ustar
+            MidPoint = Top - 0.25*(dz(I,j,k)+dz(I-1,j,k))
+            Bottom = Top - 0.5*(dz(I,j,k)+dz(I-1,j,k))
+            !bgr note that this is using a u-point I on h-point ustar
             !    this code has only been previous used for uniform
             !    grid cases.  This needs fixed if DHH85 is used for non
             !    uniform cases.
             call DHH85_mid(GV, US, CS, MidPoint, UStokes)
             ! Putting into x-direction (no option for direction
-            CS%US_x(II,jj,kk) = UStokes
+            CS%US_x(I,j,k) = UStokes
           enddo
         enddo
       enddo
-      do JJ = G%jscB,G%jecB
-        do ii = G%isc,G%iec
+      do J=G%jscB,G%jecB
+        do i=G%isc,G%iec
           Bottom = 0.0
-          do kk=1, GV%ke
+          do k = 1,GV%ke
             Top = Bottom
-            JJm1 = max(JJ-1,1)
-            MidPoint = Bottom - 0.25*(dz(ii,JJ,kk)+dz(ii,JJm1,kk))
-            Bottom = Bottom - 0.5*(dz(ii,JJ,kk)+dz(ii,JJm1,kk))
-            !bgr note that this is using a v-point jj on h-point ustar
+            MidPoint = Bottom - 0.25*(dz(i,J,k)+dz(i,J-1,k))
+            Bottom = Bottom - 0.5*(dz(i,J,k)+dz(i,J-1,k))
+            !bgr note that this is using a v-point J on h-point ustar
             !    this code has only been previous used for uniform
             !    grid cases.  This needs fixed if DHH85 is used for non
             !    uniform cases.
             ! call DHH85_mid(GV, US, CS, Midpoint, UStokes)
             ! Putting into x-direction, so setting y direction to 0
-            CS%US_y(ii,JJ,kk) = 0.0
+            CS%US_y(i,J,k) = 0.0
             ! For rotational symmetry there should be the option for this to become = UStokes
             !    bgr - see note above, but this is true
             !          if this is used for anything
@@ -975,28 +969,18 @@ subroutine Update_Stokes_Drift(G, GV, US, CS, dz, ustar, dt, dynamics_step)
     endif
     call pass_vector(CS%Us_x(:,:,:),CS%Us_y(:,:,:), G%Domain)
   else! Keep this else, fallback to 0 Stokes drift
-    do kk= 1,GV%ke
-      do jj = G%jsd,G%jed
-        do II = G%isdB,G%iedB
-          CS%Us_x(II,jj,kk) = 0.
-        enddo
-      enddo
-      do JJ = G%jsdB,G%jedB
-        do ii = G%isd,G%ied
-          CS%Us_y(ii,JJ,kk) = 0.
-        enddo
-      enddo
-    enddo
+    CS%Us_x(:,:,:) = 0.
+    CS%Us_y(:,:,:) = 0.
   endif
 
   ! Turbulent Langmuir number is computed here and available to use anywhere.
   ! SL Langmuir number requires mixing layer depth, and therefore is computed
   ! in the routine it is needed by (e.g. KPP or ePBL).
-  do jj = G%jsc, G%jec
-    do ii = G%isc,G%iec
-      call get_Langmuir_Number( La, G, GV, US, dz(ii,jj,1), ustar(ii,jj), ii, jj, &
-             dz(ii,jj,:), CS, Override_MA=.false.)
-      CS%La_turb(ii,jj) = La
+  do j=G%jsc, G%jec
+    do i=G%isc,G%iec
+      call get_Langmuir_Number( La, G, GV, US, dz(i,j,1), ustar(i,j), i, j, &
+             dz(i,j,:), CS, Override_MA=.false.)
+      CS%La_turb(i,j) = La
     enddo
   enddo
 
@@ -1197,7 +1181,7 @@ subroutine get_Langmuir_Number( LA, G, GV, US, HBL, ustar, i, j, dz, Waves, &
   logical :: ContinueLoop, USE_MA
   real, dimension(SZK_(GV)) :: US_H, VS_H ! Profiles of Stokes velocities [L T-1 ~> m s-1]
   real, allocatable :: StkBand_X(:), StkBand_Y(:) ! Stokes drifts by band [L T-1 ~> m s-1]
-  integer :: KK, BB
+  integer :: k, BB
 
   ! Compute averaging depth for Stokes drift (negative)
   Dpt_LASL = -1.0*max(Waves%LA_FracHBL*HBL, Waves%LA_HBL_min)
@@ -1211,24 +1195,24 @@ subroutine get_Langmuir_Number( LA, G, GV, US, HBL, ustar, i, j, dz, Waves, &
         "Get_LA_waves requested to consider misalignment, but velocities were not provided.")
     ContinueLoop = .true.
     bottom = 0.0
-    do kk = 1,GV%ke
+    do k = 1,GV%ke
       Top = Bottom
-      MidPoint = Bottom + 0.5*dz(kk)
-      Bottom = Bottom + dz(kk)
+      MidPoint = Bottom + 0.5*dz(k)
+      Bottom = Bottom + dz(k)
       !### Given the sign convention that Dpt_LASL is negative, the next line seems to have a bug.
       !    To correct this bug, this line should be changed to:
-      ! if (MidPoint > abs(Dpt_LASL) .and. (kk > 1) .and. ContinueLoop) then
-      if (MidPoint > Dpt_LASL .and. kk > 1 .and. ContinueLoop) then
-        ShearDirection = atan2(V_H(1)-V_H(kk),U_H(1)-U_H(kk))
+      ! if (MidPoint > abs(Dpt_LASL) .and. (k > 1) .and. ContinueLoop) then
+      if (MidPoint > Dpt_LASL .and. k > 1 .and. ContinueLoop) then
+        ShearDirection = atan2(V_H(1)-V_H(k), U_H(1)-U_H(k))
         ContinueLoop = .false.
       endif
     enddo
   endif
 
   if (Waves%WaveMethod==TESTPROF) then
-    do kk = 1,GV%ke
-      US_H(kk) = 0.5*(Waves%US_X(I,j,kk)+Waves%US_X(I-1,j,kk))
-      VS_H(kk) = 0.5*(Waves%US_Y(i,J,kk)+Waves%US_Y(i,J-1,kk))
+    do k = 1,GV%ke
+      US_H(k) = 0.5*(Waves%US_X(I,j,k)+Waves%US_X(I-1,j,k))
+      VS_H(k) = 0.5*(Waves%US_Y(i,J,k)+Waves%US_Y(i,J-1,k))
     enddo
     call Get_SL_Average_Prof( GV, Dpt_LASL, dz, US_H, LA_STKx)
     call Get_SL_Average_Prof( GV, Dpt_LASL, dz, VS_H, LA_STKy)
@@ -1245,9 +1229,9 @@ subroutine get_Langmuir_Number( LA, G, GV, US, HBL, ustar, i, j, dz, Waves, &
     deallocate(StkBand_X, StkBand_Y)
   elseif (Waves%WaveMethod==DHH85) then
     ! Temporarily integrating profile rather than spectrum for simplicity
-    do kk = 1,GV%ke
-      US_H(kk) = 0.5*(Waves%US_X(I,j,kk)+Waves%US_X(I-1,j,kk))
-      VS_H(kk) = 0.5*(Waves%US_Y(i,J,kk)+Waves%US_Y(i,J-1,kk))
+    do k = 1,GV%ke
+      US_H(k) = 0.5*(Waves%US_X(I,j,k)+Waves%US_X(I-1,j,k))
+      VS_H(k) = 0.5*(Waves%US_Y(i,J,k)+Waves%US_Y(i,J-1,k))
     enddo
     call Get_SL_Average_Prof( GV, Dpt_LASL, dz, US_H, LA_STKx)
     call Get_SL_Average_Prof( GV, Dpt_LASL, dz, VS_H, LA_STKy)
@@ -1451,20 +1435,20 @@ subroutine Get_SL_Average_Prof( GV, AvgDepth, dz, Profile, Average )
   !Local variables
   real :: Top, Bottom ! Depths, negative downward [Z ~> m]
   real :: Sum  ! The depth weighted vertical sum of a quantity [A Z ~> A m]
-  integer :: kk
+  integer :: k
 
   ! Initializing sum
   Sum = 0.0
 
   ! Integrate
   bottom = 0.0
-  do kk = 1, GV%ke
+  do k = 1, GV%ke
     Top = Bottom
-    Bottom = Bottom - dz(kk)
+    Bottom = Bottom - dz(k)
     if (AvgDepth < Bottom) then ! The whole cell is within H_LA
-      Sum = Sum + Profile(kk) * dz(kk)
+      Sum = Sum + Profile(k) * dz(k)
     elseif (AvgDepth < Top) then ! A partial cell is within H_LA
-      Sum = Sum + Profile(kk) * (Top-AvgDepth)
+      Sum = Sum + Profile(k) * (Top-AvgDepth)
       exit
     else
       exit

--- a/src/user/RGC_initialization.F90
+++ b/src/user/RGC_initialization.F90
@@ -63,7 +63,7 @@ subroutine RGC_initialize_sponges(G, GV, US, tv, u, v, depth_tot, PF, use_ALE, C
   real :: U1(SZIB_(G),SZJ_(G),SZK_(GV)) ! A temporary array for u [L T-1 ~> m s-1]
   real :: V1(SZI_(G),SZJB_(G),SZK_(GV)) ! A temporary array for v [L T-1 ~> m s-1]
   real :: tmp(SZI_(G),SZJ_(G))        ! A temporary array for tracers.
-  real :: h(SZI_(G),SZJ_(G),SZK_(GV)) ! A temporary array for thickness at h points [H ~> m or kg m-2]
+  real :: dz(SZI_(G),SZJ_(G),SZK_(GV)) ! Sponge layer thicknesses in height units [Z ~> m]
   real :: Idamp(SZI_(G),SZJ_(G))    ! The sponge damping rate at h points [T-1 ~> s-1]
   real :: TNUDG                     ! Nudging time scale [T ~> s]
   real :: pres(SZI_(G))             ! An array of the reference pressure [R L2 T-2 ~> Pa]
@@ -153,10 +153,10 @@ subroutine RGC_initialize_sponges(G, GV, US, tv, u, v, depth_tot, PF, use_ALE, C
   call MOM_read_data(filename, salt_var, S(:,:,:), G%Domain, scale=US%ppt_to_S)
   if (use_ALE) then
 
-    call MOM_read_data(filename, h_var, h(:,:,:), G%Domain, scale=GV%m_to_H)
-    call pass_var(h, G%domain)
+    call MOM_read_data(filename, h_var, dz(:,:,:), G%Domain, scale=US%m_to_Z)
+    call pass_var(dz, G%domain)
 
-    call initialize_ALE_sponge(Idamp, G, GV, PF, ACSp, h, nz)
+    call initialize_ALE_sponge(Idamp, G, GV, PF, ACSp, dz, nz, data_h_is_Z=.true.)
 
     !  The remaining calls to set_up_sponge_field can be in any order.
     if ( associated(tv%T) ) call set_up_ALE_sponge_field(T, G, GV, tv%T, ACSp, 'temp', &

--- a/src/user/Rossby_front_2d_initialization.F90
+++ b/src/user/Rossby_front_2d_initialization.F90
@@ -68,7 +68,7 @@ subroutine Rossby_front_initialize_thickness(h, G, GV, US, param_file, just_read
   call get_param(param_file, mdl, "REGRIDDING_COORDINATE_MODE", verticalCoordinate, &
                  default=DEFAULT_COORDINATE_MODE, do_not_log=just_read)
   call get_param(param_file, mdl, "T_RANGE", T_range, 'Initial temperature range', &
-                 units='C', default=0.0, scale=US%degC_to_C, do_not_log=just_read)
+                 units="degC", default=0.0, scale=US%degC_to_C, do_not_log=just_read)
   call get_param(param_file, mdl, "DRHO_DT", dRho_dT, &
                  units="kg m-3 degC-1", default=-0.2, scale=US%kg_m3_to_R*US%C_to_degC, do_not_log=.true.)
   call get_param(param_file, mdl, "MAXIMUM_DEPTH", max_depth, &
@@ -155,11 +155,11 @@ subroutine Rossby_front_initialize_temperature_salinity(T, S, h, G, GV, US, &
   call get_param(param_file, mdl,"REGRIDDING_COORDINATE_MODE", verticalCoordinate, &
                  default=DEFAULT_COORDINATE_MODE, do_not_log=just_read)
   call get_param(param_file, mdl, "S_REF", S_ref, 'Reference salinity', &
-                 default=35.0, units='1e-3', scale=US%ppt_to_S, do_not_log=just_read)
+                 default=35.0, units="ppt", scale=US%ppt_to_S, do_not_log=just_read)
   call get_param(param_file, mdl, "T_REF", T_ref, 'Reference temperature', &
-                 units='C', scale=US%degC_to_C, fail_if_missing=.not.just_read, do_not_log=just_read)
+                 units="degC", scale=US%degC_to_C, fail_if_missing=.not.just_read, do_not_log=just_read)
   call get_param(param_file, mdl, "T_RANGE", T_range, 'Initial temperature range', &
-                 units='C', default=0.0, scale=US%degC_to_C, do_not_log=just_read)
+                 units="degC", default=0.0, scale=US%degC_to_C, do_not_log=just_read)
   call get_param(param_file, mdl, "MAXIMUM_DEPTH", max_depth, &
                  units="m", default=-1.e9, scale=GV%m_to_H, do_not_log=.true.)
 
@@ -231,11 +231,11 @@ subroutine Rossby_front_initialize_velocity(u, v, h, G, GV, US, param_file, just
   call get_param(param_file, mdl, "REGRIDDING_COORDINATE_MODE", verticalCoordinate, &
                  default=DEFAULT_COORDINATE_MODE, do_not_log=just_read)
   call get_param(param_file, mdl, "T_RANGE", T_range, 'Initial temperature range', &
-                 units='C', default=0.0, scale=US%degC_to_C, do_not_log=just_read)
+                 units="degC", default=0.0, scale=US%degC_to_C, do_not_log=just_read)
   call get_param(param_file, mdl, "S_REF", S_ref, 'Reference salinity', &
-                 default=35.0, units='1e-3', scale=US%ppt_to_S, do_not_log=.true.)
+                 default=35.0, units="ppt", scale=US%ppt_to_S, do_not_log=.true.)
   call get_param(param_file, mdl, "T_REF", T_ref, 'Reference temperature', &
-                 units='C', scale=US%degC_to_C, fail_if_missing=.not.just_read, do_not_log=.true.)
+                 units="degC", scale=US%degC_to_C, fail_if_missing=.not.just_read, do_not_log=.true.)
   call get_param(param_file, mdl, "RHO_T0_S0", Rho_T0_S0, &
                  units="kg m-3", default=1000.0, scale=US%kg_m3_to_R, do_not_log=.true.)
   call get_param(param_file, mdl, "DRHO_DT", dRho_dT, &

--- a/src/user/SCM_CVMix_tests.F90
+++ b/src/user/SCM_CVMix_tests.F90
@@ -88,13 +88,13 @@ subroutine SCM_CVMix_tests_TS_init(T, S, h, G, GV, US, param_file, just_read)
                  'Initial salt mixed layer depth', &
                  units='m', default=0.0, scale=US%m_to_Z, do_not_log=just_read)
   call get_param(param_file, mdl, "SCM_L1_SALT", UpperLayerSalt, &
-                 'Layer 2 surface salinity', units='1e-3', default=35.0, scale=US%ppt_to_S, do_not_log=just_read)
+                 'Layer 2 surface salinity', units="ppt", default=35.0, scale=US%ppt_to_S, do_not_log=just_read)
   call get_param(param_file, mdl, "SCM_L1_TEMP", UpperLayerTemp, &
-                 'Layer 1 surface temperature', units='C', default=20.0, scale=US%degC_to_C, do_not_log=just_read)
+                 'Layer 1 surface temperature', units="degC", default=20.0, scale=US%degC_to_C, do_not_log=just_read)
   call get_param(param_file, mdl, "SCM_L2_SALT", LowerLayerSalt, &
-                 'Layer 2 surface salinity', units='1e-3', default=35.0, scale=US%ppt_to_S, do_not_log=just_read)
+                 'Layer 2 surface salinity', units="ppt", default=35.0, scale=US%ppt_to_S, do_not_log=just_read)
   call get_param(param_file, mdl, "SCM_L2_TEMP", LowerLayerTemp, &
-                 'Layer 2 surface temperature', units='C', default=20.0, scale=US%degC_to_C, do_not_log=just_read)
+                 'Layer 2 surface temperature', units="degC", default=20.0, scale=US%degC_to_C, do_not_log=just_read)
   call get_param(param_file, mdl, "SCM_L2_DTDZ", LowerLayerdTdZ,     &
                  'Initial temperature stratification in layer 2', &
                  units='C/m', default=0.0, scale=US%degC_to_C*US%Z_to_m, do_not_log=just_read)
@@ -102,7 +102,7 @@ subroutine SCM_CVMix_tests_TS_init(T, S, h, G, GV, US, param_file, just_read)
                  'Initial salinity stratification in layer 2', &
                  units='PPT/m', default=0.0, scale=US%ppt_to_S*US%Z_to_m, do_not_log=just_read)
   call get_param(param_file, mdl, "SCM_L2_MINTEMP",LowerLayerMinTemp, &
-                 'Layer 2 minimum temperature', units='C', default=4.0, scale=US%degC_to_C, do_not_log=just_read)
+                 'Layer 2 minimum temperature', units="degC", default=4.0, scale=US%degC_to_C, do_not_log=just_read)
 
   if (just_read) return ! All run-time parameters have been read, so return.
 

--- a/src/user/adjustment_initialization.F90
+++ b/src/user/adjustment_initialization.F90
@@ -76,12 +76,12 @@ subroutine adjustment_initialize_thickness ( h, G, GV, US, param_file, just_read
   ! Parameters used by main model initialization
   if (.not.just_read) call log_version(param_file, mdl, version, "")
   call get_param(param_file, mdl, "S_REF", S_ref, 'Reference salinity', &
-                 default=35.0, units='1e-3', scale=US%ppt_to_S, do_not_log=just_read)
+                 default=35.0, units='ppt', scale=US%ppt_to_S, do_not_log=just_read)
   call get_param(param_file, mdl, "MIN_THICKNESS", min_thickness, 'Minimum layer thickness', &
                  default=1.0e-3, units='m', scale=US%m_to_Z, do_not_log=just_read)
   call get_param(param_file, mdl, "DRHO_DS", dRho_dS, &
                  "The partial derivative of density with salinity with a linear equation of state.", &
-                 units="kg m-3 PSU-1", default=0.8, scale=US%kg_m3_to_R*US%S_to_ppt)
+                 units="kg m-3 ppt-1", default=0.8, scale=US%kg_m3_to_R*US%S_to_ppt)
 
   ! Parameters specific to this experiment configuration
   call get_param(param_file, mdl, "REGRIDDING_COORDINATE_MODE", verticalCoordinate, &
@@ -91,10 +91,10 @@ subroutine adjustment_initialize_thickness ( h, G, GV, US, param_file, just_read
                  units=G%x_ax_unit_short, fail_if_missing=.not.just_read, do_not_log=just_read)
   call get_param(param_file, mdl, "DELTA_S_STRAT", delta_S_strat,           &
                  "Top-to-bottom salinity difference of stratification",  &
-                 units="1e-3", scale=US%ppt_to_S, fail_if_missing=.not.just_read, do_not_log=just_read)
+                 units="ppt", scale=US%ppt_to_S, fail_if_missing=.not.just_read, do_not_log=just_read)
   call get_param(param_file, mdl, "ADJUSTMENT_DELTAS", adjustment_deltaS,   &
                  "Salinity difference across front",                     &
-                 units="1e-3", scale=US%ppt_to_S, fail_if_missing=.not.just_read, do_not_log=just_read)
+                 units="ppt", scale=US%ppt_to_S, fail_if_missing=.not.just_read, do_not_log=just_read)
   call get_param(param_file, mdl, "FRONT_WAVE_AMP", front_wave_amp,         &
                  "Amplitude of trans-frontal wave perturbation",         &
                  units=G%x_ax_unit_short, default=0., do_not_log=just_read)
@@ -239,11 +239,11 @@ subroutine adjustment_initialize_temperature_salinity(T, S, h, depth_tot, G, GV,
 
   ! Parameters used by main model initialization
   call get_param(param_file, mdl, "S_REF", S_ref, 'Reference salinity', &
-                 default=35.0, units='1e-3', scale=US%ppt_to_S, do_not_log=just_read)
+                 default=35.0, units="ppt", scale=US%ppt_to_S, do_not_log=just_read)
   call get_param(param_file, mdl, "T_REF", T_ref, 'Reference temperature', &
-                 units='C', scale=US%degC_to_C, fail_if_missing=.not.just_read, do_not_log=just_read)
+                 units="degC", scale=US%degC_to_C, fail_if_missing=.not.just_read, do_not_log=just_read)
   call get_param(param_file, mdl, "S_RANGE", S_range, 'Initial salinity range',  &
-                 default=2.0, units='1e-3', scale=US%ppt_to_S, do_not_log=just_read)
+                 default=2.0, units="ppt", scale=US%ppt_to_S, do_not_log=just_read)
   call get_param(param_file, mdl, "T_RANGE", T_range, 'Initial temperature range', &
                  default=1.0, units='degC', scale=US%degC_to_C, do_not_log=just_read)
   ! Parameters specific to this experiment configuration BUT logged in previous s/r
@@ -252,9 +252,9 @@ subroutine adjustment_initialize_temperature_salinity(T, S, h, depth_tot, G, GV,
   call get_param(param_file, mdl, "ADJUSTMENT_WIDTH", adjustment_width, &
                  units=G%x_ax_unit_short, fail_if_missing=.not.just_read, do_not_log=.true.)
   call get_param(param_file, mdl, "ADJUSTMENT_DELTAS", adjustment_deltaS, &
-                 units='1e-3', scale=US%ppt_to_S, fail_if_missing=.not.just_read, do_not_log=.true.)
+                 units="ppt", scale=US%ppt_to_S, fail_if_missing=.not.just_read, do_not_log=.true.)
   call get_param(param_file, mdl, "DELTA_S_STRAT", delta_S_strat, &
-                 units='1e-3', scale=US%ppt_to_S, fail_if_missing=.not.just_read, do_not_log=.true.)
+                 units="ppt", scale=US%ppt_to_S, fail_if_missing=.not.just_read, do_not_log=.true.)
   call get_param(param_file, mdl, "FRONT_WAVE_AMP", front_wave_amp, &
                  units=G%x_ax_unit_short, default=0., do_not_log=.true.)
   call get_param(param_file, mdl, "FRONT_WAVE_LENGTH", front_wave_length, &

--- a/src/user/basin_builder.F90
+++ b/src/user/basin_builder.F90
@@ -27,13 +27,13 @@ contains
 subroutine basin_builder_topography(D, G, param_file, max_depth)
   type(dyn_horgrid_type),  intent(in)  :: G !< The dynamic horizontal grid type
   real, dimension(G%isd:G%ied,G%jsd:G%jed), &
-                           intent(out) :: D !< Ocean bottom depth in the units of depth_max
+                           intent(out) :: D !< Ocean bottom depth in the units of depth_max [A]
   type(param_file_type),   intent(in)  :: param_file !< Parameter file structure
-  real,                    intent(in)  :: max_depth !< Maximum ocean depth in arbitrary units
+  real,                    intent(in)  :: max_depth !< Maximum ocean depth in arbitrary units [A]
   ! Local variables
   character(len=17) :: pname1, pname2 ! For construction of parameter names
   character(len=20) :: funcs ! Basin build function
-  real, dimension(20) :: pars ! Parameters for each function
+  real, dimension(20) :: pars ! Parameters for each function [various]
   real :: lon ! Longitude [degrees_E]
   real :: lat ! Latitude [degrees_N]
   integer :: i, j, n, n_funcs
@@ -161,9 +161,9 @@ end subroutine basin_builder_topography
 !! If clip is present the top of the cone is cut off at "clip", which
 !! effectively defaults to 1.
 real function cone(x, x0, L, clip)
-  real,           intent(in) :: x    !< non-dimensional coordinate [nondim]
-  real,           intent(in) :: x0   !< position of peak [nondim]
-  real,           intent(in) :: L    !< half-width of base of cone [nondim]
+  real,           intent(in) :: x    !< Coordinate in arbitrary units [A]
+  real,           intent(in) :: x0   !< position of peak in arbitrary units [A]
+  real,           intent(in) :: L    !< half-width of base of cone in arbitrary units [A]
   real, optional, intent(in) :: clip !< clipping height of cone [nondim]
 
   cone = max( 0., 1. - abs(x - x0) / L )
@@ -172,10 +172,10 @@ end function cone
 
 !> Returns an s-curve s(x) s.t. s(x0)<=0, s(x0+L)>=1 and cubic in between.
 real function scurve(x, x0, L)
-  real, intent(in) :: x       !< non-dimensional coordinate [nondim]
-  real, intent(in) :: x0      !< position of peak [nondim]
-  real, intent(in) :: L       !< half-width of base of cone [nondim]
-  real :: s
+  real, intent(in) :: x       !< Coordinate in arbitrary units [A]
+  real, intent(in) :: x0      !< position of peak in arbitrary units [A]
+  real, intent(in) :: L       !< half-width of base of cone in arbitrary units [A]
+  real :: s ! A rescaled position [nondim]
 
   s = max( 0., min( 1.,( x - x0 ) / L ) )
   scurve = ( 3. - 2.*s ) * ( s * s )
@@ -183,14 +183,14 @@ end function scurve
 
 !> Returns a "coastal" profile.
 real function cstprof(x, x0, L, lf, bf, sf, sh)
-  real, intent(in) :: x       !< non-dimensional coordinate [nondim]
-  real, intent(in) :: x0      !< position of peak [nondim]
-  real, intent(in) :: L       !< width of profile [nondim]
+  real, intent(in) :: x       !< Coordinate in arbitrary units [A]
+  real, intent(in) :: x0      !< position of peak in arbitrary units [A]
+  real, intent(in) :: L       !< width of profile in arbitrary units [A]
   real, intent(in) :: lf      !< fraction of width that is "land" [nondim]
   real, intent(in) :: bf      !< fraction of width that is "beach" [nondim]
   real, intent(in) :: sf      !< fraction of width that is "continental slope" [nondim]
   real, intent(in) :: sh      !< depth of shelf as fraction of full depth [nondim]
-  real :: s
+  real :: s ! A rescaled position [nondim]
 
   s = max( 0., min( 1.,( x - x0 ) / L ) )
   cstprof = sh * scurve(s-lf,0.,bf) + (1.-sh) * scurve(s - (1.-sf),0.,sf)
@@ -198,12 +198,12 @@ end function cstprof
 
 !> Distance between points x,y and a line segment (x0,y0) and (x0,y1).
 real function dist_line_fixed_x(x, y, x0, y0, y1)
-  real, intent(in) :: x       !< non-dimensional x-coordinate [nondim]
-  real, intent(in) :: y       !< non-dimensional y-coordinate [nondim]
-  real, intent(in) :: x0      !< x-position of line segment [nondim]
-  real, intent(in) :: y0      !< y-position of line segment end[nondim]
-  real, intent(in) :: y1      !< y-position of line segment end[nondim]
-  real :: dx, yr, dy
+  real, intent(in) :: x       !< X-coordinate in arbitrary units [A]
+  real, intent(in) :: y       !< Y-coordinate in arbitrary units [A]
+  real, intent(in) :: x0      !< x-position of line segment in arbitrary units [A]
+  real, intent(in) :: y0      !< y-position of line segment end in arbitrary units [A]
+  real, intent(in) :: y1      !< y-position of line segment end in arbitrary units [A]
+  real :: dx, yr, dy ! Relative positions in arbitrary units [A]
 
   dx = x - x0
   yr = min( max(y0,y1), max( min(y0,y1), y ) ) ! bound y by y0,y1
@@ -213,11 +213,11 @@ end function dist_line_fixed_x
 
 !> Distance between points x,y and a line segment (x0,y0) and (x1,y0).
 real function dist_line_fixed_y(x, y, x0, x1, y0)
-  real, intent(in) :: x       !< non-dimensional x-coordinate [nondim]
-  real, intent(in) :: y       !< non-dimensional y-coordinate [nondim]
-  real, intent(in) :: x0      !< x-position of line segment end[nondim]
-  real, intent(in) :: x1      !< x-position of line segment end[nondim]
-  real, intent(in) :: y0      !< y-position of line segment [nondim]
+  real, intent(in) :: x       !< X-coordinate in arbitrary units [A]
+  real, intent(in) :: y       !< Y-coordinate in arbitrary units [A]
+  real, intent(in) :: x0      !< x-position of line segment end in arbitrary units [A]
+  real, intent(in) :: x1      !< x-position of line segment end in arbitrary units [A]
+  real, intent(in) :: y0      !< y-position of line segment in arbitrary units [A]
 
   dist_line_fixed_y = dist_line_fixed_x(y, x, y0, x0, x1)
 end function dist_line_fixed_y
@@ -230,10 +230,11 @@ real function angled_coast(lon, lat, lon_eq, lat_mer, dr, sh)
   real, intent(in) :: lat_mer !< Latitude intersection with Prime Meridian [degrees_N]
   real, intent(in) :: dr      !< "Radius" of coast profile [degrees]
   real, intent(in) :: sh      !< depth of shelf as fraction of full depth [nondim]
-  real :: r
+  real :: r ! A relative position [degrees]
+  real :: I_dr ! The inverse of a distance [degrees-1]
 
-  r = 1/sqrt( lat_mer*lat_mer + lon_eq*lon_eq )
-  r = r * ( lat_mer*lon + lon_eq*lat - lon_eq*lat_mer)
+  I_dr = 1/sqrt( lat_mer*lat_mer + lon_eq*lon_eq )
+  r = I_dr * ( lat_mer*lon + lon_eq*lat - lon_eq*lat_mer)
   angled_coast = cstprof(r, 0., dr, 0.125, 0.125, 0.5, sh)
 end function angled_coast
 
@@ -246,7 +247,7 @@ real function NS_coast(lon, lat, lonC, lat0, lat1, dlon, sh)
   real, intent(in) :: lat1    !< Latitude of coast end [degrees_N]
   real, intent(in) :: dlon    !< "Radius" of coast profile [degrees]
   real, intent(in) :: sh      !< depth of shelf as fraction of full depth [nondim]
-  real :: r
+  real :: r  ! A relative position [degrees]
 
   r = dist_line_fixed_x( lon, lat, lonC, lat0, lat1 )
   NS_coast = cstprof(r, 0., dlon, 0.125, 0.125, 0.5, sh)
@@ -261,7 +262,7 @@ real function EW_coast(lon, lat, latC, lon0, lon1, dlat, sh)
   real, intent(in) :: lon1    !< Longitude of coast end [degrees_E]
   real, intent(in) :: dlat    !< "Radius" of coast profile [degrees]
   real, intent(in) :: sh      !< depth of shelf as fraction of full depth [nondim]
-  real :: r
+  real :: r  ! A relative position [degrees]
 
   r = dist_line_fixed_y( lon, lat, lon0, lon1, latC )
   EW_coast = cstprof(r, 0., dlat, 0.125, 0.125, 0.5, sh)
@@ -276,7 +277,7 @@ real function NS_conic_ridge(lon, lat, lonC, lat0, lat1, dlon, rh)
   real, intent(in) :: lat1    !< Latitude of ridge end [degrees_N]
   real, intent(in) :: dlon    !< "Radius" of ridge profile [degrees]
   real, intent(in) :: rh      !< depth of ridge as fraction of full depth [nondim]
-  real :: r
+  real :: r  ! A relative position [degrees]
 
   r = dist_line_fixed_x( lon, lat, lonC, lat0, lat1 )
   NS_conic_ridge = 1. - rh * cone(r, 0., dlon)
@@ -291,7 +292,7 @@ real function NS_scurve_ridge(lon, lat, lonC, lat0, lat1, dlon, rh)
   real, intent(in) :: lat1    !< Latitude of ridge end [degrees_N]
   real, intent(in) :: dlon    !< "Radius" of ridge profile [degrees]
   real, intent(in) :: rh      !< depth of ridge as fraction of full depth [nondim]
-  real :: r
+  real :: r  ! A relative position [degrees]
 
   r = dist_line_fixed_x( lon, lat, lonC, lat0, lat1 )
   NS_scurve_ridge = 1. - rh * (1. - scurve(r, 0., dlon) )
@@ -306,12 +307,13 @@ real function circ_conic_ridge(lon, lat, lon0, lat0, ring_radius, ring_thickness
   real, intent(in) :: ring_radius    !< Radius of ring [degrees]
   real, intent(in) :: ring_thickness !< Radial thickness of ring [degrees]
   real, intent(in) :: ridge_height   !< Ridge height as fraction of full depth [nondim]
-  real :: r
+  real :: r  ! A relative position [degrees]
+  real :: frac_ht ! The fractional height of the topography [nondim]
 
   r = sqrt( (lon - lon0)**2 + (lat - lat0)**2 ) ! Pseudo-distance from a point
   r = abs( r - ring_radius) ! Pseudo-distance from a circle
-  r = cone(r, 0., ring_thickness, ridge_height) ! 0 .. frac_ridge_height
-  circ_conic_ridge = 1. - r ! nondim depths (1-frac_ridge_height) .. 1
+  frac_ht = cone(r, 0., ring_thickness, ridge_height) ! 0 .. frac_ridge_height
+  circ_conic_ridge = 1. - frac_ht ! nondim depths (1-frac_ridge_height) .. 1
 end function circ_conic_ridge
 
 !> A circular ridge with cutoff scurve profile
@@ -323,13 +325,15 @@ real function circ_scurve_ridge(lon, lat, lon0, lat0, ring_radius, ring_thicknes
   real, intent(in) :: ring_radius    !< Radius of ring [degrees]
   real, intent(in) :: ring_thickness !< Radial thickness of ring [degrees]
   real, intent(in) :: ridge_height   !< Ridge height as fraction of full depth [nondim]
-  real :: r
+  real :: r  ! A relative position [degrees]
+  real :: s  ! A function of the normalized position [nondim]
+  real :: frac_ht ! The fractional height of the topography [nondim]
 
   r = sqrt( (lon - lon0)**2 + (lat - lat0)**2 ) ! Pseudo-distance from a point
   r = abs( r - ring_radius) ! Pseudo-distance from a circle
-  r = 1. - scurve(r, 0., ring_thickness) ! 0 .. 1
-  r = r * ridge_height ! 0 .. frac_ridge_height
-  circ_scurve_ridge = 1. - r ! nondim depths (1-frac_ridge_height) .. 1
+  s = 1. - scurve(r, 0., ring_thickness) ! 0 .. 1
+  frac_ht = s * ridge_height ! 0 .. frac_ridge_height
+  circ_scurve_ridge = 1. - frac_ht ! nondim depths (1-frac_ridge_height) .. 1
 end function circ_scurve_ridge
 
 end module basin_builder

--- a/src/user/benchmark_initialization.F90
+++ b/src/user/benchmark_initialization.F90
@@ -142,7 +142,7 @@ subroutine benchmark_initialize_thickness(h, depth_tot, G, GV, US, param_file, e
                  units="degC", default=29.0, scale=US%degC_to_C, do_not_log=just_read)
   call get_param(param_file, mdl, "S_REF", S_ref, &
                  "The uniform salinities used to initialize the benchmark test case.", &
-                 units="PSU", default=35.0, scale=US%ppt_to_S, do_not_log=just_read)
+                 units="ppt", default=35.0, scale=US%ppt_to_S, do_not_log=just_read)
 
   if (just_read) return ! This subroutine has no run-time parameters.
 

--- a/src/user/dense_water_initialization.F90
+++ b/src/user/dense_water_initialization.F90
@@ -122,11 +122,11 @@ subroutine dense_water_initialize_TS(G, GV, US, param_file, T, S, h, just_read)
        "Depth of unstratified mixed layer as a fraction of the water column.", &
        units="nondim", default=default_mld, do_not_log=just_read)
   call get_param(param_file, mdl, "S_REF", S_ref, 'Reference salinity', &
-                 default=35.0, units='1e-3', scale=US%ppt_to_S, do_not_log=just_read)
+                 default=35.0, units="ppt", scale=US%ppt_to_S, do_not_log=just_read)
   call get_param(param_file, mdl,"T_REF", T_ref, 'Reference temperature', &
                 units='degC', scale=US%degC_to_C, fail_if_missing=.not.just_read, do_not_log=just_read)
   call get_param(param_file, mdl,"S_RANGE", S_range, 'Initial salinity range', &
-                units='1e-3', default=2.0, scale=US%ppt_to_S, do_not_log=just_read)
+                units="ppt", default=2.0, scale=US%ppt_to_S, do_not_log=just_read)
 
   if (just_read) return ! All run-time parameters have been read, so return.
 
@@ -204,7 +204,7 @@ subroutine dense_water_initialize_sponges(G, GV, US, tv, depth_tot, param_file, 
                  units="nondim", default=0.1)
   call get_param(param_file, mdl, "DENSE_WATER_EAST_SPONGE_SALT", S_dense, &
                  "Salt anomaly of the dense water being formed in the overflow region.", &
-                 units="1e-3", default=4.0, scale=US%ppt_to_S)
+                 units="ppt", default=4.0, scale=US%ppt_to_S)
 
   call get_param(param_file, mdl, "DENSE_WATER_MLD", mld, &
                  units="nondim", default=default_mld, do_not_log=.true.)
@@ -212,9 +212,9 @@ subroutine dense_water_initialize_sponges(G, GV, US, tv, depth_tot, param_file, 
                  units="nondim", default=default_sill, do_not_log=.true.)
 
   call get_param(param_file, mdl, "S_REF", S_ref, &
-                 units='1e-3', default=35.0, scale=US%ppt_to_S, do_not_log=.true.)
+                 units="ppt", default=35.0, scale=US%ppt_to_S, do_not_log=.true.)
   call get_param(param_file, mdl, "S_RANGE", S_range, &
-                 units='1e-3', default=2.0, scale=US%ppt_to_S, do_not_log=.true.)
+                 units="ppt", default=2.0, scale=US%ppt_to_S, do_not_log=.true.)
   call get_param(param_file, mdl, "T_REF", T_ref, &
                  units='degC', scale=US%degC_to_C, fail_if_missing=.true., do_not_log=.true.)
 

--- a/src/user/dumbbell_initialization.F90
+++ b/src/user/dumbbell_initialization.F90
@@ -9,7 +9,6 @@ use MOM_error_handler, only : MOM_mesg, MOM_error, FATAL, is_root_pe
 use MOM_file_parser, only : get_param, log_version, param_file_type
 use MOM_get_input, only : directories
 use MOM_grid, only : ocean_grid_type
-use MOM_interface_heights, only : dz_to_thickness, dz_to_thickness_simple
 use MOM_interface_heights, only : thickness_to_dz
 use MOM_sponge, only : set_up_sponge_field, initialize_sponge, sponge_CS
 use MOM_tracer_registry, only : tracer_registry_type
@@ -352,7 +351,6 @@ subroutine dumbbell_initialize_sponges(G, GV, US, tv, h_in, depth_tot, param_fil
 
   real, dimension(SZI_(G),SZJ_(G)) :: Idamp ! inverse damping timescale [T-1 ~> s-1]
   real :: dz(SZI_(G),SZJ_(G),SZK_(GV)) ! Sponge thicknesses in height units [Z ~> m]
-  real :: h(SZI_(G),SZJ_(G),SZK_(GV))  ! Sponge thicknesses [H ~> m or kg m-2]
   real :: S(SZI_(G),SZJ_(G),SZK_(GV))  ! Sponge salinities [S ~> ppt]
   real :: T(SZI_(G),SZJ_(G),SZK_(GV))  ! Sponge tempertures [C ~> degC], used only to convert thicknesses
                                        ! in non-Boussinesq mode
@@ -460,15 +458,8 @@ subroutine dumbbell_initialize_sponges(G, GV, US, tv, h_in, depth_tot, param_fil
       endif
     enddo ; enddo
 
-    ! Convert thicknesses from height units to thickness units
-    if (associated(tv%eqn_of_state)) then
-      call dz_to_thickness(dz, T, S, tv%eqn_of_state, h, G, GV, US)
-    else
-      call dz_to_thickness_simple(dz, h, G, GV, US, layer_mode=.true.)
-    endif
-
     ! Store damping rates and the grid on which the T/S sponge data will reside
-    call initialize_ALE_sponge(Idamp, G, GV, param_file, ACSp, h, nz)
+    call initialize_ALE_sponge(Idamp, G, GV, param_file, ACSp, dz, nz, data_h_is_Z=.true.)
 
     if (associated(tv%S)) call set_up_ALE_sponge_field(S, G, GV, tv%S, ACSp, 'salt', &
                           sp_long_name='salinity', sp_unit='g kg-1 s-1')

--- a/src/user/dumbbell_initialization.F90
+++ b/src/user/dumbbell_initialization.F90
@@ -183,15 +183,15 @@ subroutine dumbbell_initialize_thickness ( h, depth_tot, G, GV, US, param_file, 
 
   case ( REGRIDDING_RHO, REGRIDDING_HYCOM1) ! Initial thicknesses for isopycnal coordinates
     call get_param(param_file, mdl, "INITIAL_SSS", S_surf, &
-                   units='1e-3', default=34., scale=US%ppt_to_S, do_not_log=.true.)
+                   units="ppt", default=34., scale=US%ppt_to_S, do_not_log=.true.)
     call get_param(param_file, mdl, "INITIAL_S_RANGE", S_range, &
-                   units='1e-3', default=2., scale=US%ppt_to_S, do_not_log=.true.)
+                   units="ppt", default=2., scale=US%ppt_to_S, do_not_log=.true.)
     call get_param(param_file, mdl, "S_REF", S_ref, &
-                   units='1e-3', default=35.0, scale=US%ppt_to_S, do_not_log=.true.)
+                   units="ppt", default=35.0, scale=US%ppt_to_S, do_not_log=.true.)
     call get_param(param_file, mdl, "TS_RANGE_S_LIGHT", S_light, &
-                   units='1e-3', default=US%S_to_ppt*S_Ref, scale=US%ppt_to_S, do_not_log=.true.)
+                   units="ppt", default=US%S_to_ppt*S_Ref, scale=US%ppt_to_S, do_not_log=.true.)
     call get_param(param_file, mdl, "TS_RANGE_S_DENSE", S_dense, &
-                   units='1e-3', default=US%S_to_ppt*S_Ref, scale=US%ppt_to_S, do_not_log=.true.)
+                   units="ppt", default=US%S_to_ppt*S_Ref, scale=US%ppt_to_S, do_not_log=.true.)
     call get_param(param_file, mdl, "INTERFACE_IC_QUANTA", eta_IC_quanta, &
                    "The granularity of initial interface height values "//&
                    "per meter, to avoid sensivity to order-of-arithmetic changes.", &
@@ -291,10 +291,10 @@ subroutine dumbbell_initialize_temperature_salinity ( T, S, h, G, GV, US, param_
                  units='degC', default=20., scale=US%degC_to_C, do_not_log=just_read)
   call get_param(param_file, mdl, "DUMBBELL_SREF", S_surf, &
                  'DUMBBELL REFERENCE SALINITY', &
-                 units='1e-3', default=34., scale=US%ppt_to_S, do_not_log=just_read)
+                 units="ppt", default=34., scale=US%ppt_to_S, do_not_log=just_read)
   call get_param(param_file, mdl, "DUMBBELL_S_RANGE", S_range, &
                  'DUMBBELL salinity range (right-left)', &
-                 units='1e-3', default=2., scale=US%ppt_to_S, do_not_log=just_read)
+                 units="ppt", default=2., scale=US%ppt_to_S, do_not_log=just_read)
   call get_param(param_file, mdl, "DUMBBELL_LEN", dblen, &
                  'Lateral Length scale for dumbbell ', &
                  units=G%x_ax_unit_short, default=600., do_not_log=just_read)
@@ -388,10 +388,10 @@ subroutine dumbbell_initialize_sponges(G, GV, US, tv, h_in, depth_tot, param_fil
                  units='degC', default=20., scale=US%degC_to_C, do_not_log=.true.)
   call get_param(param_file, mdl, "DUMBBELL_SREF", S_ref, &
                  'DUMBBELL REFERENCE SALINITY', &
-                 units='1e-3', default=34., scale=US%ppt_to_S, do_not_log=.true.)
+                 units="ppt", default=34., scale=US%ppt_to_S, do_not_log=.true.)
   call get_param(param_file, mdl, "DUMBBELL_S_RANGE", S_range, &
                  'DUMBBELL salinity range (right-left)', &
-                 units='1e-3', default=2., scale=US%ppt_to_S, do_not_log=.true.)
+                 units="ppt", default=2., scale=US%ppt_to_S, do_not_log=.true.)
   call get_param(param_file, mdl,"MIN_THICKNESS", min_thickness, &
                 'Minimum thickness for layer', &
                  units='m', default=1.0e-3, scale=US%m_to_Z, do_not_log=.true.)

--- a/src/user/dumbbell_surface_forcing.F90
+++ b/src/user/dumbbell_surface_forcing.F90
@@ -221,10 +221,10 @@ subroutine dumbbell_surface_forcing_init(Time, G, US, param_file, diag, CS)
                  default=.false., do_not_log=.true.)
   call get_param(param_file, mdl,"INITIAL_SSS", S_surf, &
                  "Initial surface salinity", &
-                 units="1e-3", default=34.0, scale=US%ppt_to_S, do_not_log=.true.)
+                 units="ppt", default=34.0, scale=US%ppt_to_S, do_not_log=.true.)
   call get_param(param_file, mdl,"INITIAL_S_RANGE", S_range, &
                  "Initial salinity range (bottom - surface)", &
-                 units="1e-3", default=2., scale=US%ppt_to_S, do_not_log=.true.)
+                 units="ppt", default=2., scale=US%ppt_to_S, do_not_log=.true.)
 
   call get_param(param_file, mdl, "RESTOREBUOY", CS%restorebuoy, &
                  "If true, the buoyancy fluxes drive the model back "//&

--- a/src/user/seamount_initialization.F90
+++ b/src/user/seamount_initialization.F90
@@ -233,16 +233,16 @@ subroutine seamount_initialize_temperature_salinity(T, S, h, G, GV, US, param_fi
                  'and "exponential".', default='linear', do_not_log=just_read)
   call get_param(param_file, mdl,"INITIAL_SSS", S_surf, &
                  'Initial surface salinity', &
-                 units='1e-3', default=34., scale=US%ppt_to_S, do_not_log=just_read)
+                 units="ppt", default=34., scale=US%ppt_to_S, do_not_log=just_read)
   call get_param(param_file, mdl,"INITIAL_SST", T_surf, &
                  'Initial surface temperature', &
-                 units='C', default=0., scale=US%degC_to_C, do_not_log=just_read)
+                 units="degC", default=0., scale=US%degC_to_C, do_not_log=just_read)
   call get_param(param_file, mdl,"INITIAL_S_RANGE", S_range, &
                  'Initial salinity range (bottom - surface)', &
-                 units='1e-3', default=2., scale=US%ppt_to_S, do_not_log=just_read)
+                 units="ppt", default=2., scale=US%ppt_to_S, do_not_log=just_read)
   call get_param(param_file, mdl,"INITIAL_T_RANGE", T_range, &
                  'Initial temperature range (bottom - surface)', &
-                 units='C', default=0., scale=US%degC_to_C, do_not_log=just_read)
+                 units="degC", default=0., scale=US%degC_to_C, do_not_log=just_read)
 
   select case ( coordinateMode(verticalCoordinate) )
     case ( REGRIDDING_LAYER ) ! Initial thicknesses for layer isopycnal coordinates
@@ -254,11 +254,11 @@ subroutine seamount_initialize_temperature_salinity(T, S, h, G, GV, US, param_fi
       call get_param(param_file, mdl, "TS_RANGE_T_DENSE", T_dense, &
                  units="degC", default=US%C_to_degC*T_Ref, scale=US%degC_to_C, do_not_log=.true.)
       call get_param(param_file, mdl, "S_REF", S_ref, &
-                 units="1e-3", default=35.0, scale=US%ppt_to_S, do_not_log=.true.)
+                 units="ppt", default=35.0, scale=US%ppt_to_S, do_not_log=.true.)
       call get_param(param_file, mdl, "TS_RANGE_S_LIGHT", S_light, &
-                 units="1e-3", default=US%S_to_ppt*S_Ref, scale=US%ppt_to_S, do_not_log=.true.)
+                 units="ppt", default=US%S_to_ppt*S_Ref, scale=US%ppt_to_S, do_not_log=.true.)
       call get_param(param_file, mdl, "TS_RANGE_S_DENSE", S_dense, &
-                 units="1e-3", default=US%S_to_ppt*S_Ref, scale=US%ppt_to_S, do_not_log=.true.)
+                 units="ppt", default=US%S_to_ppt*S_Ref, scale=US%ppt_to_S, do_not_log=.true.)
       call get_param(param_file, mdl, "TS_RANGE_RESOLN_RATIO", res_rat, &
                  units="nondim", default=1.0, do_not_log=.true.)
       if (just_read) return ! All run-time parameters have been read, so return.

--- a/src/user/sloshing_initialization.F90
+++ b/src/user/sloshing_initialization.F90
@@ -201,17 +201,17 @@ subroutine sloshing_initialize_temperature_salinity ( T, S, h, G, GV, US, param_
   is = G%isc ; ie = G%iec ; js = G%jsc ; je = G%jec ; nz = GV%ke
 
   call get_param(param_file, mdl, "S_REF", S_ref, 'Reference value for salinity', &
-                 default=35.0, units='1e-3', scale=US%ppt_to_S, do_not_log=just_read)
+                 default=35.0, units="ppt", scale=US%ppt_to_S, do_not_log=just_read)
   call get_param(param_file, mdl, "T_REF", T_ref, 'Reference value for temperature', &
                  units='degC', scale=US%degC_to_C, fail_if_missing=.not.just_read, do_not_log=just_read)
 
   ! The default is to assume an increase by 2 ppt for the salinity and a uniform temperature.
   call get_param(param_file, mdl, "S_RANGE", S_range, 'Initial salinity range.', &
-                 units='1e-3', default=2.0, scale=US%ppt_to_S, do_not_log=just_read)
+                 units="ppt", default=2.0, scale=US%ppt_to_S, do_not_log=just_read)
   call get_param(param_file, mdl, "T_RANGE", T_range, 'Initial temperature range', &
                  units='degC', default=0.0, scale=US%degC_to_C, do_not_log=just_read)
   call get_param(param_file, mdl, "INITIAL_SSS", S_surf, "Initial surface salinity", &
-                 units="1e-3", default=34.0, scale=US%ppt_to_S, do_not_log=just_read)
+                 units="ppt", default=34.0, scale=US%ppt_to_S, do_not_log=just_read)
   call get_param(param_file, mdl, "SLOSHING_T_PERT", T_pert, &
                  'A mid-column temperature perturbation in the sloshing test case', &
                  units='degC', default=1.0, scale=US%degC_to_C, do_not_log=just_read)

--- a/src/user/soliton_initialization.F90
+++ b/src/user/soliton_initialization.F90
@@ -26,8 +26,9 @@ public soliton_initialize_velocity
 
 contains
 
-!> Initialization of thicknesses in Equatorial Rossby soliton test
-subroutine soliton_initialize_thickness(h, depth_tot, G, GV, US)
+!> Initialization of thicknesses in equatorial Rossby soliton test, as described in section
+!! 6.1 of Haidvogel and Beckman (1990) and in Boyd (1980, JPO) and Boyd (1985, JPO).
+subroutine soliton_initialize_thickness(h, depth_tot, G, GV, US, param_file, just_read)
   type(ocean_grid_type),   intent(in)  :: G    !< The ocean's grid structure.
   type(verticalGrid_type), intent(in)  :: GV   !< The ocean's vertical grid structure.
   type(unit_scale_type),   intent(in)  :: US   !< A dimensional unit scaling type
@@ -35,45 +36,96 @@ subroutine soliton_initialize_thickness(h, depth_tot, G, GV, US)
                            intent(out) :: h    !< The thickness that is being initialized [Z ~> m]
   real, dimension(SZI_(G),SZJ_(G)), &
                            intent(in)  :: depth_tot !< The nominal total depth of the ocean [Z ~> m]
+  type(param_file_type),   intent(in)  :: param_file  !< A structure indicating the open file
+                                                      !! to parse for model parameter values.
+  logical,                 intent(in)  :: just_read   !< If true, this call will only read
+                                                      !! parameters without changing h.
 
+  ! Local variables
+  real    :: max_depth  ! Maximum depth of the model bathymetry [Z ~> m]
+  real    :: cg_max     ! The external wave speed based on max_depth [L T-1 ~> m s-1]
+  real    :: beta       ! The meridional gradient of the Coriolis parameter [T-1 L-1 ~> s-1 m-1]
+  real    :: L_eq       ! The equatorial deformation radius used in nondimensionalizing this problem [L ~> m]
+  real    :: scale_pos  ! A conversion factor to nondimensionalize the axis units, usually [m-1]
+  real    :: x0    ! Initial x-position of the soliton in the same units as geoLonT, often [m].
+  real    :: y0    ! Initial y-position of the soliton in the same units as geoLatT, often [m].
+  real    :: x, y  ! Nondimensionalized positions [nondim]
+  real    :: I_nz  ! The inverse of the number of layers [nondim]
+  real    :: val1  ! A nondimensionlized zonal decay scale [nondim]
+  real    :: val2  ! An overall surface height anomaly amplitude [L T-1 ~> m s-1]
+  real    :: val3  ! A decay factor [nondim]
+  real    :: val4  ! The local velocity amplitude [L T-1 ~> m s-1]
+  ! This include declares and sets the variable "version".
+# include "version_variable.h"
   integer :: i, j, k, is, ie, js, je, nz
-  real    :: x, y, x0, y0
-  real    :: val1, val2, val3, val4
 
   is = G%isc ; ie = G%iec ; js = G%jsc ; je = G%jec ; nz = GV%ke
 
-  call MOM_mesg("soliton_initialization.F90, soliton_initialize_thickness: setting thickness")
+  if (.not.just_read) &
+    call MOM_mesg("soliton_initialization.F90, soliton_initialize_thickness: setting thickness")
+
+  if (.not.just_read) call log_version(param_file, mdl, version, "")
+  call get_param(param_file, mdl, "MAXIMUM_DEPTH", max_depth, &
+                 units="m", default=-1.e9, scale=US%m_to_Z, do_not_log=.true.)
+  call get_param(param_file, mdl, "BETA", beta, &
+                 "The northward gradient of the Coriolis parameter with the betaplane option.", &
+                 units="m-1 s-1", default=0.0, scale=US%T_to_s*US%L_to_m, do_not_log=.true.)
+
+  if (just_read) return ! All run-time parameters have been read, so return.
+
+  if (max_depth <= 0.0) call MOM_error(FATAL, &
+      "soliton_initialization, soliton_initialize_thickness: "//&
+      "This module requires a positive value of MAXIMUM_DEPTH.")
+  if (abs(beta) <= 0.0) call MOM_error(FATAL, &
+      "soliton_initialization, soliton_initialize_thickness: "//&
+      "This module requires a non-zero value of BETA.")
+
+  cg_max = sqrt(GV%g_Earth * max_depth)
+  L_eq = sqrt(cg_max / abs(beta))
+  scale_pos = US%m_to_L / L_eq
+  I_nz = 1.0 / real(nz)
 
   x0 = 2.0*G%len_lon/3.0
   y0 = 0.0
   val1 = 0.395
-  val2 = US%m_to_Z * 0.771*(val1*val1)
+  val2 = max_depth * 0.771*(val1*val1)
 
   do j = G%jsc,G%jec ; do i = G%isc,G%iec
     do k = 1, nz
-      x = G%geoLonT(i,j)-x0
-      y = G%geoLatT(i,j)-y0
+      x = (G%geoLonT(i,j)-x0) * scale_pos
+      y = (G%geoLatT(i,j)-y0) * scale_pos
       val3 = exp(-val1*x)
       val4 = val2 * ( 2.0*val3 / (1.0 + (val3*val3)) )**2
-      h(i,j,k) = (0.25*val4*(6.0*y*y + 3.0) * exp(-0.5*y*y) + depth_tot(i,j))
+      h(i,j,k) = (0.25*val4*(6.0*y*y + 3.0) * exp(-0.5*y*y) + depth_tot(i,j)) * I_nz
     enddo
   enddo ; enddo
 
 end subroutine soliton_initialize_thickness
 
 
-!> Initialization of u and v in the equatorial Rossby soliton test
-subroutine soliton_initialize_velocity(u, v, G, GV, US)
+!> Initialization of u and v in the equatorial Rossby soliton test, as described in section
+!! 6.1 of Haidvogel and Beckman (1990) and in Boyd (1980, JPO) and Boyd (1985, JPO).
+subroutine soliton_initialize_velocity(u, v, G, GV, US, param_file, just_read)
   type(ocean_grid_type),                      intent(in)  :: G  !< Grid structure
   type(verticalGrid_type),                    intent(in)  :: GV !< The ocean's vertical grid structure
   real, dimension(SZIB_(G),SZJ_(G),SZK_(GV)), intent(out) :: u  !< i-component of velocity [L T-1 ~> m s-1]
   real, dimension(SZI_(G),SZJB_(G),SZK_(GV)), intent(out) :: v  !< j-component of velocity [L T-1 ~> m s-1]
   type(unit_scale_type),                      intent(in)  :: US !< A dimensional unit scaling type
+  type(param_file_type),   intent(in)  :: param_file  !< A structure indicating the open file
+                                                      !! to parse for model parameter values.
+  logical,                 intent(in)  :: just_read   !< If true, this call will only read
+                                                      !! parameters without changing h.
 
   ! Local variables
-  real    :: x, x0 ! Positions in the same units as geoLonT.
-  real    :: y, y0 ! Positions in the same units as geoLatT.
-  real    :: val1  ! A zonal decay scale in the inverse of the units of geoLonT.
+  real    :: max_depth  ! Maximum depth of the model bathymetry [Z ~> m]
+  real    :: cg_max     ! The external wave speed based on max_depth [L T-1 ~> m s-1]
+  real    :: beta       ! The meridional gradient of the Coriolis parameter [T-1 L-1 ~> s-1 m-1]
+  real    :: L_eq       ! The equatorial deformation radius used in nondimensionalizing this problem [L ~> m]
+  real    :: scale_pos  ! A conversion factor to nondimensionalize the axis units, usually [m-1]
+  real    :: x0    ! Initial x-position of the soliton in the same units as geoLonT, often [m].
+  real    :: y0    ! Initial y-position of the soliton in the same units as geoLatT, often [m].
+  real    :: x, y  ! Nondimensionalized positions [nondim]
+  real    :: val1  ! A nondimensionlized zonal decay scale [nondim]
   real    :: val2  ! An overall velocity amplitude [L T-1 ~> m s-1]
   real    :: val3  ! A decay factor [nondim]
   real    :: val4  ! The local velocity amplitude [L T-1 ~> m s-1]
@@ -81,18 +133,40 @@ subroutine soliton_initialize_velocity(u, v, G, GV, US)
 
   is = G%isc ; ie = G%iec ; js = G%jsc ; je = G%jec ; nz = GV%ke
 
+  if (.not.just_read) &
+    call MOM_mesg("soliton_initialization.F90, soliton_initialize_thickness: setting thickness")
+
+  call get_param(param_file, mdl, "MAXIMUM_DEPTH", max_depth, &
+                 units="m", default=-1.e9, scale=US%m_to_Z, do_not_log=.true.)
+  call get_param(param_file, mdl, "BETA", beta, &
+                 "The northward gradient of the Coriolis parameter with the betaplane option.", &
+                 units="m-1 s-1", default=0.0, scale=US%T_to_s*US%L_to_m, do_not_log=.true.)
+
+  if (just_read) return ! All run-time parameters have been read, so return.
+
+  if (max_depth <= 0.0) call MOM_error(FATAL, &
+      "soliton_initialization, soliton_initialize_velocity: "//&
+      "This module requires a positive value of MAXIMUM_DEPTH.")
+  if (abs(beta) <= 0.0) call MOM_error(FATAL, &
+      "soliton_initialization, soliton_initialize_velocity: "//&
+      "This module requires a non-zero value of BETA.")
+
+  cg_max = sqrt(GV%g_Earth * max_depth)
+  L_eq = sqrt(cg_max / abs(beta))
+  scale_pos = US%m_to_L / L_eq
+
   x0 = 2.0*G%len_lon/3.0
   y0 = 0.0
   val1 = 0.395
-  val2 = US%m_s_to_L_T * 0.771*(val1*val1)
+  val2 = cg_max * 0.771*(val1*val1)
 
   v(:,:,:) = 0.0
   u(:,:,:) = 0.0
 
   do j = G%jsc,G%jec ; do I = G%isc-1,G%iec+1
     do k = 1, nz
-      x = 0.5*(G%geoLonT(i+1,j)+G%geoLonT(i,j))-x0
-      y = 0.5*(G%geoLatT(i+1,j)+G%geoLatT(i,j))-y0
+      x = (0.5*(G%geoLonT(i+1,j)+G%geoLonT(i,j))-x0) * scale_pos
+      y = (0.5*(G%geoLatT(i+1,j)+G%geoLatT(i,j))-y0) * scale_pos
       val3 = exp(-val1*x)
       val4 = val2*((2.0*val3/(1.0+(val3*val3)))**2)
       u(I,j,k) = 0.25*val4*(6.0*y*y-9.0) * exp(-0.5*y*y)

--- a/src/user/tidal_bay_initialization.F90
+++ b/src/user/tidal_bay_initialization.F90
@@ -110,7 +110,7 @@ subroutine tidal_bay_set_OBC_data(OBC, CS, G, GV, US, h, Time)
       enddo
     endif
   enddo ; enddo
-  total_area = reproducing_sum(my_area)
+  total_area = US%m_to_Z*US%m_to_L * reproducing_sum(my_area)
   my_flux = - CS%tide_flow * SIN(2.0*PI*time_sec / CS%tide_period)
 
   do n = 1, OBC%number_of_segments
@@ -118,7 +118,7 @@ subroutine tidal_bay_set_OBC_data(OBC, CS, G, GV, US, h, Time)
 
     if (.not. segment%on_pe) cycle
 
-    segment%normal_vel_bt(:,:) = my_flux / (US%m_to_Z*US%m_to_L*total_area)
+    segment%normal_vel_bt(:,:) = my_flux / total_area
     segment%SSH(:,:) = cff_eta
 
   enddo ! end segment loop


### PR DESCRIPTION
MOM6 main repo. merged the "gfdl-to-main-2024-05-31" on 20240729 (see detail at https://github.com/mom-ocean/MOM6/pull/1631). Need to pull it into dev/emc correspondingly.
Note this PR will require a new BL because

- a new variable "h_ML" is being added in the restart file (see detail at https://github.com/mom-ocean/MOM6/commit/7305528fd99bc09bda648693cd7130e4627de25c)
- a  bug fixing on "incorrect PPM:H3 tracer advection stencil" (see detail at 3fac1c5a). Note we can retain original answer by setting USE_HUYNH_STENCIL_BUG=True.

we will also set DEFAULT_ANSWER_DATE=20231231 in 5x5 setting as currently it is using its default value which is too aggressive (suggested by GFDL)

note the switch FIX_USTAR_GUSTLESS_BUG=F to USTAR_GUSTLESS_BUG=T (they give same answer but  FIX_USTAR_GUSTLESS_BUG is going to be obsolated)