### PR TITLE
Fix divide by zero fpe in apply_oda_incupd

### DIFF
--- a/src/ocean_data_assim/MOM_oda_incupd.F90
+++ b/src/ocean_data_assim/MOM_oda_incupd.F90
@@ -599,19 +599,19 @@ subroutine apply_oda_incupd(h, tv, u, v, dt, G, GV, US, CS)
   tmp_val1(:) = 0.0
   tmp_t(:,:,:) = 0.0 ; tmp_s(:,:,:) = 0.0 ! diagnostics
   do j=js,je ; do i=is,ie
-    ! account for the different SSH
-    sum_h1 = 0.0
-    do k=1,nz
-      sum_h1 = sum_h1+h(i,j,k)
-    enddo
-    sum_h2 = 0.0
-    do k=1,nz_data
-      sum_h2 = sum_h2+h_obs(i,j,k)
-    enddo
-    do k=1,nz_data
-      tmp_h(k) = ( sum_h1 / sum_h2 ) * h_obs(i,j,k)
-    enddo
     if (G%mask2dT(i,j) == 1) then
+      ! account for the different SSH
+      sum_h1 = 0.0
+      do k=1,nz
+        sum_h1 = sum_h1+h(i,j,k)
+      enddo
+      sum_h2 = 0.0
+      do k=1,nz_data
+        sum_h2 = sum_h2+h_obs(i,j,k)
+      enddo
+      do k=1,nz_data
+        tmp_h(k) = ( sum_h1 / sum_h2 ) * h_obs(i,j,k)
+      enddo
       ! get temperature increment
       do k=1,nz_data
         tmp_val2(k) = CS%Inc(1)%p(i,j,k)


### PR DESCRIPTION
Move computation of tmp_h inside the if G%mask2dT test to avoid divide by zero error.

See https://github.com/ufs-community/ufs-weather-model/issues/2906 for details.