### PR TITLE
Write out date in ISO format to `ocean.stats`

### DIFF
--- a/src/diagnostics/MOM_sum_output.F90
+++ b/src/diagnostics/MOM_sum_output.F90
@@ -114,7 +114,8 @@ type, public :: sum_output_CS ; private
   real    :: timeunit           !< The length of the units for the time axis and certain input parameters
                                 !! including ENERGYSAVEDAYS [s].
 
-  logical :: date_stamped_output !< If true, use dates (not times) in messages to stdout.
+  logical :: date_ISO_stamped_output !< If true, use ISO formatted dates in messages to stdout.
+  logical :: date_stamped_output     !< If true, use dates (not times) in messages to stdout.
   type(time_type) :: Start_time !< The start time of the simulation.
                                 ! Start_time is set in MOM_initialization.F90
   integer, pointer :: ntrunc => NULL() !< The number of times the velocity has been
@@ -235,6 +236,9 @@ subroutine MOM_sum_output_init(G, GV, US, param_file, directory, ntrnc, &
   CS%energyfile = trim(CS%energyfile)//"."//trim(adjustl(STATSLABEL))
 #endif
 
+  call get_param(param_file, mdl, "DATE_ISO_STAMPED_STDOUT", CS%date_ISO_stamped_output, &
+                 "If true, use ISO formatted dates in messages to stdout", &
+                 default=.false.)
   call get_param(param_file, mdl, "DATE_STAMPED_STDOUT", CS%date_stamped_output, &
                  "If true, use dates (not times) in messages to stdout", &
                  default=.true.)
@@ -869,6 +873,7 @@ subroutine write_energy(u, v, h, tv, day, n, G, GV, US, CS, tracer_CSp, dt_forci
   En_mass = toten / mass_tot
 
   call get_time(day, start_of_day, num_days)
+  date_stamped = (CS%date_stamped_output .and. (get_calendar_type() /= NO_CALENDAR))
   if (date_stamped) &
     call get_date(day, iyear, imonth, iday, ihour, iminute, isecond, itick)
   if (abs(CS%timeunit - 86400.0) < 1.0) then

--- a/src/diagnostics/MOM_sum_output.F90
+++ b/src/diagnostics/MOM_sum_output.F90
@@ -417,7 +417,7 @@ subroutine write_energy(u, v, h, tv, day, n, G, GV, US, CS, tracer_CSp, dt_forci
   real    :: reday  ! Time in units given by CS%Timeunit, but often [days]
   character(len=240) :: energypath_nc
   character(len=200) :: mesg
-  character(len=32)  :: mesg_intro, time_units, day_str, n_str, date_str
+  character(len=32)  :: mesg_intro, time_units, day_str, n_str, date_str, date_str_ISO
   logical :: date_stamped
   type(time_type) :: dt_force ! A time_type version of the forcing timestep.
 
@@ -472,6 +472,8 @@ subroutine write_energy(u, v, h, tv, day, n, G, GV, US, CS, tracer_CSp, dt_forci
 
  ! A description for output of each of the fields.
   type(vardesc) :: vars(NUM_FIELDS+MAX_FIELDS_)
+
+  date_stamped = (CS%date_stamped_output .and. (get_calendar_type() /= NO_CALENDAR))
 
   ! write_energy_time is the next integral multiple of energysavedays.
   dt_force = set_time(seconds=2) ; if (present(dt_forcing)) dt_force = dt_forcing
@@ -616,16 +618,31 @@ subroutine write_energy(u, v, h, tv, day, n, G, GV, US, CS, tracer_CSp, dt_forci
         call open_ASCII_file(CS%fileenergy_ascii, trim(CS%energyfile), action=WRITEONLY_FILE)
         if (abs(CS%timeunit - 86400.0) < 1.0) then
           if (CS%use_temperature) then
-            write(CS%fileenergy_ascii,'("  Step,",7x,"Day,  Truncs,      &
-                &Energy/Mass,      Maximum CFL,  Mean Sea Level,  Total Mass,  Mean Salin, &
-                &Mean Temp, Frac Mass Err,   Salin Err,    Temp Err")')
-            write(CS%fileenergy_ascii,'(12x,"[days]",17x,"[m2 s-2]",11x,"[Nondim]",7x,"[m]",13x,&
-                &"[kg]",9x,"[PSU]",6x,"[degC]",7x,"[Nondim]",8x,"[PSU]",8x,"[degC]")')
+           if (date_stamped) then
+             write(CS%fileenergy_ascii,'("  Step,",5x,"Date,  Truncs,      &
+                 &Energy/Mass,      Maximum CFL,  Mean Sea Level,  Total Mass,  Mean Salin, &
+                 &Mean Temp, Frac Mass Err,   Salin Err,    Temp Err")')
+             write(CS%fileenergy_ascii,'(10x,"[ISO]",17x,"[m2 s-2]",11x,"[Nondim]",7x,"[m]",13x,&
+                 &"[kg]",9x,"[PSU]",6x,"[degC]",7x,"[Nondim]",8x,"[PSU]",8x,"[degC]")')
+           else
+             write(CS%fileenergy_ascii,'("  Step,",7x,"Day,  Truncs,      &
+                 &Energy/Mass,      Maximum CFL,  Mean Sea Level,  Total Mass,  Mean Salin, &
+                 &Mean Temp, Frac Mass Err,   Salin Err,    Temp Err")')
+             write(CS%fileenergy_ascii,'(12x,"[days]",17x,"[m2 s-2]",11x,"[Nondim]",7x,"[m]",13x,&
+                 &"[kg]",9x,"[PSU]",6x,"[degC]",7x,"[Nondim]",8x,"[PSU]",8x,"[degC]")')
+           endif
           else
-            write(CS%fileenergy_ascii,'("  Step,",7x,"Day,  Truncs,      &
+           if (date_stamped) then
+             write(CS%fileenergy_ascii,'("  Step,",5x,"Date,  Truncs,      &
                 &Energy/Mass,      Maximum CFL,  Mean sea level,   Total Mass,    Frac Mass Err")')
-            write(CS%fileenergy_ascii,'(12x,"[days]",17x,"[m2 s-2]",11x,"[Nondim]",8x,"[m]",13x,&
+             write(CS%fileenergy_ascii,'(10x,"[ISO]",17x,"[m2 s-2]",11x,"[Nondim]",8x,"[m]",13x,&
                 &"[kg]",11x,"[Nondim]")')
+           else
+             write(CS%fileenergy_ascii,'("  Step,",7x,"Day,  Truncs,      &
+                &Energy/Mass,      Maximum CFL,  Mean sea level,   Total Mass,    Frac Mass Err")')
+             write(CS%fileenergy_ascii,'(12x,"[days]",17x,"[m2 s-2]",11x,"[Nondim]",8x,"[m]",13x,&
+                &"[kg]",11x,"[Nondim]")')
+           endif
           endif
         else
           if ((CS%timeunit >= 0.99) .and. (CS%timeunit < 1.01)) then
@@ -641,17 +658,33 @@ subroutine write_energy(u, v, h, tv, day, n, G, GV, US, CS, tracer_CSp, dt_forci
           endif
 
           if (CS%use_temperature) then
-            write(CS%fileenergy_ascii,'("  Step,",7x,"Time, Truncs,      &
-                &Energy/Mass,      Maximum CFL,  Mean Sea Level,  Total Mass,  Mean Salin, &
-                &Mean Temp, Frac Mass Err,   Salin Err,    Temp Err")')
-            write(CS%fileenergy_ascii,'(A25,10x,"[m2 s-2]",11x,"[Nondim]",7x,"[m]",13x,&
-                &"[kg]",9x,"[PSU]",6x,"[degC]",7x,"[Nondim]",8x,"[PSU]",6x,&
-                &"[degC]")') time_units
+           if (date_stamped) then
+             write(CS%fileenergy_ascii,'("  Step,",7x,"Time, Truncs,      &
+                 &Energy/Mass,      Maximum CFL,  Mean Sea Level,  Total Mass,  Mean Salin, &
+                 &Mean Temp, Frac Mass Err,   Salin Err,    Temp Err")')
+             write(CS%fileenergy_ascii,'(A25,10x,"[m2 s-2]",11x,"[Nondim]",7x,"[m]",13x,&
+                 &"[kg]",9x,"[PSU]",6x,"[degC]",7x,"[Nondim]",8x,"[PSU]",6x,&
+                 &"[degC]")') "                         "
+           else
+             write(CS%fileenergy_ascii,'("  Step,",7x,"Time, Truncs,      &
+                 &Energy/Mass,      Maximum CFL,  Mean Sea Level,  Total Mass,  Mean Salin, &
+                 &Mean Temp, Frac Mass Err,   Salin Err,    Temp Err")')
+             write(CS%fileenergy_ascii,'(A25,10x,"[m2 s-2]",11x,"[Nondim]",7x,"[m]",13x,&
+                 &"[kg]",9x,"[PSU]",6x,"[degC]",7x,"[Nondim]",8x,"[PSU]",6x,&
+                 &"[degC]")') time_units
+           endif
           else
+           if (date_stamped) then
+            write(CS%fileenergy_ascii,'("  Step,",7x,"Time, Truncs,      &
+                &Energy/Mass,      Maximum CFL,  Mean sea level,   Total Mass,    Frac Mass Err")')
+            write(CS%fileenergy_ascii,'(A25,10x,"[m2 s-2]",11x,"[Nondim]",8x,"[m]",13x,&
+                &"[kg]",11x,"[Nondim]")') "                         "
+           else
             write(CS%fileenergy_ascii,'("  Step,",7x,"Time, Truncs,      &
                 &Energy/Mass,      Maximum CFL,  Mean sea level,   Total Mass,    Frac Mass Err")')
             write(CS%fileenergy_ascii,'(A25,10x,"[m2 s-2]",11x,"[Nondim]",8x,"[m]",13x,&
                 &"[kg]",11x,"[Nondim]")') time_units
+           endif
           endif
         endif
       endif
@@ -836,7 +869,6 @@ subroutine write_energy(u, v, h, tv, day, n, G, GV, US, CS, tracer_CSp, dt_forci
   En_mass = toten / mass_tot
 
   call get_time(day, start_of_day, num_days)
-  date_stamped = (CS%date_stamped_output .and. (get_calendar_type() /= NO_CALENDAR))
   if (date_stamped) &
     call get_date(day, iyear, imonth, iday, ihour, iminute, isecond, itick)
   if (abs(CS%timeunit - 86400.0) < 1.0) then
@@ -859,6 +891,8 @@ subroutine write_energy(u, v, h, tv, day, n, G, GV, US, CS, tracer_CSp, dt_forci
   if (date_stamped) then
     write(date_str,'("MOM Date",i7,2("/",i2.2)," ",i2.2,2(":",i2.2))') &
        iyear, imonth, iday, ihour, iminute, isecond
+    write(date_str_ISO,'(i7.4,2(i2.2),"T",i2.2,2(i2.2))') &
+       iyear, imonth, iday, ihour, iminute, isecond
   else
     date_str = trim(mesg_intro)//trim(day_str)
   endif
@@ -875,19 +909,37 @@ subroutine write_energy(u, v, h, tv, day, n, G, GV, US, CS, tracer_CSp, dt_forci
     endif
 
     if (CS%use_temperature) then
-      write(CS%fileenergy_ascii,'(A,",",A,",", I6,", En ",ES22.16, &
+      if (date_stamped) then
+        write(CS%fileenergy_ascii,'(A,",",A,",", I6,", En ",ES22.16, &
+                               &", CFL ", F8.5, ", SL ",&
+                               &es11.4,", M ",ES11.5,", S",f8.4,", T",f8.4,&
+                               &", Me ",ES9.2,", Se ",ES9.2,", Te ",ES9.2)') &
+            trim(n_str), trim(date_str_ISO), CS%ntrunc, En_mass, max_CFL(1), &
+            -H_0APE(1), mass_tot, salin, temp, mass_anom/mass_tot, salin_anom, &
+            temp_anom
+      else
+        write(CS%fileenergy_ascii,'(A,",",A,",", I6,", En ",ES22.16, &
                                &", CFL ", F8.5, ", SL ",&
                                &es11.4,", M ",ES11.5,", S",f8.4,", T",f8.4,&
                                &", Me ",ES9.2,", Se ",ES9.2,", Te ",ES9.2)') &
             trim(n_str), trim(day_str), CS%ntrunc, En_mass, max_CFL(1), &
             -H_0APE(1), mass_tot, salin, temp, mass_anom/mass_tot, salin_anom, &
             temp_anom
+      endif
     else
-      write(CS%fileenergy_ascii,'(A,",",A,",", I6,", En ",ES22.16, &
+      if (date_stamped) then
+        write(CS%fileenergy_ascii,'(A,",",A,",", I6,", En ",ES22.16, &
+                                &", CFL ", F8.5, ", SL ",&
+                                  &ES11.4,", Mass ",ES11.5,", Me ",ES9.2)') &
+            trim(n_str), trim(date_str_ISO), CS%ntrunc, En_mass, max_CFL(1), &
+            -H_0APE(1), mass_tot, mass_anom/mass_tot
+      else
+        write(CS%fileenergy_ascii,'(A,",",A,",", I6,", En ",ES22.16, &
                                 &", CFL ", F8.5, ", SL ",&
                                   &ES11.4,", Mass ",ES11.5,", Me ",ES9.2)') &
             trim(n_str), trim(day_str), CS%ntrunc, En_mass, max_CFL(1), &
             -H_0APE(1), mass_tot, mass_anom/mass_tot
+      endif
     endif
 
     if (CS%ntrunc > 0) then


### PR DESCRIPTION
# What is proposed?
- Run time output includes: `ocean.stats` (an ASCII file; see `*`below).
- Modifications proposed in this PR gives an option to write `date` in `yyyymmddTHHMMSS` format to ⬆️ mentioned file.
- (@DeniseWorthen:) This follows a conversation with @aerorahul who requested this enhancement for the UFS [Global-workflow](https://github.com/NOAA-EMC/global-workflow) to be able to monitor status of MOM6 time stepping (possibly to trigger post-processing).

# How to turn `ON` this _feature_?
Set DATE_ISO_STAMPED_STDOUT to `True` for e.g., `MOM_override` via:
```
#override DATE_ISO_STAMPED_STDOUT= True
```
**Note**: Default for `DATE_ISO_STAMPED_STDOUT = False`; this was done for the sake of passing regression tests.

` *` If one would prefer a different name instead of `ocean.stats`, see below:
 ```
 Santha.Akella@c5n1561:~/test-timeOut> cat MOM_override
!#Instead of writing to (default) ocean.stats, write to:
#override ENERGYFILE = "MOM6_time_step_progress.log"
!#Write 3-hr
#override ENERGYSAVEDAYS = 0.125
```

# Sample output - Before proposed changes
```
Santha.Akella@gaea51:~/test-timeOut> cat ocean.stats
  Step,       Day,  Truncs,      Energy/Mass,      Maximum CFL,  Mean sea level,   Total Mass,    Frac Mass Err
            [days]                 [m2 s-2]           [Nondim]        [m]             [kg]           [Nondim]
     0,       0.000,     0, En 1.4237074622021026E-13, CFL  0.00000, SL  4.7606E-12, Mass 5.28818E+18, Me  0.00E+00
    72,       1.000,     0, En 4.5804317887744286E-06, CFL  0.00023, SL  4.7606E-12, Mass 5.28818E+18, Me -1.67E-17
   144,       2.000,     0, En 8.9582059501972509E-06, CFL  0.00040, SL  4.7606E-12, Mass 5.28818E+18, Me  8.91E-18
   216,       3.000,     0, En 1.1667077649798048E-05, CFL  0.00045, SL  4.7606E-12, Mass 5.28818E+18, Me  1.19E-17
   288,       4.000,     0, En 1.5422955375275323E-05, CFL  0.00044, SL  5.0022E-12, Mass 5.28818E+18, Me  1.89E-18
   360,       5.000,     0, En 1.8260222693487214E-05, CFL  0.00053, SL  4.7606E-12, Mass 5.28818E+18, Me -1.23E-17
   432,       6.000,     0, En 2.3974311228877540E-05, CFL  0.00062, SL  4.7606E-12, Mass 5.28818E+18, Me -9.41E-19
   504,       7.000,     0, En 2.9279621462045188E-05, CFL  0.00073, SL  4.7606E-12, Mass 5.28818E+18, Me -1.04E-17
   576,       8.000,     0, En 3.4864407126366701E-05, CFL  0.00081, SL  4.7606E-12, Mass 5.28818E+18, Me -5.40E-18
   648,       9.000,     0, En 4.1955651757945079E-05, CFL  0.00090, SL  4.7606E-12, Mass 5.28818E+18, Me  7.26E-18
   720,      10.000,     0, En 4.6047288874226238E-05, CFL  0.00100, SL  4.7606E-12, Mass 5.28818E+18, Me  8.17E-18
```

# Sample output - After proposed changes
```
Santha.Akella@c5n1563:~/test-timeOut> cat ocean.stats
  Step,     Date,  Truncs,      Energy/Mass,      Maximum CFL,  Mean sea level,   Total Mass,    Frac Mass Err
          [ISO]                 [m2 s-2]           [Nondim]        [m]             [kg]           [Nondim]
     0,   00010101T000000,     0, En 1.4237074622021026E-13, CFL  0.00000, SL  4.7606E-12, Mass 5.28818E+18, Me  0.00E+00
    72,   00010102T000000,     0, En 4.5804317887744286E-06, CFL  0.00023, SL  4.7606E-12, Mass 5.28818E+18, Me -1.67E-17
   144,   00010103T000000,     0, En 8.9582059501972509E-06, CFL  0.00040, SL  4.7606E-12, Mass 5.28818E+18, Me  8.91E-18
   216,   00010104T000000,     0, En 1.1667077649798048E-05, CFL  0.00045, SL  4.7606E-12, Mass 5.28818E+18, Me  1.19E-17
   288,   00010105T000000,     0, En 1.5422955375275323E-05, CFL  0.00044, SL  5.0022E-12, Mass 5.28818E+18, Me  1.89E-18
   360,   00010106T000000,     0, En 1.8260222693487214E-05, CFL  0.00053, SL  4.7606E-12, Mass 5.28818E+18, Me -1.23E-17
   432,   00010107T000000,     0, En 2.3974311228877540E-05, CFL  0.00062, SL  4.7606E-12, Mass 5.28818E+18, Me -9.41E-19
   504,   00010108T000000,     0, En 2.9279621462045188E-05, CFL  0.00073, SL  4.7606E-12, Mass 5.28818E+18, Me -1.04E-17
   576,   00010109T000000,     0, En 3.4864407126366701E-05, CFL  0.00081, SL  4.7606E-12, Mass 5.28818E+18, Me -5.40E-18
   648,   00010110T000000,     0, En 4.1955651757945079E-05, CFL  0.00090, SL  4.7606E-12, Mass 5.28818E+18, Me  7.26E-18
   720,   00010111T000000,     0, En 4.6047288874226238E-05, CFL  0.00100, SL  4.7606E-12, Mass 5.28818E+18, Me  8.17E-18
```

# Where and how was it tested?
- On [Gaea C5](https://docs.rdhpcs.noaa.gov/systems/gaea_user_guide.html), path: `/autofs/ncrc-svm1_home1/Santha.Akella/test-timeOut`. Once this PR is merged, this path will be purged.
- In `ocean_only` mode, [double_gyre configuration](https://github.com/NOAA-GFDL/MOM6-examples/tree/dev/gfdl/ocean_only/double_gyre) with [`DATE_ISO_STAMPED_STDOUT= True`](https://github.com/NOAA-GFDL/MOM6-examples/blob/77964b09c9b2dc2e403bc0049e9485229195cc6d/ocean_only/double_gyre/MOM_input#L248)