### PR TITLE
Add output logging

### DIFF
--- a/config_src/drivers/nuopc_cap/mom_cap.F90
+++ b/config_src/drivers/nuopc_cap/mom_cap.F90
@@ -1909,13 +1909,13 @@ subroutine ModelAdvance(gcomp, rc)
     write_restart_eor = .false.
     if (restart_eor) then
       if (ESMF_AlarmIsRinging(stop_alarm, rc=rc)) then
-         if (ChkErr(rc,__LINE__,u_FILE_u)) return
-         write_restart_eor = .true.
-         ! turn off the alarm
-         call ESMF_AlarmRingerOff(stop_alarm, rc=rc )
-         if (ChkErr(rc,__LINE__,u_FILE_u)) return
-       end if
-     end if
+        if (ChkErr(rc,__LINE__,u_FILE_u)) return
+        write_restart_eor = .true.
+        ! turn off the alarm
+        call ESMF_AlarmRingerOff(stop_alarm, rc=rc )
+        if (ChkErr(rc,__LINE__,u_FILE_u)) return
+      end if
+    end if
 
 #ifndef CESMCOUPLED
     call is_restart_fh(clock, restartfh_info, write_restartfh)

--- a/config_src/drivers/nuopc_cap/mom_cap.F90
+++ b/config_src/drivers/nuopc_cap/mom_cap.F90
@@ -2341,6 +2341,9 @@ subroutine ocean_model_finalize(gcomp, rc)
   call io_infra_end()
   call MOM_infra_end()
 
+  call outputAlarms_run(clock, rc)
+  if (ChkErr(rc,__LINE__,u_FILE_u)) return
+
   if(write_runtimelog .and. is_root_pe()) write(stdout,*) 'In ',trim(subname),' time ', MPI_Wtime()-timefs
 
 end subroutine ocean_model_finalize

--- a/config_src/drivers/nuopc_cap/mom_cap.F90
+++ b/config_src/drivers/nuopc_cap/mom_cap.F90
@@ -31,14 +31,15 @@ use MOM_cap_methods,          only: ChkErr
 use MOM_ensemble_manager,     only: ensemble_manager_init
 use MOM_coms,                 only: sum_across_PEs
 
+! stubroutines for CESMCOUPLED
+use mom_cap_outputlog, only: outputlog_init, outputlog_run
+
 #ifdef CESMCOUPLED
 use shr_log_mod,             only: shr_log_setLogUnit
 use nuopc_shr_methods,       only: get_component_instance
 #endif
+
 use time_utils_mod,           only: esmf2fms_time
-
-use mom_cap_logging, only: outputAlarms_init, outputAlarms_run
-
 use, intrinsic :: iso_fortran_env, only: output_unit
 
 use ESMF,  only: ESMF_ClockAdvance, ESMF_ClockGet, ESMF_ClockPrint, ESMF_VMget
@@ -2012,45 +2013,8 @@ subroutine ModelAdvance(gcomp, rc)
     endif
   endif ! restart_mode
 
-  call outputAlarms_run(clock, rc=rc)
+  call outputlog_run(clock, rc=rc)
   if (ChkErr(rc,__LINE__,u_FILE_u)) return
-#ifdef test
-  call ESMF_ClockGetAlarm(clock, alarmname='history_alarm', alarm=history_alarm, rc=rc)
-  if (ChkErr(rc,__LINE__,u_FILE_u)) return
-  if (ESMF_AlarmIsRinging(history_alarm, rc=rc)) then
-    if (ChkErr(rc,__LINE__,u_FILE_u)) return
-    chkfile_nextAdvance = .true.
-    ! turn off the alarm
-    call ESMF_AlarmRingerOff(history_alarm, rc=rc )
-    if (ChkErr(rc,__LINE__,u_FILE_u)) return
-    ! set filename
-    call ESMF_ClockGetNextTime(clock, MyTime, rc=rc)
-    if (ChkErr(rc,__LINE__,u_FILE_u)) return
-    call ESMF_TimeGet (MyTime-9*outputInterval, yy=year, mm=month, dd=day, h=hour, rc=rc )
-    !call ESMF_TimeGet (MyTime-36*outputInterval, yy=year, mm=month, dd=day, h=hour, rc=rc )
-    if (ChkErr(rc,__LINE__,u_FILE_u)) return
-    write(history_fname,'(a,i4.4,3(a,i2.2),a)')'ocn_',year,'_',month,'_',day,'_',hour,'.nc'
-    if(is_root_pe())print *,'XX0 '//trim(history_fname)//'  '//trim(import_timestr)//'  '//trim(export_timestr)
-  end if
-
-  if (chkfile_nextAdvance) then
-    ! check if file is written
-    inquire(file=trim(history_fname), exist=existflag)
-    if (existflag) then
-      !open and inquire unlimdim
-      rc = nf90_open(trim(history_fname), nf90_nowrite, ncid)
-      rc = nf90_inquire(ncid, unlimiteddimid=dimid)
-      rc = nf90_inquire_dimension(ncid, dimid, len=nlen)
-      rc = nf90_close(ncid)
-      if (nlen > 0) then
-        chkfile_nextAdvance = .false.
-        if(is_root_pe())print *,'XX '//trim(history_fname)//'  '//trim(import_timestr)//'  '//trim(export_timestr)//' complete'
-      else
-        if(is_root_pe())print *,'XX '//trim(history_fname)//'  '//trim(import_timestr)//'  '//trim(export_timestr)//' still 0'
-      end if
-    end if
-  end if
-#endif
 
   !---------------
   ! Write diagnostics
@@ -2250,24 +2214,9 @@ subroutine ModelSetRunClock(gcomp, rc)
     call ESMF_TimeGet(dstoptime, timestring=timestr, rc=rc)
     call ESMF_LogWrite("Stop Alarm will ring at : "//trim(timestr), ESMF_LOGMSG_INFO)
 
-    call outputAlarms_init(mclock, rc)
-    if (ChkErr(rc,__LINE__,u_FILE_u)) return
-#ifdef test
-    call ESMF_TimeIntervalSet(outputInterval, h=1, rc=rc)
-    if (ChkErr(rc,__LINE__,u_FILE_u)) return
-    call AlarmInit(mclock,        &
-         alarm   = history_alarm, &
-         option  = 'nhours',      &
-         opt_n   = 6,             &
-         opt_ymd = -999,          &
-         RefTime = mcurrTime,     &
-         alarmname = 'history_alarm', rc=rc)
+    call outputlog_init(mclock, rc)
     if (ChkErr(rc,__LINE__,u_FILE_u)) return
 
-    call ESMF_AlarmSet(history_alarm, clock=mclock, rc=rc)
-    if (ChkErr(rc,__LINE__,u_FILE_u)) return
-    call ESMF_LogWrite(subname//" History alarm is Created and Set", ESMF_LOGMSG_INFO)
-#endif
     first_time = .false.
 
   endif
@@ -2341,9 +2290,8 @@ subroutine ocean_model_finalize(gcomp, rc)
   call io_infra_end()
   call MOM_infra_end()
 
-  call outputAlarms_run(clock, rc)
+  call outputlog_run(clock, rc)
   if (ChkErr(rc,__LINE__,u_FILE_u)) return
-
   if(write_runtimelog .and. is_root_pe()) write(stdout,*) 'In ',trim(subname),' time ', MPI_Wtime()-timefs
 
 end subroutine ocean_model_finalize

--- a/config_src/drivers/nuopc_cap/mom_cap.F90
+++ b/config_src/drivers/nuopc_cap/mom_cap.F90
@@ -95,7 +95,6 @@ use NUOPC_Model, only: SetVM
 
 #ifndef CESMCOUPLED
 use shr_is_restart_fh_mod, only : init_is_restart_fh, is_restart_fh, is_restart_fh_type
-use shr_is_restart_fh_mod, only : log_restart_fh
 #endif
 
 implicit none; private
@@ -1986,13 +1985,9 @@ subroutine ModelAdvance(gcomp, rc)
 
         ! write restart file(s)
         call ocean_model_restart(ocean_state, restartname=restartname, &
-                                stoch_restartname=stoch_restartname)
-#ifndef CESMCOUPLED
-        if (is_root_pe()) then
-          call log_restart_fh(MyTime, startTime, 'mom6.res', prefixtime=.true., rc=rc)
-          if (ChkErr(rc,__LINE__,u_FILE_u)) return
-        endif
-#endif
+                                stoch_restartname=stoch_restartname, num_rest_files=num_rest_files)
+
+        call outputlog_restart(clock, num_rest_files, rc=rc)
       endif
 
       if (is_root_pe()) then

--- a/config_src/drivers/nuopc_cap/mom_cap.F90
+++ b/config_src/drivers/nuopc_cap/mom_cap.F90
@@ -31,15 +31,14 @@ use MOM_cap_methods,          only: ChkErr
 use MOM_ensemble_manager,     only: ensemble_manager_init
 use MOM_coms,                 only: sum_across_PEs
 
-! stubroutines for CESMCOUPLED
-use mom_cap_outputlog, only: outputlog_init, outputlog_run
-
+! stub routines for CESMCOUPLED
+use mom_cap_outputlog,       only: outputlog_init, outputlog_run
 #ifdef CESMCOUPLED
 use shr_log_mod,             only: shr_log_setLogUnit
 use nuopc_shr_methods,       only: get_component_instance
 #endif
+use time_utils_mod,          only: esmf2fms_time
 
-use time_utils_mod,           only: esmf2fms_time
 use, intrinsic :: iso_fortran_env, only: output_unit
 
 use ESMF,  only: ESMF_ClockAdvance, ESMF_ClockGet, ESMF_ClockPrint, ESMF_VMget
@@ -76,7 +75,7 @@ use ESMF,  only: ESMF_AlarmGet, ESMF_AlarmIsCreated, ESMF_ALARMLIST_ALL, ESMF_Al
 use ESMF,  only: ESMF_STATEITEM_NOTFOUND, ESMF_FieldWrite
 use ESMF,  only: ESMF_END_ABORT, ESMF_Finalize
 use ESMF,  only: ESMF_REDUCE_MAX, ESMF_REDUCE_MIN, ESMF_VMAllReduce
-use ESMF,  only: operator(==), operator(/=), operator(+), operator(-), operator(*)
+use ESMF,  only: operator(==), operator(/=), operator(+), operator(-)
 
 ! TODO ESMF_GridCompGetInternalState does not have an explicit Fortran interface.
 !! Model does not compile with "use ESMF,  only: ESMF_GridCompGetInternalState"
@@ -165,11 +164,6 @@ character(len=8)  :: restart_mode = 'alarms'
 character(len=16) :: inst_suffix = ''
 logical           :: pointer_date = .true. ! append date to rpointer
 real(8) :: timere
-
-!type(ESMF_Alarm)        :: history_alarm
-!type(ESMF_TimeInterval) :: outputInterval
-!character(len=256) :: history_fname
-!logical :: chkfile_nextAdvance = .false.
 
 contains
 
@@ -1704,9 +1698,6 @@ end subroutine DataInitialize
 !! @param gcomp an ESMF_GridComp object
 !! @param rc return code
 subroutine ModelAdvance(gcomp, rc)
-  !debug
-  use netcdf
-
   type(ESMF_GridComp)                    :: gcomp !< ESMF_GridComp object
   integer, intent(out)                   :: rc    !< return code
 
@@ -1754,9 +1745,6 @@ subroutine ModelAdvance(gcomp, rc)
   real(8)                                :: MPI_Wtime, timers
   logical                                :: write_restart, write_restartfh
   logical                                :: write_restart_eor
-  ! debug
-  !integer :: nlen, ncid, dimid
-  !character(len=256) :: fname
 
   rc = ESMF_SUCCESS
   if(profile_memory) call ESMF_VMLogMemInfo("Entering MOM Model_ADVANCE: ")
@@ -2012,7 +2000,6 @@ subroutine ModelAdvance(gcomp, rc)
       endif
     endif
   endif ! restart_mode
-
   call outputlog_run(clock, rc=rc)
   if (ChkErr(rc,__LINE__,u_FILE_u)) return
 
@@ -2048,9 +2035,6 @@ end subroutine ModelAdvance
 
 
 subroutine ModelSetRunClock(gcomp, rc)
-  ! debug
-  use ESMF, only : ESMF_TimeIntervalSet
-
   type(ESMF_GridComp)  :: gcomp
   integer, intent(out) :: rc
 
@@ -2214,9 +2198,8 @@ subroutine ModelSetRunClock(gcomp, rc)
     call ESMF_TimeGet(dstoptime, timestring=timestr, rc=rc)
     call ESMF_LogWrite("Stop Alarm will ring at : "//trim(timestr), ESMF_LOGMSG_INFO)
 
-    call outputlog_init(mclock, rc)
+    call outputlog_init(gcomp, mclock, rc)
     if (ChkErr(rc,__LINE__,u_FILE_u)) return
-
     first_time = .false.
 
   endif

--- a/config_src/drivers/nuopc_cap/mom_cap.F90
+++ b/config_src/drivers/nuopc_cap/mom_cap.F90
@@ -514,7 +514,7 @@ subroutine InitializeAdvertise(gcomp, importState, exportState, clock, rc)
 
   rpointer_filename = 'rpointer.ocn'//trim(inst_suffix)
   if (pointer_date) then
-    write(timestamp,'(".",i4.4,"-",i2.2,"-",i2.2,"-",i5.5)'),year,month,day,hour*3600+minute*60+second
+    write(timestamp,'(".",i4.4,"-",i2.2,"-",i2.2,"-",i5.5)')year,month,day,hour*3600+minute*60+second
     inquire(file=trim(rpointer_filename//timestamp), exist=found)
     ! for backward compatibility
     if (found) then
@@ -1881,7 +1881,7 @@ subroutine ModelAdvance(gcomp, rc)
       call state_diagnose(exportState,subname//':ES ',rc=rc)
       if (ChkErr(rc,__LINE__,u_FILE_u)) return
     endif
-  endif
+  endif ! do_advance
 
   !---------------
   ! Get the stop alarm
@@ -1915,7 +1915,7 @@ subroutine ModelAdvance(gcomp, rc)
          call ESMF_AlarmRingerOff(stop_alarm, rc=rc )
          if (ChkErr(rc,__LINE__,u_FILE_u)) return
        end if
-    end if
+     end if
 
 #ifndef CESMCOUPLED
     call is_restart_fh(clock, restartfh_info, write_restartfh)

--- a/config_src/drivers/nuopc_cap/mom_cap.F90
+++ b/config_src/drivers/nuopc_cap/mom_cap.F90
@@ -37,6 +37,8 @@ use nuopc_shr_methods,       only: get_component_instance
 #endif
 use time_utils_mod,           only: esmf2fms_time
 
+use mom_cap_logging, only: outputAlarms_init, outputAlarms_run
+
 use, intrinsic :: iso_fortran_env, only: output_unit
 
 use ESMF,  only: ESMF_ClockAdvance, ESMF_ClockGet, ESMF_ClockPrint, ESMF_VMget
@@ -163,10 +165,10 @@ character(len=16) :: inst_suffix = ''
 logical           :: pointer_date = .true. ! append date to rpointer
 real(8) :: timere
 
-type(ESMF_Alarm)        :: history_alarm
-type(ESMF_TimeInterval) :: outputInterval
-character(len=256) :: history_fname
-logical :: chkfile_nextAdvance = .false.
+!type(ESMF_Alarm)        :: history_alarm
+!type(ESMF_TimeInterval) :: outputInterval
+!character(len=256) :: history_fname
+!logical :: chkfile_nextAdvance = .false.
 
 contains
 
@@ -1752,7 +1754,8 @@ subroutine ModelAdvance(gcomp, rc)
   logical                                :: write_restart, write_restartfh
   logical                                :: write_restart_eor
   ! debug
-  integer :: nlen, ncid, dimid
+  !integer :: nlen, ncid, dimid
+  !character(len=256) :: fname
 
   rc = ESMF_SUCCESS
   if(profile_memory) call ESMF_VMLogMemInfo("Entering MOM Model_ADVANCE: ")
@@ -1785,7 +1788,9 @@ subroutine ModelAdvance(gcomp, rc)
   call ESMF_LogWrite(trim(msgString), ESMF_LOGMSG_INFO)
 
   call ESMF_TimeGet(currTime,          timestring=import_timestr, rc=rc)
+  if (ChkErr(rc,__LINE__,u_FILE_u)) return
   call ESMF_TimeGet(currTime+timestep, timestring=export_timestr, rc=rc)
+  if (ChkErr(rc,__LINE__,u_FILE_u)) return
 
   Time_step_coupled = esmf2fms_time(timeStep)
   Time = esmf2fms_time(currTime)
@@ -1995,7 +2000,7 @@ subroutine ModelAdvance(gcomp, rc)
                                 stoch_restartname=stoch_restartname)
 #ifndef CESMCOUPLED
         if (is_root_pe()) then
-          call log_restart_fh(MyTime, startTime, 'mom6', rc=rc)
+          call log_restart_fh(MyTime, startTime, 'mom6.res', prefixtime=.true., rc=rc)
           if (ChkErr(rc,__LINE__,u_FILE_u)) return
         endif
 #endif
@@ -2007,6 +2012,9 @@ subroutine ModelAdvance(gcomp, rc)
     endif
   endif ! restart_mode
 
+  call outputAlarms_run(clock, rc=rc)
+  if (ChkErr(rc,__LINE__,u_FILE_u)) return
+#ifdef test
   call ESMF_ClockGetAlarm(clock, alarmname='history_alarm', alarm=history_alarm, rc=rc)
   if (ChkErr(rc,__LINE__,u_FILE_u)) return
   if (ESMF_AlarmIsRinging(history_alarm, rc=rc)) then
@@ -2019,9 +2027,10 @@ subroutine ModelAdvance(gcomp, rc)
     call ESMF_ClockGetNextTime(clock, MyTime, rc=rc)
     if (ChkErr(rc,__LINE__,u_FILE_u)) return
     call ESMF_TimeGet (MyTime-9*outputInterval, yy=year, mm=month, dd=day, h=hour, rc=rc )
+    !call ESMF_TimeGet (MyTime-36*outputInterval, yy=year, mm=month, dd=day, h=hour, rc=rc )
     if (ChkErr(rc,__LINE__,u_FILE_u)) return
     write(history_fname,'(a,i4.4,3(a,i2.2),a)')'ocn_',year,'_',month,'_',day,'_',hour,'.nc'
-    if(is_root_pe()) print *,'XXX0 '//trim(history_fname),'  ',trim(export_timestr)
+    if(is_root_pe())print *,'XX0 '//trim(history_fname)//'  '//trim(import_timestr)//'  '//trim(export_timestr)
   end if
 
   if (chkfile_nextAdvance) then
@@ -2040,9 +2049,8 @@ subroutine ModelAdvance(gcomp, rc)
         if(is_root_pe())print *,'XX '//trim(history_fname)//'  '//trim(import_timestr)//'  '//trim(export_timestr)//' still 0'
       end if
     end if
-    !check filename currtime-9
-    !if file exists, done, chkfile_nextAdvance=.false.
   end if
+#endif
 
   !---------------
   ! Write diagnostics
@@ -2242,6 +2250,9 @@ subroutine ModelSetRunClock(gcomp, rc)
     call ESMF_TimeGet(dstoptime, timestring=timestr, rc=rc)
     call ESMF_LogWrite("Stop Alarm will ring at : "//trim(timestr), ESMF_LOGMSG_INFO)
 
+    call outputAlarms_init(mclock, rc)
+    if (ChkErr(rc,__LINE__,u_FILE_u)) return
+#ifdef test
     call ESMF_TimeIntervalSet(outputInterval, h=1, rc=rc)
     if (ChkErr(rc,__LINE__,u_FILE_u)) return
     call AlarmInit(mclock,        &
@@ -2256,7 +2267,7 @@ subroutine ModelSetRunClock(gcomp, rc)
     call ESMF_AlarmSet(history_alarm, clock=mclock, rc=rc)
     if (ChkErr(rc,__LINE__,u_FILE_u)) return
     call ESMF_LogWrite(subname//" History alarm is Created and Set", ESMF_LOGMSG_INFO)
-
+#endif
     first_time = .false.
 
   endif

--- a/config_src/drivers/nuopc_cap/mom_cap.F90
+++ b/config_src/drivers/nuopc_cap/mom_cap.F90
@@ -2084,6 +2084,16 @@ subroutine ModelSetRunClock(gcomp, rc)
     return
   endif
 
+  if (first_time) then
+    call ESMF_TimeGet(dcurrtime, timeString=dtimestring, rc=rc)
+    if (ChkErr(rc,__LINE__,u_FILE_u)) return
+    if (is_root_pe()) print *,'XXX init '//trim(dtimestring)
+
+    call ESMF_TimeGet(mcurrtime, timeString=mtimestring, rc=rc)
+    if (ChkErr(rc,__LINE__,u_FILE_u)) return
+    if (is_root_pe()) print *,'XXX init '//trim(mtimestring)
+  end if
+
   !--------------------------------
   ! force model clock currtime and timestep to match driver and set stoptime
   !--------------------------------

--- a/config_src/drivers/nuopc_cap/mom_cap.F90
+++ b/config_src/drivers/nuopc_cap/mom_cap.F90
@@ -73,7 +73,7 @@ use ESMF,  only: ESMF_AlarmGet, ESMF_AlarmIsCreated, ESMF_ALARMLIST_ALL, ESMF_Al
 use ESMF,  only: ESMF_STATEITEM_NOTFOUND, ESMF_FieldWrite
 use ESMF,  only: ESMF_END_ABORT, ESMF_Finalize
 use ESMF,  only: ESMF_REDUCE_MAX, ESMF_REDUCE_MIN, ESMF_VMAllReduce
-use ESMF,  only: operator(==), operator(/=), operator(+), operator(-)
+use ESMF,  only: operator(==), operator(/=), operator(+), operator(-), operator(*)
 
 ! TODO ESMF_GridCompGetInternalState does not have an explicit Fortran interface.
 !! Model does not compile with "use ESMF,  only: ESMF_GridCompGetInternalState"
@@ -92,7 +92,8 @@ use NUOPC_Model, only: model_label_Finalize       => label_Finalize
 use NUOPC_Model, only: SetVM
 
 #ifndef CESMCOUPLED
-  use shr_is_restart_fh_mod, only : init_is_restart_fh, is_restart_fh, is_restart_fh_type
+use shr_is_restart_fh_mod, only : init_is_restart_fh, is_restart_fh, is_restart_fh_type
+use shr_is_restart_fh_mod, only : log_restart_fh
 #endif
 
 implicit none; private
@@ -161,6 +162,11 @@ character(len=8)  :: restart_mode = 'alarms'
 character(len=16) :: inst_suffix = ''
 logical           :: pointer_date = .true. ! append date to rpointer
 real(8) :: timere
+
+type(ESMF_Alarm)        :: history_alarm
+type(ESMF_TimeInterval) :: outputInterval
+character(len=256) :: history_fname
+logical :: chkfile_nextAdvance = .false.
 
 contains
 
@@ -1695,6 +1701,9 @@ end subroutine DataInitialize
 !! @param gcomp an ESMF_GridComp object
 !! @param rc return code
 subroutine ModelAdvance(gcomp, rc)
+  !debug
+  use netcdf
+
   type(ESMF_GridComp)                    :: gcomp !< ESMF_GridComp object
   integer, intent(out)                   :: rc    !< return code
 
@@ -1742,6 +1751,8 @@ subroutine ModelAdvance(gcomp, rc)
   real(8)                                :: MPI_Wtime, timers
   logical                                :: write_restart, write_restartfh
   logical                                :: write_restart_eor
+  ! debug
+  integer :: nlen, ncid, dimid
 
   rc = ESMF_SUCCESS
   if(profile_memory) call ESMF_VMLogMemInfo("Entering MOM Model_ADVANCE: ")
@@ -1982,7 +1993,12 @@ subroutine ModelAdvance(gcomp, rc)
         ! write restart file(s)
         call ocean_model_restart(ocean_state, restartname=restartname, &
                                 stoch_restartname=stoch_restartname)
-
+#ifndef CESMCOUPLED
+        if (is_root_pe()) then
+          call log_restart_fh(MyTime, startTime, 'mom6', rc=rc)
+          if (ChkErr(rc,__LINE__,u_FILE_u)) return
+        endif
+#endif
       endif
 
       if (is_root_pe()) then
@@ -1990,6 +2006,43 @@ subroutine ModelAdvance(gcomp, rc)
       endif
     endif
   endif ! restart_mode
+
+  call ESMF_ClockGetAlarm(clock, alarmname='history_alarm', alarm=history_alarm, rc=rc)
+  if (ChkErr(rc,__LINE__,u_FILE_u)) return
+  if (ESMF_AlarmIsRinging(history_alarm, rc=rc)) then
+    if (ChkErr(rc,__LINE__,u_FILE_u)) return
+    chkfile_nextAdvance = .true.
+    ! turn off the alarm
+    call ESMF_AlarmRingerOff(history_alarm, rc=rc )
+    if (ChkErr(rc,__LINE__,u_FILE_u)) return
+    ! set filename
+    call ESMF_ClockGetNextTime(clock, MyTime, rc=rc)
+    if (ChkErr(rc,__LINE__,u_FILE_u)) return
+    call ESMF_TimeGet (MyTime-9*outputInterval, yy=year, mm=month, dd=day, h=hour, rc=rc )
+    if (ChkErr(rc,__LINE__,u_FILE_u)) return
+    write(history_fname,'(a,i4.4,3(a,i2.2),a)')'ocn_',year,'_',month,'_',day,'_',hour,'.nc'
+    if(is_root_pe()) print *,'XXX0 '//trim(history_fname),'  ',trim(export_timestr)
+  end if
+
+  if (chkfile_nextAdvance) then
+    ! check if file is written
+    inquire(file=trim(history_fname), exist=existflag)
+    if (existflag) then
+      !open and inquire unlimdim
+      rc = nf90_open(trim(history_fname), nf90_nowrite, ncid)
+      rc = nf90_inquire(ncid, unlimiteddimid=dimid)
+      rc = nf90_inquire_dimension(ncid, dimid, len=nlen)
+      rc = nf90_close(ncid)
+      if (nlen > 0) then
+        chkfile_nextAdvance = .false.
+        if(is_root_pe())print *,'XX '//trim(history_fname)//'  '//trim(import_timestr)//'  '//trim(export_timestr)//' complete'
+      else
+        if(is_root_pe())print *,'XX '//trim(history_fname)//'  '//trim(import_timestr)//'  '//trim(export_timestr)//' still 0'
+      end if
+    end if
+    !check filename currtime-9
+    !if file exists, done, chkfile_nextAdvance=.false.
+  end if
 
   !---------------
   ! Write diagnostics
@@ -2023,6 +2076,9 @@ end subroutine ModelAdvance
 
 
 subroutine ModelSetRunClock(gcomp, rc)
+  ! debug
+  use ESMF, only : ESMF_TimeIntervalSet
+
   type(ESMF_GridComp)  :: gcomp
   integer, intent(out) :: rc
 
@@ -2185,6 +2241,21 @@ subroutine ModelSetRunClock(gcomp, rc)
 
     call ESMF_TimeGet(dstoptime, timestring=timestr, rc=rc)
     call ESMF_LogWrite("Stop Alarm will ring at : "//trim(timestr), ESMF_LOGMSG_INFO)
+
+    call ESMF_TimeIntervalSet(outputInterval, h=1, rc=rc)
+    if (ChkErr(rc,__LINE__,u_FILE_u)) return
+    call AlarmInit(mclock,        &
+         alarm   = history_alarm, &
+         option  = 'nhours',      &
+         opt_n   = 6,             &
+         opt_ymd = -999,          &
+         RefTime = mcurrTime,     &
+         alarmname = 'history_alarm', rc=rc)
+    if (ChkErr(rc,__LINE__,u_FILE_u)) return
+
+    call ESMF_AlarmSet(history_alarm, clock=mclock, rc=rc)
+    if (ChkErr(rc,__LINE__,u_FILE_u)) return
+    call ESMF_LogWrite(subname//" History alarm is Created and Set", ESMF_LOGMSG_INFO)
 
     first_time = .false.
 

--- a/config_src/drivers/nuopc_cap/mom_cap.F90
+++ b/config_src/drivers/nuopc_cap/mom_cap.F90
@@ -2084,16 +2084,6 @@ subroutine ModelSetRunClock(gcomp, rc)
     return
   endif
 
-  if (first_time) then
-    call ESMF_TimeGet(dcurrtime, timeString=dtimestring, rc=rc)
-    if (ChkErr(rc,__LINE__,u_FILE_u)) return
-    if (is_root_pe()) print *,'XXX init '//trim(dtimestring)
-
-    call ESMF_TimeGet(mcurrtime, timeString=mtimestring, rc=rc)
-    if (ChkErr(rc,__LINE__,u_FILE_u)) return
-    if (is_root_pe()) print *,'XXX init '//trim(mtimestring)
-  end if
-
   !--------------------------------
   ! force model clock currtime and timestep to match driver and set stoptime
   !--------------------------------

--- a/config_src/drivers/nuopc_cap/mom_cap.F90
+++ b/config_src/drivers/nuopc_cap/mom_cap.F90
@@ -1937,7 +1937,7 @@ subroutine ModelAdvance(gcomp, rc)
         call ESMF_VMGet(vm, localPet=localPet, rc=rc)
         if (ChkErr(rc,__LINE__,u_FILE_u)) return
 
-        write(timestamp,'(".",i4.4,"-",i2.2,"-",i2.2,"-",i5.5)'),year,month,day,hour*3600+minute*60+seconds
+        write(timestamp,'(".",i4.4,"-",i2.2,"-",i2.2,"-",i5.5)')year,month,day,hour*3600+minute*60+seconds
 
         rpointer_filename = 'rpointer.ocn'//trim(inst_suffix)
         if (pointer_date) then

--- a/config_src/drivers/nuopc_cap/mom_cap.F90
+++ b/config_src/drivers/nuopc_cap/mom_cap.F90
@@ -32,7 +32,7 @@ use MOM_ensemble_manager,     only: ensemble_manager_init
 use MOM_coms,                 only: sum_across_PEs
 
 ! stub routines for CESMCOUPLED
-use mom_cap_outputlog,       only: outputlog_init, outputlog_run
+use mom_cap_outputlog,       only: outputlog_init, outputlog_run, outputlog_restart
 #ifdef CESMCOUPLED
 use shr_log_mod,             only: shr_log_setLogUnit
 use nuopc_shr_methods,       only: get_component_instance
@@ -1988,6 +1988,7 @@ subroutine ModelAdvance(gcomp, rc)
                                 stoch_restartname=stoch_restartname, num_rest_files=num_rest_files)
 
         call outputlog_restart(clock, num_rest_files, rc=rc)
+        if (ChkErr(rc,__LINE__,u_FILE_u)) return
       endif
 
       if (is_root_pe()) then
@@ -1995,6 +1996,7 @@ subroutine ModelAdvance(gcomp, rc)
       endif
     endif
   endif ! restart_mode
+
   call outputlog_run(clock, rc=rc)
   if (ChkErr(rc,__LINE__,u_FILE_u)) return
 
@@ -2268,8 +2270,12 @@ subroutine ocean_model_finalize(gcomp, rc)
   call io_infra_end()
   call MOM_infra_end()
 
-  call outputlog_run(clock, rc)
+  ! need to call twice to force logging of last output file
+  call outputlog_run(clock, rc=rc)
   if (ChkErr(rc,__LINE__,u_FILE_u)) return
+  call outputlog_run(clock, .true., rc=rc)
+  if (ChkErr(rc,__LINE__,u_FILE_u)) return
+
   if(write_runtimelog .and. is_root_pe()) write(stdout,*) 'In ',trim(subname),' time ', MPI_Wtime()-timefs
 
 end subroutine ocean_model_finalize

--- a/config_src/drivers/nuopc_cap/mom_cap_logging.F90
+++ b/config_src/drivers/nuopc_cap/mom_cap_logging.F90
@@ -1,0 +1,160 @@
+module MOM_cap_logging
+
+  ! USES:
+  use MOM_error_handler,      only: is_root_pe
+  use ESMF                  , only : ESMF_Time, ESMF_Clock, ESMF_ClockGet, ESMF_Alarm, ESMF_AlarmSet
+  use ESMF                  , only : ESMF_ClockGetAlarm, ESMF_AlarmIsRinging, ESMF_AlarmRingerOff
+  use ESMF                  , only : ESMF_ClockGetNextTime, ESMF_TimeGet, ESMF_TimeInterval
+  use ESMF                  , only : ESMF_TimeIntervalSet
+  ! use ESMF                  , only : ESMF_TimeGet, ESMF_TimeSet
+  ! use ESMF                  , only : ESMF_TimeInterval, ESMF_TimeIntervalSet
+  ! use ESMF                  , only : ESMF_ClockGet, ESMF_AlarmCreate
+  use ESMF                  , only : ESMF_SUCCESS, ESMF_LogWrite, ESMF_LOGMSG_INFO
+  use ESMF                  , only : ESMF_LogSetError, ESMF_LogFoundError, ESMF_LOGERR_PASSTHRU
+  ! use ESMF                  , only : ESMF_RC_ARG_BAD
+  ! use ESMF                  , only : operator(<), operator(/=), operator(+), operator(-), operator(*) , operator(>=)
+  ! use ESMF                  , only : operator(<=), operator(>), operator(==)
+  use ESMF                  , only : operator(*), operator(+), operator(-)
+  use MOM_cap_methods       , only : ChkErr
+  use MOM_cap_time          , only : AlarmInit
+  use shr_is_restart_fh_mod , only : log_restart_fh
+  use netcdf
+
+  implicit none; private
+
+  public :: outputAlarms_init, outputAlarms_run
+
+  ! for now, only one type of output we need to log (6hrly)
+  integer, parameter :: n_freq  = 1
+  integer, parameter, dimension(n_freq) :: freq = (/6/)
+
+  ! for generic cases, convienent to use a standard 30min output interval type to account for eg 1 or 3 hrly output
+  ! for now, use only 1 hour for 6-hrly case
+  type(ESMF_TimeInterval) :: outputInterval
+
+  type :: ologfile_type
+    character(len=256) :: alarm_name
+    integer            :: opt_n
+    integer            :: interval_factor     !number of intervals between output files, for a given output freq
+    logical            :: chkfile_nextAdvance
+    character(len=256) :: filename
+    type(ESMF_Alarm)   :: alarm
+  end type ologfile_type
+
+  type(ologfile_type) :: olog(n_freq)
+
+  character(len=*), parameter :: u_FILE_u = &
+       __FILE__
+
+contains
+
+  subroutine outputAlarms_init(mclock, rc)
+
+    type(ESMF_Clock)     :: mclock
+    integer, intent(out) :: rc
+
+    ! local variables
+    type(ESMF_Time)    :: mcurrtime
+    type(ESMF_TimeInterval) :: timestep
+    character(len=3)   :: chour
+    integer            :: n
+    character(len=256) :: subname='MOM_cap:(outputAlarms_init) '
+    !--------------------------------
+
+    rc = ESMF_SUCCESS
+
+    call ESMF_ClockGet(mclock, currTime=mcurrtime, rc=rc)
+    if (ChkErr(rc,__LINE__,u_FILE_u)) return
+
+    call ESMF_TimeIntervalSet(outputInterval, h=1, rc=rc)
+    if (ChkErr(rc,__LINE__,u_FILE_u)) return
+
+    do n = 1,n_freq
+      write(chour,'(i2.2,a)')freq(n),'h'
+      olog(n)%alarm_name = 'output_alarm'//trim(chour)
+      olog(n)%opt_n = freq(n)
+      ! for 6hr, factor = 6 + 3
+      olog(n)%interval_factor = olog(n)%opt_n + olog(n)%opt_n/2
+      olog(n)%chkfile_nextAdvance = .false.
+      olog(n)%filename = ''
+
+      call AlarmInit(mclock,         &
+           alarm   = olog(n)%alarm,  &
+           option  = 'nhours',       &
+           opt_n   = olog(n)%opt_n,  &
+           opt_ymd = -999,           &
+           RefTime = mcurrTime,      &
+           alarmname = olog(n)%alarm_name, rc=rc)
+      if (ChkErr(rc,__LINE__,u_FILE_u)) return
+
+      call ESMF_AlarmSet(olog(n)%alarm, clock=mclock, rc=rc)
+      if (ChkErr(rc,__LINE__,u_FILE_u)) return
+      call ESMF_LogWrite(subname//" Output alarm "//trim(olog(n)%alarm_name)//" is Created and Set", ESMF_LOGMSG_INFO)
+    end do
+  end subroutine outputAlarms_init
+
+  subroutine outputAlarms_run(mclock, rc)
+
+    type(ESMF_Clock)     :: mclock
+    integer, intent(out) :: rc
+
+    ! local variables
+    type(ESMF_Time)         :: nextTime, mcurrTime
+    type(ESMF_TimeInterval) :: timeStep
+    logical                 :: existflag
+    integer                 :: n, ncid, dimid, nlen
+    integer                 :: year, month, day, hour
+    character(256)          :: import_timestr, export_timestr
+    character(len=256)      :: subname='MOM_cap:(outputAlarms_run) '
+    !--------------------------------
+
+    rc = ESMF_SUCCESS
+
+    call ESMF_ClockGet(mclock, currTime=mcurrTime, timeStep=timeStep, rc=rc)
+    if (ChkErr(rc,__LINE__,u_FILE_u)) return
+    call ESMF_TimeGet(mcurrTime,          timestring=import_timestr, rc=rc)
+    if (ChkErr(rc,__LINE__,u_FILE_u)) return
+    call ESMF_TimeGet(mcurrTime+timestep, timestring=export_timestr, rc=rc)
+    if (ChkErr(rc,__LINE__,u_FILE_u)) return
+
+    do n = 1,n_freq
+      call ESMF_ClockGetAlarm(mclock, alarmname=trim(olog(n)%alarm_name), alarm=olog(n)%alarm, rc=rc)
+      if (ChkErr(rc,__LINE__,u_FILE_u)) return
+      if (ESMF_AlarmIsRinging(olog(n)%alarm, rc=rc)) then
+        if (ChkErr(rc,__LINE__,u_FILE_u)) return
+        olog(n)%chkfile_nextAdvance = .true.
+        ! turn off the alarm
+        call ESMF_AlarmRingerOff(olog(n)%alarm, rc=rc )
+        if (ChkErr(rc,__LINE__,u_FILE_u)) return
+        ! set filename
+        call ESMF_ClockGetNextTime(mclock, nextTime, rc=rc)
+        if (ChkErr(rc,__LINE__,u_FILE_u)) return
+        call ESMF_TimeGet (nextTime-olog(n)%interval_factor*outputInterval, yy=year, mm=month, dd=day, h=hour, rc=rc )
+        !call ESMF_TimeGet (MyTime-36*outputInterval, yy=year, mm=month, dd=day, h=hour, rc=rc )
+        if (ChkErr(rc,__LINE__,u_FILE_u)) return
+        write(olog(n)%filename,'(a,i4.4,3(a,i2.2),a)')'ocn_',year,'_',month,'_',day,'_',hour,'.nc'
+        if(is_root_pe())print *,'XX0 '//trim(olog(n)%filename)//'  '//trim(import_timestr)//'  '//trim(export_timestr)
+      end if
+
+      if (olog(n)%chkfile_nextAdvance) then
+        ! check if file is written
+        inquire(file=trim(olog(n)%filename), exist=existflag)
+        if (existflag) then
+          !open and inquire unlimdim
+          rc = nf90_open(trim(olog(n)%filename), nf90_nowrite, ncid)
+          rc = nf90_inquire(ncid, unlimiteddimid=dimid)
+          rc = nf90_inquire_dimension(ncid, dimid, len=nlen)
+          rc = nf90_close(ncid)
+          if (nlen > 0) then
+            olog(n)%chkfile_nextAdvance = .false.
+            if(is_root_pe())print *,'XX '//trim(olog(n)%filename)//'  '//trim(import_timestr)//'  '//trim(export_timestr)//' complete'
+          else
+            if(is_root_pe())print *,'XX '//trim(olog(n)%filename)//'  '//trim(import_timestr)//'  '//trim(export_timestr)//' still 0'
+          end if
+        end if
+      end if
+    end do
+
+  end subroutine outputAlarms_run
+
+end module MOM_cap_logging

--- a/config_src/drivers/nuopc_cap/mom_cap_logging.F90
+++ b/config_src/drivers/nuopc_cap/mom_cap_logging.F90
@@ -1,19 +1,14 @@
+!> This module contains a set of subroutines that check if MOM diagnostic
+!! output files have been written and closed
 module MOM_cap_logging
 
-  ! USES:
   use MOM_error_handler,      only: is_root_pe
   use ESMF                  , only : ESMF_Time, ESMF_Clock, ESMF_ClockGet, ESMF_Alarm, ESMF_AlarmSet
   use ESMF                  , only : ESMF_ClockGetAlarm, ESMF_AlarmIsRinging, ESMF_AlarmRingerOff
   use ESMF                  , only : ESMF_ClockGetNextTime, ESMF_TimeGet, ESMF_TimeInterval
   use ESMF                  , only : ESMF_TimeIntervalSet
-  ! use ESMF                  , only : ESMF_TimeGet, ESMF_TimeSet
-  ! use ESMF                  , only : ESMF_TimeInterval, ESMF_TimeIntervalSet
-  ! use ESMF                  , only : ESMF_ClockGet, ESMF_AlarmCreate
   use ESMF                  , only : ESMF_SUCCESS, ESMF_LogWrite, ESMF_LOGMSG_INFO
   use ESMF                  , only : ESMF_LogSetError, ESMF_LogFoundError, ESMF_LOGERR_PASSTHRU
-  ! use ESMF                  , only : ESMF_RC_ARG_BAD
-  ! use ESMF                  , only : operator(<), operator(/=), operator(+), operator(-), operator(*) , operator(>=)
-  ! use ESMF                  , only : operator(<=), operator(>), operator(==)
   use ESMF                  , only : operator(*), operator(+), operator(-)
   use MOM_cap_methods       , only : ChkErr
   use MOM_cap_time          , only : AlarmInit
@@ -28,14 +23,15 @@ module MOM_cap_logging
   integer, parameter :: n_freq  = 1
   integer, parameter, dimension(n_freq) :: freq = (/6/)
 
-  ! for generic cases, convienent to use a standard 30min output interval type to account for eg 1 or 3 hrly output
+  ! for generic cases, it will be convienent to use a standard 30min output
+  ! interval type to account for eg 1 or 3 hrly output
   ! for now, use only 1 hour for 6-hrly case
   type(ESMF_TimeInterval) :: outputInterval
 
   type :: ologfile_type
     character(len=256) :: alarm_name
     integer            :: opt_n
-    integer            :: interval_factor     !number of intervals between output files, for a given output freq
+    integer            :: interval_factor     !num of intervals between output files, for a given output freq
     logical            :: chkfile_nextAdvance
     character(len=256) :: filename
     type(ESMF_Alarm)   :: alarm
@@ -48,17 +44,21 @@ module MOM_cap_logging
 
 contains
 
+!> Initialize a set of Alarms at the diagnostic output frequency
+!!
+!! @param clock an ESMF_Clock object
+!! @param rc return code
   subroutine outputAlarms_init(mclock, rc)
 
-    type(ESMF_Clock)     :: mclock
-    integer, intent(out) :: rc
+    type(ESMF_Clock)     :: mclock !< the ESMF_clock for the model
+    integer, intent(out) :: rc     !< return code
 
     ! local variables
-    type(ESMF_Time)    :: mcurrtime
+    type(ESMF_Time)         :: mcurrtime
     type(ESMF_TimeInterval) :: timestep
-    character(len=3)   :: chour
-    integer            :: n
-    character(len=256) :: subname='MOM_cap:(outputAlarms_init) '
+    character(len=3)        :: chour
+    integer                 :: n
+    character(len=256)      :: subname='MOM_cap:(outputAlarms_init) '
     !--------------------------------
 
     rc = ESMF_SUCCESS
@@ -92,11 +92,15 @@ contains
       call ESMF_LogWrite(subname//" Output alarm "//trim(olog(n)%alarm_name)//" is Created and Set", ESMF_LOGMSG_INFO)
     end do
   end subroutine outputAlarms_init
-
+  !> Use Alarms at the diagnostic output frequency to determine if output has been
+  !! completed
+  !!
+  !! @param clock an ESMF_Clock object
+  !! @param rc return code
   subroutine outputAlarms_run(mclock, rc)
 
-    type(ESMF_Clock)     :: mclock
-    integer, intent(out) :: rc
+    type(ESMF_Clock)     :: mclock !< the ESMF_clock for the model
+    integer, intent(out) :: rc     !< return code
 
     ! local variables
     type(ESMF_Time)         :: nextTime, mcurrTime
@@ -104,7 +108,7 @@ contains
     logical                 :: existflag
     integer                 :: n, ncid, dimid, nlen
     integer                 :: year, month, day, hour
-    character(256)          :: import_timestr, export_timestr
+    character(256)          :: import_timestr, export_timestr, fname
     character(len=256)      :: subname='MOM_cap:(outputAlarms_run) '
     !--------------------------------
 
@@ -130,7 +134,6 @@ contains
         call ESMF_ClockGetNextTime(mclock, nextTime, rc=rc)
         if (ChkErr(rc,__LINE__,u_FILE_u)) return
         call ESMF_TimeGet (nextTime-olog(n)%interval_factor*outputInterval, yy=year, mm=month, dd=day, h=hour, rc=rc )
-        !call ESMF_TimeGet (MyTime-36*outputInterval, yy=year, mm=month, dd=day, h=hour, rc=rc )
         if (ChkErr(rc,__LINE__,u_FILE_u)) return
         write(olog(n)%filename,'(a,i4.4,3(a,i2.2),a)')'ocn_',year,'_',month,'_',day,'_',hour,'.nc'
         if(is_root_pe())print *,'XX0 '//trim(olog(n)%filename)//'  '//trim(import_timestr)//'  '//trim(export_timestr)
@@ -138,13 +141,14 @@ contains
 
       if (olog(n)%chkfile_nextAdvance) then
         ! check if file is written
-        inquire(file=trim(olog(n)%filename), exist=existflag)
+        fname = trim(olog(n)%filename)
+        inquire(file=fname, exist=existflag)
         if (existflag) then
           !open and inquire unlimdim
-          rc = nf90_open(trim(olog(n)%filename), nf90_nowrite, ncid)
-          rc = nf90_inquire(ncid, unlimiteddimid=dimid)
-          rc = nf90_inquire_dimension(ncid, dimid, len=nlen)
-          rc = nf90_close(ncid)
+          call nf90_err(nf90_open(fname, nf90_nowrite, ncid), 'nf90_open: '//fname)
+          call nf90_err(nf90_inquire(ncid, unlimiteddimid=dimid), 'inquire unlimiteddimid')
+          call nf90_err(nf90_inquire_dimension(ncid, dimid, len=nlen), 'inquire unlimited dimension')
+          call nf90_err(nf90_close(ncid), 'close: '//fname)
           if (nlen > 0) then
             olog(n)%chkfile_nextAdvance = .false.
             if(is_root_pe())print *,'XX '//trim(olog(n)%filename)//'  '//trim(import_timestr)//'  '//trim(export_timestr)//' complete'
@@ -154,7 +158,25 @@ contains
         end if
       end if
     end do
-
   end subroutine outputAlarms_run
+  !> Handle netcdf errors
+  !!
+  !! @param[in]  ierr        the error code
+  !! @param[in]  string      the error message
+  !!
+  subroutine nf90_err(ierr, string)
 
+    integer ,         intent(in) :: ierr
+    character(len=*), intent(in) :: string
+    !----------------------------------------------------------------------------
+
+    if (ierr /= nf90_noerr) then
+      write(0, '(a)') 'FATAL ERROR: ' // trim(string)// ' : ' // trim(nf90_strerror(ierr))
+      ! This fails on WCOSS2 with Intel 19 compiler. See
+      ! https://community.intel.com/t5/Intel-Fortran-Compiler/STOP-and-ERROR-STOP-with-variable-stop-codes/m-p/1182521#M149254
+      ! When WCOSS2 moves to Intel 2020+, uncomment the next line and remove stop 99
+      !stop ierr
+      stop 99
+    end if
+  end subroutine nf90_err
 end module MOM_cap_logging

--- a/config_src/drivers/nuopc_cap/mom_cap_outputlog.F90
+++ b/config_src/drivers/nuopc_cap/mom_cap_outputlog.F90
@@ -129,7 +129,7 @@ contains
     integer, intent(out) :: rc     !< return code
 
     ! local variables
-    type(ESMF_Time)         :: mcurrTime, startTime
+    type(ESMF_Time)         :: mcurrTime
     type(ESMF_TimeInterval) :: timestep
     logical                 :: isPresent, isSet
     integer                 :: iau_offset
@@ -138,7 +138,6 @@ contains
     character(len=256)      :: subname='MOM_cap:(outputlog_init) '
     !debug
     character(len=16) :: timestr
-    integer :: year,month,day,hour,minute
     !----------------------------------------------------------------------------
 
     rc = ESMF_SUCCESS
@@ -205,13 +204,13 @@ contains
     if (isPresent .and. isSet) debug=(trim(value)=="true")
     if (debug) call ESMF_LogWrite('MOM_cap:MOM6 output debug ON', ESMF_LOGMSG_INFO)
 
-    call ESMF_ClockGet(mclock, currTime=mcurrTime, startTime=startTime, rc=rc)
+    call ESMF_ClockGet(mclock, currTime=mcurrTime, rc=rc)
     if (ChkErr(rc,__LINE__,u_FILE_u)) return
     call ESMF_TimeIntervalSet(tincrement, m=1, rc=rc)
     if (ChkErr(rc,__LINE__,u_FILE_u)) return
 
     ! initialize
-    lastrestart = startTime
+    lastrestart = mcurrTime
 
     timestr = get_timestr(mcurrTime-iau_offset*30*tincrement, rc)
     if (ChkErr(rc,__LINE__,u_FILE_u)) return
@@ -227,17 +226,17 @@ contains
       olog(n)%filename            = ''
       olog(n)%time_lastrestart    = lastrestart
       if (freq(n) .eq. 6) then
-        olog(n)%fh_iauoffset      = iau_offset*30*tincrement
+        olog(n)%fh_iauoffset      = iau_offset*60*tincrement
       else
         olog(n)%fh_iauoffset      = 0*tincrement
       end if
 
-      call AlarmInit(mclock,                           &
-           alarm     = olog(n)%alarm,                  &
-           option    = 'nhours',                       &
-           opt_n     = olog(n)%opt_n,                  &
-           opt_ymd   = -999,                           &
-           RefTime   = mcurrTime-olog(n)%fh_iauoffset, &
+      call AlarmInit(mclock,                               &
+           alarm     = olog(n)%alarm,                      &
+           option    = 'nhours',                           &
+           opt_n     = olog(n)%opt_n,                      &
+           opt_ymd   = -999,                               &
+           RefTime   = mcurrTime-iau_offset*30*tincrement, &
            alarmname = olog(n)%alarm_name, rc=rc)
       if (ChkErr(rc,__LINE__,u_FILE_u)) return
 
@@ -268,7 +267,6 @@ contains
     type(ESMF_TimeInterval) :: timeStep
     logical                 :: lstop
     integer                 :: n, ncid, dimid, nlen(1)
-    integer                 :: year, month, day, hour, minute
     character(len=512)      :: import_timestr, export_timestr, importexport !debugging only
     character(len=16)       :: timestr
     character(len=512)      :: fname
@@ -298,21 +296,22 @@ contains
         ! when the alarm rings, set file check on next advance and construct the filename
         if (ESMF_AlarmIsRinging(olog(n)%alarm, rc=rc)) then
           if (ChkErr(rc,__LINE__,u_FILE_u)) return
-          if (debug .and. is_root_pe()) then
-            print *,'XXXX alarm is ringing '//trim(importexport)
-          end if
+          ! if (debug .and. is_root_pe()) then
+          !   print *,'XXXX alarm is ringing '//trim(importexport)
+          ! end if
           call ESMF_AlarmRingerOff(olog(n)%alarm, rc=rc )
           if (ChkErr(rc,__LINE__,u_FILE_u)) return
           olog(n)%chkfile_nextAdvance = .true.
 
           call ESMF_ClockGetNextTime(mclock, nextTime, rc=rc)
           if (ChkErr(rc,__LINE__,u_FILE_u)) return
-          timestr = get_timestr(nextTime-olog(n)%filename_fhoffset, rc)
+          timestr = get_timestr(nextTime-olog(n)%filename_fhoffset+olog(n)%fh_iauoffset, rc)
           if (ChkErr(rc,__LINE__,u_FILE_u)) return
           write(olog(n)%filename,'(A)')trim(outputdir)//'ocn_'//trim(timestr)//'.nc'
 
           if (debug .and. is_root_pe()) then
-            print '(A)',trim(subname)//' fname '//trim(olog(n)%filename)//'  '//trim(importexport)
+             print '(A,L)',trim(subname)//' fname '//trim(olog(n)%filename)//'  '//trim(importexport) &
+                  //' checkflag ',olog(n)%chkfile_nextAdvance
           end if
         end if
 
@@ -321,7 +320,7 @@ contains
           inquire(file=fname, exist=existflag)
           if (existflag) then
             if (is_root_pe()) then
-              nlen(1) = get_unlimited_len(trim(fname))
+              nlen(1) = get_unlimited_len(trim(fname), trim(importexport))
             end if
             call ESMF_VMBroadCast(vm, nlen, 1, 0, rc=rc)
             if (ChkErr(rc,__LINE__,u_FILE_u)) return
@@ -329,7 +328,8 @@ contains
               olog(n)%chkfile_nextAdvance = .false.
               olog(n)%time_lastrestart = lastrestart
               if (is_root_pe()) then
-                call log_restart_fh(currTime-olog(n)%fhoffset, startTime, 'mom6.'//chour, prefixtime=.true., &
+                call log_restart_fh(currTime-olog(n)%fhoffset+olog(n)%fh_iauoffset, startTime, &
+                     'mom6.'//chour, prefixtime=.true., &
                      lastrestart=olog(n)%time_lastrestart, lastoutput=olog(n)%filename, rc=rc)
                 if (ChkErr(rc,__LINE__,u_FILE_u)) return
               endif
@@ -359,7 +359,7 @@ contains
           inquire(file=fname, exist=existflag)
           if (existflag) then
             if (is_root_pe()) then
-              nlen(1) = get_unlimited_len(fname)
+              nlen(1) = get_unlimited_len(fname,trim(importexport))
             end if
             call ESMF_VMBroadCast(vm, nlen, 1, 0, rc=rc)
             if (ChkErr(rc,__LINE__,u_FILE_u)) return
@@ -381,7 +381,7 @@ contains
           fname = trim(olog(n)%filename)
           inquire(file=fname, exist=existflag)
           if (existflag) then
-            nlen(1) = get_unlimited_len(fname)
+            nlen(1) = get_unlimited_len(fname,' ')
             write(msgString,'(A)')trim(subname)//trim(fname)//' exists '//trim(importexport)
             if (nlen(1) > 0) then
               print '(A,L)',trim(msgString)//' complete ',olog(n)%chkfile_nextAdvance
@@ -408,7 +408,7 @@ contains
     ! local variables
     type(ESMF_Time)         :: startTime, currTime, nextTime
     type(ESMF_TimeInterval) :: timestep
-  integer                 :: n, ncid, dimid, nlen(1)
+    integer                 :: n, ncid, dimid, nlen(1)
     integer                 :: year, month, day, hour, minute, seconds
     character(len=512)      :: fname
     character(len=15)       :: timestr
@@ -455,7 +455,7 @@ contains
       inquire(file=trim(fname), exist=existflag)
       if (existflag) then
         if (is_root_pe())then
-          nlen(1) = get_unlimited_len(trim(fname))
+          nlen(1) = get_unlimited_len(trim(fname),' ')
         end if
         call ESMF_VMBroadCast(vm, nlen, 1, 0, rc=rc)
         if (ChkErr(rc,__LINE__,u_FILE_u)) return
@@ -486,18 +486,34 @@ contains
   !!
   !! @param[in]  fname   the file name
   !! @return             unlimited dimension length
-  integer function get_unlimited_len(fname) result(unlen)
+  integer function get_unlimited_len(fname,string) result(unlen)
 
     character(len=*), intent(in) :: fname
+    character(len=*), intent(in) :: string
 
     integer :: ncid, dimid
+    ! debug
+    integer :: varid
+    real(kind=8) :: tval
+    character(len=4) :: dimname
     !----------------------------------------------------------------------------
 
+    tval = 1.0e36
+    dimname = ''
     unlen = 0
     call nf90_err(nf90_open(trim(fname), nf90_nowrite, ncid), 'nf90_open: '//trim(fname))
     call nf90_err(nf90_inquire(ncid, unlimiteddimid=dimid), 'inquire unlimiteddimid')
     call nf90_err(nf90_inquire_dimension(ncid, dimid, len=unlen), 'inquire unlimited dimension')
+    if (unlen > 0) then
+      call nf90_err(nf90_inquire_dimension(ncid, dimid, name=dimname), 'inquire unlimited dimension name')
+      call nf90_err(nf90_inq_varid(ncid, dimname, varid), 'get variable Id: unlimited dimension '//trim(fname))
+      call nf90_err(nf90_get_var(ncid, varid, tval), 'get variable: unlimited dimension value '//trim(fname))
+    end if
     call nf90_err(nf90_close(ncid), 'close: '//trim(fname))
+
+    if (len_trim(string) > 0) then
+      print '(A,g14.7,i8)','checkdim '//trim(string)//' '//trim(dimname)//' =  ',tval,unlen
+    end if
 
   end function get_unlimited_len
   !> Convert ESMF_Time to a formatted 16-character string

--- a/config_src/drivers/nuopc_cap/mom_cap_outputlog.F90
+++ b/config_src/drivers/nuopc_cap/mom_cap_outputlog.F90
@@ -81,10 +81,11 @@ contains
   !      21 = 30 - (12 + 3)
   !                03 = 30 - (3)
   !
-  ! since both the final interval and the next-to-final interval are closed at the stop time,
-  ! a different log file name is required for  the final log file, otherwise the next-to-final
+  ! since both the final interval and the next-to-final interval can be closed at the stop time,
+  ! a different log file name is required for the final log file, otherwise the next-to-final
   ! log is overwritten
   !
+  ! TODO: explain why filesize is also a criteria
   ! an output file is declared closed when the unlimited dimension in the file is > 0
   ! each closed output file is recorded in a logfile named with the associated forecast hour.
 
@@ -96,7 +97,9 @@ contains
     character(len=128)      :: alarm_name
     integer                 :: opt_n
     logical                 :: chkfile_nextAdvance
+    logical                 :: use_filesize
     character(len=1024)     :: filename
+    integer                 :: createsize
     type(ESMF_Alarm)        :: alarm
     type(ESMF_TimeInterval) :: fhoffset
     type(ESMF_TimeInterval) :: filename_fhoffset
@@ -124,9 +127,9 @@ contains
   !! @param rc      return code
   subroutine outputlog_init(gcomp, mclock, rc)
 
-    type(ESMF_GridComp)  :: gcomp  !< ESMF_GridComp object
-    type(ESMF_Clock)     :: mclock !< ESMF_clock for the model
-    integer, intent(out) :: rc     !< return code
+    type(ESMF_GridComp)  :: gcomp
+    type(ESMF_Clock)     :: mclock
+    integer, intent(out) :: rc
 
     ! local variables
     type(ESMF_Time)         :: mcurrTime
@@ -216,7 +219,9 @@ contains
       olog(n)%alarm_name          = 'output_alarm'//trim(chour)
       olog(n)%opt_n               = freq(n)
       olog(n)%chkfile_nextAdvance = .false.
+      olog(n)%use_filesize        = .false.
       olog(n)%filename            = ''
+      olog(n)%createsize            = 0
       olog(n)%time_lastrestart    = lastrestart
       olog(n)%fhoffset            = 60*freq(n)*tincrement
       olog(n)%filename_fhoffset   = 90*freq(n)*tincrement
@@ -255,15 +260,15 @@ contains
   !! @param rc           return code
   subroutine outputlog_run(mclock, atStopTime, rc)
 
-    type(ESMF_Clock)              :: mclock     !< the ESMF_clock for the model
-    logical, intent(in), optional :: atStopTime !< if true, checks for final output file
-    integer, intent(out)          :: rc         !< return code
+    type(ESMF_Clock)              :: mclock
+    logical, intent(in), optional :: atStopTime
+    integer, intent(out)          :: rc
 
     ! local variables
     type(ESMF_Time)    :: nextTime, currTime, startTime, prevRing
     logical            :: lstop
-    integer            :: n, nlen(1)
-    integer            :: filesize
+    logical            :: filetest
+    integer            :: n, nlen(1), fsize(1)
     character(len=40)  :: importexport
     character(len=16)  :: timestr
     character(len=512) :: fname
@@ -284,6 +289,10 @@ contains
       lstop = atStopTime
     end if
 
+    filetest = .false.
+    fsize(1) = nf90_fill_int
+    nlen(1)  = nf90_fill_int
+
     do n = 1,n_freq
       write(chour,'(I2.2,A)')freq(n),'h'
       if (chour(1:2) == output_fh(1:2)) then
@@ -299,42 +308,50 @@ contains
           timestr = get_timestr(nextTime-olog(n)%filename_fhoffset, rc=rc)
           if (ChkErr(rc,__LINE__,u_FILE_u)) return
           write(olog(n)%filename,'(A)')trim(outputdir)//'ocn_'//trim(timestr)//'.nc'
-          if (debug .and. is_root_pe()) then
-             print '(A,L)',trim(subname)//' fname '//trim(olog(n)%filename)//'  '//trim(importexport) &
-                  //' checkflag ',olog(n)%chkfile_nextAdvance
-          end if
-        end if
 
-        if (olog(n)%chkfile_nextAdvance) then
           fname = trim(olog(n)%filename)
           inquire(file=fname, exist=existflag)
           if (existflag) then
             if (is_root_pe()) then
               nlen(1) = get_unlimited_len(trim(fname))
+              inquire(file=fname, size=fsize(1))
             end if
             call ESMF_VMBroadCast(vm, nlen, 1, 0, rc=rc)
             if (ChkErr(rc,__LINE__,u_FILE_u)) return
+            call ESMF_VMBroadCast(vm, fsize, 1, 0, rc=rc)
+            if (ChkErr(rc,__LINE__,u_FILE_u)) return
+            olog(n)%createsize = fsize(1)
 
-            if (nlen(1) > 0) then
-              olog(n)%chkfile_nextAdvance = .false.
-              olog(n)%time_lastrestart = lastrestart
-              if (is_root_pe()) then
-                if (toffset > 0) then
-                  call log_restart_fh(nextTime-olog(n)%fhoffset, startTime, 'mom6.'//chour, prefixtime=.true., &
-                       lastrestart=olog(n)%time_lastrestart, lastoutput=olog(n)%filename, rc=rc)
-                  if (ChkErr(rc,__LINE__,u_FILE_u)) return
-                else
-                  call log_restart_fh(currTime-olog(n)%fhoffset, startTime, 'mom6.'//chour, prefixtime=.true., &
-                       lastrestart=olog(n)%time_lastrestart, lastoutput=olog(n)%filename, rc=rc)
-                  if (ChkErr(rc,__LINE__,u_FILE_u)) return
-                end if
-              endif
+            if (nlen(1) == 0) then
+              olog(n)%use_filesize = .false.
+            else
+              olog(n)%use_filesize = .true.
             end if
-          end if ! existflag
+          end if
+          if (debug .and. is_root_pe()) then
+            print '(A,2(A,L),A,2i16)',trim(subname)//' fname '//trim(olog(n)%filename)//'  '//trim(importexport), &
+                 ' checkflag ',olog(n)%chkfile_nextAdvance,' use_filesize ',olog(n)%use_filesize,                 &
+                 '  ',olog(n)%createsize,nlen(1)
+          end if
         end if
 
-        if (debug .and. is_root_pe()) call debug_info(trim(subname)//'  ',trim(fname), &
-             olog(n)%chkfile_nextAdvance, importexport)
+        if (olog(n)%chkfile_nextAdvance) then
+          fname = trim(olog(n)%filename)
+          filetest = file_is_complete(fname, olog(n)%use_filesize, olog(n)%createsize, rc)
+          if (ChkErr(rc,__LINE__,u_FILE_u)) return
+
+          if (filetest) then
+            olog(n)%chkfile_nextAdvance = .false.
+            olog(n)%time_lastrestart = lastrestart
+            if (is_root_pe()) then
+              call log_restart_fh(currTime-olog(n)%fhoffset, startTime, 'mom6.'//chour, prefixtime=.true., &
+                   lastrestart=olog(n)%time_lastrestart, lastoutput=olog(n)%filename, rc=rc)
+              if (ChkErr(rc,__LINE__,u_FILE_u)) return
+            endif
+          end if
+        end if
+        if (debug .and. is_root_pe()) call debug_info(trim(subname)//'  ',trim(olog(n)%filename), &
+             olog(n)%chkfile_nextAdvance, olog(n)%createsize, importexport)
 
         if (lstop) then
           ! use prevRing in place of currTime to allow for stopping between averaging intervals
@@ -345,32 +362,23 @@ contains
           timestr = get_timestr(prevring-30*freq(n)*tincrement, rc=rc)
           if (ChkErr(rc,__LINE__,u_FILE_u)) return
           write(olog(n)%filename,'(A)')trim(outputdir)//'ocn_'//trim(timestr)//'.nc'
-          if (debug .and. is_root_pe()) then
-            print '(A)',trim(subname)//' fname at lstop '//trim(olog(n)%filename)//'  '//trim(importexport)
-          end if
 
           fname = trim(olog(n)%filename)
-          inquire(file=fname, exist=existflag)
-          if (existflag) then
-            if (is_root_pe()) then
-              nlen(1) = get_unlimited_len(fname)
-            end if
-            call ESMF_VMBroadCast(vm, nlen, 1, 0, rc=rc)
-            if (ChkErr(rc,__LINE__,u_FILE_u)) return
+          filetest = file_is_complete(fname, olog(n)%use_filesize, olog(n)%createsize, rc)
+          if (ChkErr(rc,__LINE__,u_FILE_u)) return
 
-            if (nlen(1) > 0) then
-              olog(n)%chkfile_nextAdvance = .false.
-              olog(n)%time_lastrestart = lastrestart
-              if (is_root_pe()) then
-                call log_restart_fh(prevring, startTime, 'mom6.'//chour, prefixtime=.true., &
-                     lastrestart=olog(n)%time_lastrestart, lastoutput=olog(n)%filename, rc=rc)
-                if (ChkErr(rc,__LINE__,u_FILE_u)) return
-              end if
+          if (filetest) then
+            olog(n)%chkfile_nextAdvance = .false.
+            olog(n)%time_lastrestart = lastrestart
+            if (is_root_pe()) then
+              call log_restart_fh(prevring, startTime, 'mom6.lstop.'//chour, prefixtime=.true., &
+                   lastrestart=olog(n)%time_lastrestart, lastoutput=olog(n)%filename, rc=rc)
+              if (ChkErr(rc,__LINE__,u_FILE_u)) return
             end if
           end if
+          if (debug .and. is_root_pe()) call debug_info(trim(subname)//' lstop ',trim(olog(n)%filename), &
+               olog(n)%chkfile_nextAdvance, olog(n)%createsize, importexport)
 
-          if (debug .and. is_root_pe()) call debug_info(trim(subname)//' lstop ',trim(fname), &
-              olog(n)%chkfile_nextAdvance, importexport)
         end if ! lstop
       end if ! chour = output_fh
     end do
@@ -378,13 +386,13 @@ contains
 
   !> Check all restart files to determine if output has been completed
   !!
-  !! @param clock          an ESMF_Clock object
-  !! @param num_rest_files the number of restart files
-  !! @param rc             return code
+  !! @param[in]    clock            an ESMF_Clock object
+  !! @param[in]    num_rest_files   the number of restart files
+  !! @param[out]   rc               return code
   subroutine outputlog_restart(mclock, num_rest_files, rc)
-    type(ESMF_Clock)     :: mclock         !< the ESMF_clock for the model
-    integer, intent(in)  :: num_rest_files !< the number of restart files
-    integer, intent(out) :: rc             !< return code
+    type(ESMF_Clock)     :: mclock
+    integer, intent(in)  :: num_rest_files
+    integer, intent(out) :: rc
 
     ! local variables
     type(ESMF_Time)      :: startTime, currTime, nextTime
@@ -456,6 +464,48 @@ contains
       endif
     end if
   end subroutine outputlog_restart
+
+  !> Determine if the netcdf output file is complete
+  !!
+  !! @param[in]   fname         the file name
+  !! @param[in]   chk4size      logical flag for check method in use
+  !! @param[in]   createsize    the filesize at creation
+  !! @param[out]  rc            return code
+  logical function file_is_complete(fname, chk4size, createsize, rc) result(filetest)
+
+    character(len=*), intent(in)  :: fname
+    logical,          intent(in)  :: chk4size
+    integer,          intent(in)  :: createsize
+    integer,          intent(out) :: rc
+
+    integer :: nlen(1), fsize(1)
+    !----------------------------------------------------------------------------
+
+    rc = ESMF_SUCCESS
+
+    filetest = .false.
+    nlen(1) = nf90_fill_int
+    fsize(1) = nf90_fill_int
+
+    inquire(file=fname, exist=existflag)
+    if (existflag) then
+      if (is_root_pe()) then
+        nlen(1) = get_unlimited_len(fname)
+        inquire(file=fname, size=fsize(1))
+      end if
+      call ESMF_VMBroadCast(vm, nlen, 1, 0, rc=rc)
+      if (ChkErr(rc,__LINE__,u_FILE_u)) return
+      call ESMF_VMBroadCast(vm, fsize, 1, 0, rc=rc)
+      if (ChkErr(rc,__LINE__,u_FILE_u)) return
+    end if
+
+    if (chk4size) then
+      filetest = (nlen(1) > 0 .and. fsize(1) > createsize)
+    else
+      filetest = (nlen(1) > 0)
+    end if
+  end function file_is_complete
+
   !> Return the length of the unlimited dimension
   !!
   !! @param[in]  fname   the file name
@@ -486,6 +536,7 @@ contains
 
     integer :: year, month, day, hour, minute
     !----------------------------------------------------------------------------
+
     rc = ESMF_SUCCESS
 
     call ESMF_TimeGet(MyTime, yy=year, mm=month, dd=day, h=hour, m=minute, rc=rc)
@@ -506,6 +557,7 @@ contains
 
     character(len=19) :: import_timestr, export_timestr
     !----------------------------------------------------------------------------
+
     rc = ESMF_SUCCESS
 
     call ESMF_TimeGet(currTime, timestring=import_timestr, rc=rc)
@@ -515,32 +567,36 @@ contains
     importexport = trim(import_timestr)//'  '//trim(export_timestr)
   end function get_importexport
 
-  !> Write debug info to stdout
+  !> Write debug info to stdout, only called on root pe
   !!
   !! @param[in] tag            an information tag
   !! @param[in] fname          the filename to check
+  !! @param[in] filesize       the filesize at creation time
   !! @param[in] chkflag        logical flag for checking next Advance
   !! @param[in] timestring     a timestring
   !! @param [out]rc            return code
-  subroutine debug_info(tag,fname,chkflag,timestring)
+  subroutine debug_info(tag,fname,chkflag,filesize,timestring)
 
     character(len=*), intent(in) :: tag
     character(len=*), intent(in) :: fname
+    integer,          intent(in) :: filesize
     logical,          intent(in) :: chkflag
     character(len=*), intent(in) :: timestring
 
-    integer :: nlen(1), filesize
+    integer :: fsize
     !----------------------------------------------------------------------------
 
-    inquire(file=fname, exist=existflag, size=filesize)
+    inquire(file=fname, exist=existflag)
     if (existflag) then
-      nlen(1) = get_unlimited_len(fname)
+      inquire(file=fname, size=fsize)
       write(msgString,'(A)')tag//'  '//fname//' exists '//timestring
-      if (nlen(1) > 0) then
-        print '(A,L,i14)',trim(msgString)//' complete, chkflag ',chkflag,filesize
+      if (chkflag) then
+        print '(A,L,2i16)',trim(msgString)//' not complete, chkflag ',chkflag,filesize,fsize
       else
-        print '(A,L,i14)',trim(msgString)//' still  0, chkflag ',chkflag,filesize
+        print '(A,L,2i16)',trim(msgString)//'     complete, chkflag ',chkflag,filesize,fsize
       end if
+    else
+      write(msgString,'(A)')tag//'  '//fname//' does not exist '//timestring
     end if
   end subroutine debug_info
 

--- a/config_src/drivers/nuopc_cap/mom_cap_outputlog.F90
+++ b/config_src/drivers/nuopc_cap/mom_cap_outputlog.F90
@@ -1,7 +1,7 @@
-!> This module contains a set of subroutines that check if MOM restart
-!! and history files have been written and closed. This file is specific
-!! to UWM operational requirements and configurations (eg specific output
-!! frequencys in hours) and may break if used outside the scope of intended use.
+!> This module contains a set of subroutines that check if MOM restart and history files
+!! have been written and closed. This file is specific to UWM operational requirements
+!! and configurations (eg specific output frequencys in hours) and may break if used outside
+!! the scope of intended use.
 !! This module a stub when CESMCOUPLED is defined
 module MOM_cap_outputlog
 
@@ -59,7 +59,7 @@ contains
   ! the file name must be set as the mid-point of the averaging period via the diagtable
   ! and the output filename timestrings are given by
   !      T - (interval * 60 * increment + interval/2 * 60 * increment )
-  ! where T is the time that the currTime when the file is closed
+  ! where T is the time when the file is closed
   !
   !   00   .   03   .   06   .   09
   !       1:30 = 6 - (3 + 1:30)
@@ -86,7 +86,7 @@ contains
   ! log is overwritten
   !
   ! an output file is declared closed when the unlimited dimension in the file is > 0
-  ! each closed output file is recorded in a logfile at the associated forecast hour.
+  ! each closed output file is recorded in a logfile named with the associated forecast hour.
 
   type(ESMF_TimeInterval) :: tincrement
   type(ESMF_Time)         :: lastrestart
@@ -99,6 +99,7 @@ contains
     type(ESMF_Alarm)        :: alarm
     type(ESMF_TimeInterval) :: fhoffset
     type(ESMF_TimeInterval) :: filename_fhoffset
+    type(ESMF_TimeInterval) :: fh_iauoffset
     type(ESMF_Time)         :: time_lastrestart
   end type outputlog_type
 
@@ -110,28 +111,33 @@ contains
   character(len=256) :: outputdir
   character(len=2)   :: output_fh
   character(len=3)   :: chour
+  character(len=512) :: msgString
   character(len=*), parameter :: u_FILE_u = &
        __FILE__
 
 contains
   !> Initialize a set of Alarms at the allowed output frequencies
   !!
-  !! @param gcomp an ESMF_GridComp object
-  !! @param clock an ESMF_Clock object
-  !! @param rc    return code
+  !! @param gcomp   an ESMF_GridComp object
+  !! @param clock   an ESMF_Clock object
+  !! @param rc      return code
   subroutine outputlog_init(gcomp, mclock, rc)
 
-    type(ESMF_GridComp)  :: gcomp  !< an ESMF_GridComp object
-    type(ESMF_Clock)     :: mclock !< the ESMF_clock for the model
+    type(ESMF_GridComp)  :: gcomp  !< ESMF_GridComp object
+    type(ESMF_Clock)     :: mclock !< ESMF_clock for the model
     integer, intent(out) :: rc     !< return code
 
     ! local variables
     type(ESMF_Time)         :: mcurrTime, startTime
     type(ESMF_TimeInterval) :: timestep
     logical                 :: isPresent, isSet
+    integer                 :: iau_offset
     integer                 :: n
     character(len=256)      :: value
     character(len=256)      :: subname='MOM_cap:(outputlog_init) '
+    !debug
+    character(len=16) :: timestr
+    integer :: year,month,day,hour,minute
     !----------------------------------------------------------------------------
 
     rc = ESMF_SUCCESS
@@ -147,7 +153,8 @@ contains
     if (restartdir(len_trim(restartdir):len_trim(restartdir)) /= '/') then
       restartdir = trim(restartdir)//'/'
     end if
-    call ESMF_LogWrite('MOM_cap:MOM6 restart directory = '//trim(restartdir), ESMF_LOGMSG_INFO)
+    write(msgString,'(A)')'MOM_cap:MOM6 restart directory = '//trim(restartdir)
+    call ESMF_LogWrite(trim(msgString), ESMF_LOGMSG_INFO)
 
     call NUOPC_CompAttributeGet(gcomp, name="mom6_output_dir", value=value, &
          isPresent=isPresent, isSet=isSet, rc=rc)
@@ -160,7 +167,8 @@ contains
     if (outputdir(len_trim(outputdir):len_trim(outputdir)) /= '/') then
       outputdir = trim(outputdir)//'/'
     end if
-    call ESMF_LogWrite('MOM_cap:MOM6 output directory = '//trim(outputdir), ESMF_LOGMSG_INFO)
+    write(msgString,'(A)')'MOM_cap:MOM6 output directory = '//trim(outputdir)
+    call ESMF_LogWrite(trim(msgString), ESMF_LOGMSG_INFO)
 
     call NUOPC_CompAttributeGet(gcomp, name="mom6_output_fh", value=value, &
          isPresent=isPresent, isSet=isSet, rc=rc)
@@ -174,7 +182,18 @@ contains
     else
       output_fh = '06'
     end if
-    call ESMF_LogWrite('MOM_cap:MOM6 output frequency = '//trim(output_fh), ESMF_LOGMSG_INFO)
+    write(msgString,'(A)')'MOM_cap:MOM6 output frequency = '//trim(output_fh)
+    call ESMF_LogWrite(trim(msgString), ESMF_LOGMSG_INFO)
+
+    iau_offset = 0
+    call NUOPC_CompAttributeGet(gcomp, name="iau_offset", value=value, &
+         isPresent=isPresent, isSet=isSet, rc=rc)
+    if (ChkErr(rc,__LINE__,u_FILE_u)) return
+    if (isPresent .and. isSet) then
+      read(value,*)iau_offset
+    end if
+    write(msgString,'(A,i6)')'MOM_cap:MOM6 iau_offset ',iau_offset
+    call ESMF_LogWrite(trim(msgString), ESMF_LOGMSG_INFO)
 
     debug = .false.
     call NUOPC_CompAttributeGet(gcomp, name="debug_outputlog", value=value, &
@@ -191,42 +210,51 @@ contains
     ! initialize
     lastrestart = startTime
 
+    call ESMF_TimeGet (mcurrTime-iau_offset*30*tincrement, yy=year, mm=month, dd=day, h=hour, m=minute, rc=rc )
+    if (ChkErr(rc,__LINE__,u_FILE_u)) return
+    write(timestr,'(I4.4,4(A,I2.2))')year,'_',month,'_',day,'_',hour,'_',minute
+    if (debug .and. is_root_pe())print *,'XXX ',trim(timestr)
+
     do n = 1,n_freq
       write(chour,'(I2.2,A)')freq(n),'h'
       olog(n)%alarm_name          = 'output_alarm'//trim(chour)
       olog(n)%opt_n               = freq(n)
       olog(n)%fhoffset            = 60*freq(n)*tincrement
       olog(n)%filename_fhoffset   = 90*freq(n)*tincrement
-      olog(n)%chkfile_nextAdvance = .false.               ! alarms ring at the ouput freq, but files close on next advance
+      olog(n)%chkfile_nextAdvance = .false.
       olog(n)%filename            = ''
       olog(n)%time_lastrestart    = lastrestart
+      if (freq(n) .eq. 6) then
+        olog(n)%fh_iauoffset      = iau_offset*30*tincrement
+      else
+        olog(n)%fh_iauoffset      = 0
+      end if
 
-      call AlarmInit(mclock,           &
-           alarm     = olog(n)%alarm,  &
-           option    = 'nhours',       &
-           opt_n     = olog(n)%opt_n,  &
-           opt_ymd   = -999,           &
-           RefTime   = mcurrTime,      &
+      call AlarmInit(mclock,                           &
+           alarm     = olog(n)%alarm,                  &
+           option    = 'nhours',                       &
+           opt_n     = olog(n)%opt_n,                  &
+           opt_ymd   = -999,                           &
+           RefTime   = mcurrTime-olog(n)%fh_iauoffset, &
            alarmname = olog(n)%alarm_name, rc=rc)
       if (ChkErr(rc,__LINE__,u_FILE_u)) return
 
       call ESMF_AlarmSet(olog(n)%alarm, clock=mclock, rc=rc)
       if (ChkErr(rc,__LINE__,u_FILE_u)) return
-      call ESMF_LogWrite(trim(subname)//" Output alarm "//trim(olog(n)%alarm_name)//" is Created and Set", ESMF_LOGMSG_INFO)
+      write(msgString,'(A)')trim(subname)//' Output alarm '//trim(olog(n)%alarm_name)//' Created & Set'
+      call ESMF_LogWrite(trim(msgString), ESMF_LOGMSG_INFO)
       if (debug .and. is_root_pe()) then
         call ESMF_TimeIntervalPrint(olog(n)%filename_fhoffset, options="string", rc=rc)
         if (ChkErr(rc,__LINE__,u_FILE_u)) return
       end if
-
     end do
 
   end subroutine outputlog_init
-  !> Use Alarms at the output frequency to determine if output has been
-  !! completed
+  !> Use Alarms at the output frequency to determine if output has been completed
   !!
-  !! @param clock      an ESMF_Clock object
-  !! @param atStopTime when present, checks for final output file
-  !! @param rc         return code
+  !! @param clock        an ESMF_Clock object
+  !! @param atStopTime   when present, checks for final output file
+  !! @param rc           return code
   subroutine outputlog_run(mclock, atStopTime, rc)
 
     type(ESMF_Clock)              :: mclock     !< the ESMF_clock for the model
@@ -236,10 +264,11 @@ contains
     ! local variables
     type(ESMF_Time)         :: nextTime, currTime, startTime, prevRing
     type(ESMF_TimeInterval) :: timeStep
-    logical                 :: lstop, stop_on_interval
+    logical                 :: lstop
     integer                 :: n, ncid, dimid, nlen
     integer                 :: year, month, day, hour, minute
-    character(len=256)      :: import_timestr, export_timestr, importexport !debugging only
+    character(len=512)      :: import_timestr, export_timestr, importexport !debugging only
+    character(len=16)       :: timestr
     character(len=512)      :: fname
     character(len=256)      :: subname='MOM_cap:(outputlog_run) '
     !----------------------------------------------------------------------------
@@ -255,7 +284,6 @@ contains
     importexport = trim(import_timestr)//'  '//trim(export_timestr)
 
     lstop = .false.
-    stop_on_interval = .false.
     if (present(atStopTime)) then
       lstop = atStopTime
     end if
@@ -268,6 +296,9 @@ contains
         ! when the alarm rings, set file check on next advance and construct the filename
         if (ESMF_AlarmIsRinging(olog(n)%alarm, rc=rc)) then
           if (ChkErr(rc,__LINE__,u_FILE_u)) return
+          if (debug .and. is_root_pe()) then
+            print *,'XXXX alarm is ringing '//trim(importexport)
+          end if
           call ESMF_AlarmRingerOff(olog(n)%alarm, rc=rc )
           if (ChkErr(rc,__LINE__,u_FILE_u)) return
           olog(n)%chkfile_nextAdvance = .true.
@@ -276,7 +307,8 @@ contains
           if (ChkErr(rc,__LINE__,u_FILE_u)) return
           call ESMF_TimeGet (nextTime-olog(n)%filename_fhoffset, yy=year, mm=month, dd=day, h=hour, m=minute, rc=rc )
           if (ChkErr(rc,__LINE__,u_FILE_u)) return
-          write(olog(n)%filename,'(A,I4.4,4(A,I2.2),A)')trim(outputdir)//'ocn_',year,'_',month,'_',day,'_',hour,'_',minute,'.nc'
+          write(timestr,'(I4.4,4(A,I2.2))')year,'_',month,'_',day,'_',hour,'_',minute
+          write(olog(n)%filename,'(A)')trim(outputdir)//'ocn_'//trim(timestr)//'.nc'
 
           if (debug .and. is_root_pe()) then
             print '(A)',trim(subname)//' fname '//trim(olog(n)%filename)//'  '//trim(importexport)
@@ -304,28 +336,21 @@ contains
         end if
 
         if (lstop) then
-          ! need separate logic for stopping on interval and stopping between intervals
+          ! use prevRing in place of currTime to allow for stopping between averaging
+          ! intervals; prevring == currTime if stopping on intervals
           call ESMF_AlarmGet(olog(n)%alarm, prevRingTime=prevring, rc=rc)
           if (ChkErr(rc,__LINE__,u_FILE_u)) return
           if (debug .and. is_root_pe()) then
             call ESMF_TimeGet(prevring, yy=year, mm=month, dd=day, h=hour, m=minute, rc=rc)
             if (ChkErr(rc,__LINE__,u_FILE_u)) return
-            print '(A,I4.4,4(A,I2.2))',trim(subname)//' prevring at lstop ',year,'_',month,'_',day,'_',hour,'_',minute
+            write(timestr,'(I4.4,4(A,I2.2))')year,'_',month,'_',day,'_',hour,'_',minute
+            print '(A)',trim(subname)//' prevring at lstop '//trim(timestr)
           end if
 
-          if (prevring == currTime) then
-            stop_on_interval = .true.
-          else
-            stop_on_interval = .false.
-          end if
-          if (stop_on_interval) then
-            call ESMF_TimeGet(currTime-30*freq(n)*tincrement, yy=year, mm=month, dd=day, h=hour, m=minute, rc=rc)
-            if (ChkErr(rc,__LINE__,u_FILE_u)) return
-          else
-            call ESMF_TimeGet(prevring-30*freq(n)*tincrement, yy=year, mm=month, dd=day, h=hour, m=minute, rc=rc)
-            if (ChkErr(rc,__LINE__,u_FILE_u)) return
-          end if
-          write(olog(n)%filename,'(A,I4.4,4(A,I2.2),A)')trim(outputdir)//'ocn_',year,'_',month,'_',day,'_',hour,'_',minute,'.nc'
+          call ESMF_TimeGet(prevring-30*freq(n)*tincrement, yy=year, mm=month, dd=day, h=hour, m=minute, rc=rc)
+          if (ChkErr(rc,__LINE__,u_FILE_u)) return
+          write(timestr,'(I4.4,4(A,I2.2))')year,'_',month,'_',day,'_',hour,'_',minute
+          write(olog(n)%filename,'(A)')trim(outputdir)//'ocn_'//trim(timestr)//'.nc'
           if (debug .and. is_root_pe()) then
             print '(A)',trim(subname)//' fname at lstop '//trim(olog(n)%filename)//'  '//trim(importexport)
           end if
@@ -343,13 +368,8 @@ contains
               call ESMF_ClockGet(mclock, currTime=currTime, rc=rc)
               if (ChkErr(rc,__LINE__,u_FILE_u)) return
               if (is_root_pe()) then
-                if (stop_on_interval) then
-                  call log_restart_fh(currTime, startTime, 'mom6.stop.'//chour, prefixtime=.true., &
-                       lastrestart=olog(n)%time_lastrestart, lastoutput=olog(n)%filename, rc=rc)
-                else
-                  call log_restart_fh(prevring, startTime, 'mom6.stop.'//chour, prefixtime=.true., &
-                       lastrestart=olog(n)%time_lastrestart, lastoutput=olog(n)%filename, rc=rc)
-                end if
+                call log_restart_fh(prevring, startTime, 'mom6.stop.'//chour, prefixtime=.true., &
+                     lastrestart=olog(n)%time_lastrestart, lastoutput=olog(n)%filename, rc=rc)
                 if (ChkErr(rc,__LINE__,u_FILE_u)) return
               end if
             end if
@@ -360,15 +380,16 @@ contains
           fname = trim(olog(n)%filename)
           inquire(file=fname, exist=existflag)
           if (existflag) then
-            call nf90_err(nf90_open(fname, nf90_nowrite, ncid), 'nf90_open: '//fname)
-            call nf90_err(nf90_inquire(ncid, unlimiteddimid=dimid), 'inquire unlimiteddimid')
-            call nf90_err(nf90_inquire_dimension(ncid, dimid, len=nlen), 'inquire unlimited dimension')
-            call nf90_err(nf90_close(ncid), 'close: '//fname)
+           call nf90_err(nf90_open(fname, nf90_nowrite, ncid), 'nf90_open: '//fname)
+           call nf90_err(nf90_inquire(ncid, unlimiteddimid=dimid), 'inquire unlimiteddimid')
+           call nf90_err(nf90_inquire_dimension(ncid, dimid, len=nlen), 'inquire unlimited dimension')
+           call nf90_err(nf90_close(ncid), 'close: '//fname)
             if (is_root_pe()) then
+              write(msgString,'(A)')trim(subname)//trim(fname)//' exists '//trim(importexport)
               if (nlen > 0) then
-                print '(A,L)',trim(subname)//trim(fname)//' exists '//trim(importexport)//' complete ',olog(n)%chkfile_nextAdvance
+                print '(A,L)',trim(msgString)//' complete ',olog(n)%chkfile_nextAdvance
               else
-                print '(A,L)',trim(subname)//trim(fname)//' exists '//trim(importexport)//' still 0 ',olog(n)%chkfile_nextAdvance
+                print '(A,L)',trim(msgString)//' still  0 ',olog(n)%chkfile_nextAdvance
               end if
             end if
           end if
@@ -437,10 +458,10 @@ contains
       ! check if file is written
       inquire(file=trim(fname), exist=existflag)
       if (existflag) then
-        call nf90_err(nf90_open(fname, nf90_nowrite, ncid), 'nf90_open: '//fname)
+        call nf90_err(nf90_open(trim(fname), nf90_nowrite, ncid), 'nf90_open: '//trim(fname))
         call nf90_err(nf90_inquire(ncid, unlimiteddimid=dimid), 'inquire unlimiteddimid')
         call nf90_err(nf90_inquire_dimension(ncid, dimid, len=nlen), 'inquire unlimited dimension')
-        call nf90_err(nf90_close(ncid), 'close: '//fname)
+        call nf90_err(nf90_close(ncid), 'close: '//trim(fname))
         if (nlen > 0) allDone(n) = .true.
 
         if (debug .and. is_root_pe()) then

--- a/config_src/drivers/nuopc_cap/mom_cap_outputlog.F90
+++ b/config_src/drivers/nuopc_cap/mom_cap_outputlog.F90
@@ -6,38 +6,40 @@
 module MOM_cap_outputlog
 
 #ifdef CESMCOUPLED
-  use ESMF                  , only : ESMF_Clock, ESMF_SUCCESS
+  use ESMF                  , only : ESMF_GridComp, ESMF_Clock, ESMF_SUCCESS
   implicit none; private
 
   public :: outputlog_init, outputlog_run, outputlog_restart
 contains
   subroutine outputlog_init(gcomp, mclock, rc)
-
     type(ESMF_GridComp)  :: gcomp  !< an ESMF_GridComp object
     type(ESMF_Clock)     :: mclock !< the ESMF_clock for the model
     integer, intent(out) :: rc     !< return code
     rc = ESMF_SUCCESS
   end subroutine outputlog_init
-  subroutine outputlog_run(mclock, rc)
-    type(ESMF_Clock)     :: mclock !< the ESMF_clock for the model
-    integer, intent(out) :: rc     !< return code
+  subroutine outputlog_run(mclock, atStopTime, rc)
+    type(ESMF_Clock)              :: mclock     !< the ESMF_clock for the model
+    logical, intent(in), optional :: atStopTime !< if true, checks for final output file
+    integer, intent(out)          :: rc         !< return code
     rc = ESMF_SUCCESS
   end subroutine outputlog_run
-  subroutine outputlog_restart(mclock, num_rest_files, rc=rc)
+  subroutine outputlog_restart(mclock, num_rest_files, rc)
     type(ESMF_Clock)     :: mclock         !< the ESMF_clock for the model
     integer, intent(in)  :: num_rest_files !< the number of restart files
     integer, intent(out) :: rc             !< return code
     rc = ESMF_SUCCESS
   end subroutine outputlog_restart
 #else
-  use MOM_error_handler,      only : is_root_pe
+  use MOM_error_handler     , only : is_root_pe, MOM_error, FATAL
+  use NUOPC                 , only : NUOPC_CompAttributeGet
+  use ESMF                  , only : ESMF_GridComp
   use ESMF                  , only : ESMF_Time, ESMF_Clock, ESMF_ClockGet, ESMF_Alarm, ESMF_AlarmSet
   use ESMF                  , only : ESMF_ClockGetAlarm, ESMF_AlarmIsRinging, ESMF_AlarmRingerOff
   use ESMF                  , only : ESMF_ClockGetNextTime, ESMF_TimeGet, ESMF_TimeInterval
-  use ESMF                  , only : ESMF_TimeIntervalSet
+  use ESMF                  , only : ESMF_TimeIntervalSet, ESMF_TimeIntervalPrint, ESMF_TimePrint
   use ESMF                  , only : ESMF_SUCCESS, ESMF_LogWrite, ESMF_LOGMSG_INFO
   use ESMF                  , only : ESMF_LogSetError, ESMF_LogFoundError, ESMF_LOGERR_PASSTHRU
-  use ESMF                  , only : operator(*), operator(+), operator(-)
+  use ESMF                  , only : operator(*), operator(+), operator(-), operator(>), operator(==)
   use MOM_cap_methods       , only : ChkErr
   use MOM_cap_time          , only : AlarmInit
   use shr_is_restart_fh_mod , only : log_restart_fh
@@ -45,7 +47,7 @@ contains
 
   implicit none; private
 
-  public :: outputlog_init, outputlog_run
+  public :: outputlog_init, outputlog_run, outputlog_restart
 
   ! the allowable output frequency for MOM6 history, in hours only
   ! TODO: 3hrly output reqs filename with minutes field
@@ -55,13 +57,25 @@ contains
   integer, parameter, dimension(n_freq) :: freq = (/3, 6, 24/)
 
   ! the timeoffset interval is used only to construct the file name.
-  ! filenames will be given by T - (interval * offset + interval/2 * offset)
+  ! the file name must be set as the mid-point of the averaging period.
+  ! filenames will be given by
+  !      T - (interval * offset + interval/2 * offset)
   ! where interval is the averaging interval in minutes
-  !   00   .     06   .   12   .  18
-  !        03 = 12 - (6 + 3)
-  !                  09 = 18 - (6 + 3)
-  ! the timeoffset must be defined in minutes to allow sub-6hrly output
+  !
+  !   00   .   03   .   06   .   09
+  !       1:30 = 6 - (3 + 1:30)
+  !                4:30 = 9 - (3 + 1:30)
+  !
+  !   00   .   06   .   12   .   18
+  !       03 = 12 - (6 + 3)
+  !                 09 = 18 - (6 + 3)
+  !
+  !   00   .   24   .   48   .   72
+  !       12 = 48 - (24 + 12)
+  !                 36 = 72 - (24 + 12)
+  !
   type(ESMF_TimeInterval) :: timeoffset
+  type(ESMF_Time)         :: lastrestart
 
   type :: outputlog_type
     character(len=128)      :: alarm_name
@@ -70,10 +84,13 @@ contains
     character(len=1024)     :: filename
     type(ESMF_Alarm)        :: alarm
     type(ESMF_TimeInterval) :: filename_timeoffset
+    type(ESMF_Time)         :: time_lastrestart
   end type outputlog_type
 
   type(outputlog_type) :: olog(n_freq)
 
+  logical            :: debug
+  logical            :: existflag
   character(len=256) :: restartdir
   character(len=256) :: outputdir
   character(len=2)   :: output_fh
@@ -94,16 +111,17 @@ contains
     integer, intent(out) :: rc     !< return code
 
     ! local variables
-    type(ESMF_Time)         :: mcurrtime
+    type(ESMF_Time)         :: mcurrTime, startTime
     type(ESMF_TimeInterval) :: timestep
+    logical                 :: isPresent, isSet
     integer                 :: n
     character(len=256)      :: value
     character(len=256)      :: subname='MOM_cap:(outputlog_init) '
-    !--------------------------------
+    !----------------------------------------------------------------------------
 
     rc = ESMF_SUCCESS
 
-    call NUOPC_CompAttributeGet(gcomp, name="mom6_restartdir", value=value, &
+    call NUOPC_CompAttributeGet(gcomp, name="mom6_restart_dir", value=value, &
          isPresent=isPresent, isSet=isSet, rc=rc)
     if (ChkErr(rc,__LINE__,u_FILE_u)) return
     if (isPresent .and. isSet) then
@@ -111,9 +129,12 @@ contains
     else
       restartdir = './'
     end if
+    if (restartdir(len_trim(restartdir):len_trim(restartdir)) /= '/') then
+      restartdir = trim(restartdir)//'/'
+    end if
     call ESMF_LogWrite('MOM_cap:MOM6 restart directory = '//trim(restartdir), ESMF_LOGMSG_INFO)
 
-    call NUOPC_CompAttributeGet(gcomp, name="mom6_outputdir", value=value, &
+    call NUOPC_CompAttributeGet(gcomp, name="mom6_output_dir", value=value, &
          isPresent=isPresent, isSet=isSet, rc=rc)
     if (ChkErr(rc,__LINE__,u_FILE_u)) return
     if (isPresent .and. isSet) then
@@ -121,31 +142,45 @@ contains
     else
       outputdir = './'
     end if
+    if (outputdir(len_trim(outputdir):len_trim(outputdir)) /= '/') then
+      outputdir = trim(outputdir)//'/'
+    end if
     call ESMF_LogWrite('MOM_cap:MOM6 output directory = '//trim(outputdir), ESMF_LOGMSG_INFO)
 
     call NUOPC_CompAttributeGet(gcomp, name="mom6_output_fh", value=value, &
          isPresent=isPresent, isSet=isSet, rc=rc)
     if (ChkErr(rc,__LINE__,u_FILE_u)) return
     if (isPresent .and. isSet) then
-      write(output_fh, '(a2)')trim(value)
+      if (len_trim(value) == 1) then
+        output_fh = '0'//trim(value)
+      else
+        output_fh = trim(value)
+      end if
     else
       output_fh = '06'
     end if
     call ESMF_LogWrite('MOM_cap:MOM6 output frequency = '//trim(output_fh), ESMF_LOGMSG_INFO)
 
-    call ESMF_ClockGet(mclock, currTime=mcurrtime, rc=rc)
+    debug = .false.
+    call NUOPC_CompAttributeGet(gcomp, name="debug_outputlog", value=value, &
+         isPresent=isPresent, isSet=isSet, rc=rc)
     if (ChkErr(rc,__LINE__,u_FILE_u)) return
+    if (isPresent .and. isSet) debug=(trim(value)=="true")
+    if (debug) call ESMF_LogWrite('MOM_cap:MOM6 output debug ON', ESMF_LOGMSG_INFO)
 
+    call ESMF_ClockGet(mclock, currTime=mcurrTime, startTime=startTime, rc=rc)
+    if (ChkErr(rc,__LINE__,u_FILE_u)) return
     call ESMF_TimeIntervalSet(timeoffset, m=1, rc=rc)
     if (ChkErr(rc,__LINE__,u_FILE_u)) return
 
     do n = 1,n_freq
-      write(chour,'(i2.2,a)')freq(n),'h'
+      write(chour,'(I2.2,A)')freq(n),'h'
       olog(n)%alarm_name = 'output_alarm'//trim(chour)
       olog(n)%opt_n = freq(n)
       olog(n)%filename_timeoffset = 90*freq(n)*timeoffset
       olog(n)%chkfile_nextAdvance = .false.
       olog(n)%filename = ''
+      olog(n)%time_lastrestart = startTime
 
       call AlarmInit(mclock,         &
            alarm   = olog(n)%alarm,  &
@@ -158,28 +193,37 @@ contains
 
       call ESMF_AlarmSet(olog(n)%alarm, clock=mclock, rc=rc)
       if (ChkErr(rc,__LINE__,u_FILE_u)) return
-      call ESMF_LogWrite(subname//" Output alarm "//trim(olog(n)%alarm_name)//" is Created and Set", ESMF_LOGMSG_INFO)
+      call ESMF_LogWrite(trim(subname)//" Output alarm "//trim(olog(n)%alarm_name)//" is Created and Set", ESMF_LOGMSG_INFO)
+      if (debug .and. is_root_pe()) then
+        call ESMF_TimeIntervalPrint(olog(n)%filename_timeoffset, options="string", rc=rc)
+        if (ChkErr(rc,__LINE__,u_FILE_u)) return
+      end if
+
     end do
+
   end subroutine outputlog_init
   !> Use Alarms at the output frequency to determine if output has been
   !! completed
   !!
-  !! @param clock an ESMF_Clock object
-  !! @param rc    return code
-  subroutine outputlog_run(mclock, rc)
+  !! @param clock      an ESMF_Clock object
+  !! @param atStopTime when present, checks for final output file
+  !! @param rc         return code
+  subroutine outputlog_run(mclock, atStopTime, rc)
 
-    type(ESMF_Clock)     :: mclock !< the ESMF_clock for the model
-    integer, intent(out) :: rc     !< return code
+    type(ESMF_Clock)              :: mclock     !< the ESMF_clock for the model
+    logical, intent(in), optional :: atStopTime !< if true, checks for final output file
+    integer, intent(out)          :: rc         !< return code
 
     ! local variables
     type(ESMF_Time)         :: nextTime, currTime, startTime
     type(ESMF_TimeInterval) :: timeStep
-    logical                 :: existflag
+    logical                 :: lstop
     integer                 :: n, ncid, dimid, nlen
     integer                 :: year, month, day, hour, minute
-    character(len=256)      :: import_timestr, export_timestr, fname
+    character(len=256)      :: import_timestr, export_timestr, importexport !debugging only
+    character(len=512)      :: fname
     character(len=256)      :: subname='MOM_cap:(outputlog_run) '
-    !--------------------------------
+    !----------------------------------------------------------------------------
 
     rc = ESMF_SUCCESS
 
@@ -189,35 +233,41 @@ contains
     if (ChkErr(rc,__LINE__,u_FILE_u)) return
     call ESMF_TimeGet(currTime+timestep, timestring=export_timestr, rc=rc)
     if (ChkErr(rc,__LINE__,u_FILE_u)) return
+    importexport = trim(import_timestr)//'  '//trim(export_timestr)
+
+    lstop = .false.
+    if (present(atStopTime)) then
+      lstop = atStopTime
+    end if
 
     do n = 1,n_freq
-      write(chour,'(i2.2,a)')freq(n),'h'
-      if (chour == output_fh(1:2)) then
+      write(chour,'(I2.2,A)')freq(n),'h'
+      if (chour(1:2) == output_fh(1:2)) then
         call ESMF_ClockGetAlarm(mclock, alarmname=trim(olog(n)%alarm_name), alarm=olog(n)%alarm, rc=rc)
         if (ChkErr(rc,__LINE__,u_FILE_u)) return
+        ! when the alarm rings, set file check on next advance and construct the filename
         if (ESMF_AlarmIsRinging(olog(n)%alarm, rc=rc)) then
           if (ChkErr(rc,__LINE__,u_FILE_u)) return
           olog(n)%chkfile_nextAdvance = .true.
-          ! turn off the alarm
           call ESMF_AlarmRingerOff(olog(n)%alarm, rc=rc )
           if (ChkErr(rc,__LINE__,u_FILE_u)) return
-          ! set filename
           call ESMF_ClockGetNextTime(mclock, nextTime, rc=rc)
           if (ChkErr(rc,__LINE__,u_FILE_u)) return
-          if (freq(n) < 6) then
-            call ESMF_TimeGet (nextTime-olog(n)%filename_timeoffset, yy=year, mm=month, dd=day, h=hour, m=minute, rc=rc )
-            if (ChkErr(rc,__LINE__,u_FILE_u)) return
-            write(olog(n)%filename,'(a,i4.4,4(a,i2.2),a)')trim(outputdir)//'ocn_',year,'_',month,'_',day,'_',hour,'_',minute,'.nc'
-          else
-            call ESMF_TimeGet (nextTime-olog(n)%filename_timeoffset, yy=year, mm=month, dd=day, h=hour, rc=rc )
-            if (ChkErr(rc,__LINE__,u_FILE_u)) return
-            write(olog(n)%filename,'(a,i4.4,3(a,i2.2),a)')trim(outputdir)//'ocn_',year,'_',month,'_',day,'_',hour,'.nc'
+          !if (freq(n) < 6) then
+          call ESMF_TimeGet (nextTime-olog(n)%filename_timeoffset, yy=year, mm=month, dd=day, h=hour, m=minute, rc=rc )
+          if (ChkErr(rc,__LINE__,u_FILE_u)) return
+          write(olog(n)%filename,'(A,I4.4,4(A,I2.2),A)')trim(outputdir)//'ocn_',year,'_',month,'_',day,'_',hour,'_',minute,'.nc'
+          !else
+          !  call ESMF_TimeGet (nextTime-olog(n)%filename_timeoffset, yy=year, mm=month, dd=day, h=hour, rc=rc )
+          !  if (ChkErr(rc,__LINE__,u_FILE_u)) return
+          !  write(olog(n)%filename,'(A,I4.4,3(A,I2.2),A)')trim(outputdir)//'ocn_',year,'_',month,'_',day,'_',hour,'.nc'
+          !end if
+          if (debug .and. is_root_pe()) then
+            print '(A)',trim(subname)//' fname '//trim(olog(n)%filename)//'  '//trim(importexport)
           end if
-          if(is_root_pe())print *,'XX0 '//trim(olog(n)%filename)//'  '//trim(import_timestr)//'  '//trim(export_timestr)
         end if
 
         if (olog(n)%chkfile_nextAdvance) then
-          ! check if file is written
           fname = trim(olog(n)%filename)
           inquire(file=fname, exist=existflag)
           if (existflag) then
@@ -227,95 +277,172 @@ contains
             call nf90_err(nf90_close(ncid), 'close: '//fname)
             if (nlen > 0) then
               olog(n)%chkfile_nextAdvance = .false.
+              olog(n)%time_lastrestart = lastrestart
               if (is_root_pe()) then
-                call log_restart_fh(currTime+timestep, startTime, 'mom6.'//chour, prefixtime=.true., rc=rc)
+                ! the file check is taking place one advance after the end of the interval *after* the averaging
+                ! interval in the file (eg, 06 average file is checked for at hour=12+1), so the time
+                ! needed for logging the file completion is one full averaging interval prior to the current time
+                call ESMF_ClockGet(mclock, currTime=currTime, rc=rc)
                 if (ChkErr(rc,__LINE__,u_FILE_u)) return
+                if (olog(n)%time_lastrestart > startTime) then
+                  call log_restart_fh(currTime-60*freq(n)*timeoffset, startTime, 'mom6.'//chour, prefixtime=.true., appendtime=olog(n)%time_lastrestart, rc=rc)
+                  if (ChkErr(rc,__LINE__,u_FILE_u)) return
+                else
+                  call log_restart_fh(currTime-60*freq(n)*timeoffset, startTime, 'mom6.'//chour, prefixtime=.true., rc=rc)
+                  if (ChkErr(rc,__LINE__,u_FILE_u)) return
+                end if
               endif
-              if(is_root_pe())print *,'XX '//trim(olog(n)%filename)//'  '//trim(import_timestr)//'  '//trim(export_timestr)//' complete'
-            else
-              if(is_root_pe())print *,'XX '//trim(olog(n)%filename)//'  '//trim(import_timestr)//'  '//trim(export_timestr)//' still 0'
             end if
           end if ! existflag
-        end if ! chkfile_nextAdvance
+        end if
+
+        if (lstop) then
+          call ESMF_TimeGet (currTime-30*freq(n)*timeoffset, yy=year, mm=month, dd=day, h=hour, m=minute, rc=rc )
+          if (ChkErr(rc,__LINE__,u_FILE_u)) return
+          write(olog(n)%filename,'(A,I4.4,4(A,I2.2),A)')trim(outputdir)//'ocn_',year,'_',month,'_',day,'_',hour,'_',minute,'.nc'
+          if (debug .and. is_root_pe()) then
+            print '(A)',trim(subname)//' fname XX '//trim(olog(n)%filename)//'  '//trim(importexport)
+          end if
+
+          fname = trim(olog(n)%filename)
+          inquire(file=fname, exist=existflag)
+          if (existflag) then
+            call nf90_err(nf90_open(fname, nf90_nowrite, ncid), 'nf90_open: '//fname)
+            call nf90_err(nf90_inquire(ncid, unlimiteddimid=dimid), 'inquire unlimiteddimid')
+            call nf90_err(nf90_inquire_dimension(ncid, dimid, len=nlen), 'inquire unlimited dimension')
+            call nf90_err(nf90_close(ncid), 'close: '//fname)
+            if (nlen > 0) then
+              olog(n)%chkfile_nextAdvance = .false.
+              olog(n)%time_lastrestart = lastrestart
+              if (is_root_pe()) then
+                ! the file check is taking place at the stopTime (==currTime)
+                call ESMF_ClockGet(mclock, currTime=currTime, rc=rc)
+                if (ChkErr(rc,__LINE__,u_FILE_u)) return
+                if (olog(n)%time_lastrestart > startTime) then
+                  call log_restart_fh(currTime, startTime, 'mom6.'//chour, prefixtime=.true., appendtime=olog(n)%time_lastrestart, rc=rc)
+                  if (ChkErr(rc,__LINE__,u_FILE_u)) return
+                else
+                  call log_restart_fh(currTime, startTime, 'mom6.'//chour, prefixtime=.true., rc=rc)
+                  if (ChkErr(rc,__LINE__,u_FILE_u)) return
+                end if
+              end if
+            end if
+          end if
+        end if ! lstop
+
+        if (debug) then
+          fname = trim(olog(n)%filename)
+          inquire(file=fname, exist=existflag)
+          if (existflag) then
+            call nf90_err(nf90_open(fname, nf90_nowrite, ncid), 'nf90_open: '//fname)
+            call nf90_err(nf90_inquire(ncid, unlimiteddimid=dimid), 'inquire unlimiteddimid')
+            call nf90_err(nf90_inquire_dimension(ncid, dimid, len=nlen), 'inquire unlimited dimension')
+            call nf90_err(nf90_close(ncid), 'close: '//fname)
+            if (is_root_pe()) then
+              if (nlen > 0) then
+                print '(A,L)',trim(subname)//trim(fname)//' exists '//trim(importexport)//' complete ',olog(n)%chkfile_nextAdvance
+              else
+                print '(A,L)',trim(subname)//trim(fname)//' exists '//trim(importexport)//' still 0 ',olog(n)%chkfile_nextAdvance
+              end if
+            end if
+          end if
+        end if
+
       end if ! chour = output_fh
     end do
+
   end subroutine outputlog_run
   !> Check all restart files to determine if output has been completed
   !!
   !! @param clock          an ESMF_Clock object
   !! @param num_rest_files the number of restart files
   !! @param rc             return code
-  subroutine outputlog_restart(mclock, num_rest_files, rc=rc)
+  subroutine outputlog_restart(mclock, num_rest_files, rc)
     type(ESMF_Clock)     :: mclock         !< the ESMF_clock for the model
     integer, intent(in)  :: num_rest_files !< the number of restart files
     integer, intent(out) :: rc             !< return code
 
     ! local variables
-    type(ESMF_Time)         :: nextTime
+    type(ESMF_Time)         :: startTime, currTime, nextTime
+    type(ESMF_TimeInterval) :: timestep
     integer                 :: n, ncid, dimid, nlen
     integer                 :: year, month, day, hour, minute, seconds
     character(len=512)      :: fname
-    character(len=13)       :: timestr
-    logical, allocatable(:) :: allDone
+    character(len=15)       :: timestr
+    character(len=256)      :: import_timestr, export_timestr, importexport !debugging only
+    logical, allocatable    :: allDone(:)
     character(len=8)        :: suffix
     character(len=256)      :: subname='MOM_cap:(outputlog_restart) '
-    !--------------------------------
+    !----------------------------------------------------------------------------
 
     rc = ESMF_SUCCESS
 
+    call ESMF_ClockGet(mclock, startTime=startTime, currTime=currTime, timeStep=timeStep, rc=rc)
+    if (ChkErr(rc,__LINE__,u_FILE_u)) return
+    call ESMF_TimeGet(currTime,          timestring=import_timestr, rc=rc)
+    if (ChkErr(rc,__LINE__,u_FILE_u)) return
+    call ESMF_TimeGet(currTime+timestep, timestring=export_timestr, rc=rc)
+    if (ChkErr(rc,__LINE__,u_FILE_u)) return
+    importexport = trim(import_timestr)//'  '//trim(export_timestr)
+
     call ESMF_ClockGetNextTime(mclock, nextTime, rc=rc)
     if (ChkErr(rc,__LINE__,u_FILE_u)) return
-    call ESMF_TimeGet (MyTime, yy=year, mm=month, dd=day, h=hour, m=minute, s=seconds, rc=rc )
+    call ESMF_TimeGet (nextTime, yy=year, mm=month, dd=day, h=hour, m=minute, s=seconds, rc=rc )
     if (ChkErr(rc,__LINE__,u_FILE_u)) return
-    write(timestr,'(i4.4,2(i2.2),A,3(i2.2)') year, month, day,".", hour, minute, seconds
+    write(timestr,'(I4.4,2(I2.2),A,3(I2.2))') year, month, day,".", hour, minute, seconds
 
-    allocate(allDone(0:num_rest_files-1))
+    allocate(allDone(1:num_rest_files))
     allDone = .false.
 
-    do n = 0,num_rest_files-1
-      if (n == 0) then
+    do n = 1,num_rest_files
+      if (n == 1) then
         suffix = ''
-      else if (n < 10) then
-        write(suffix,'("_",I1)') n
+      else if (n-1 < 10) then
+        write(suffix,'("_",I1)') n-1
       else
-        write(suffix,'("_",I2)') n
+        write(suffix,'("_",I2)') n-1
       endif
       if (len_trim(suffix) == 0) then
-        fname = trim(outputdir)//trim(timestring)//'.MOM.res.nc'
+        fname = trim(restartdir)//trim(timestr)//'.MOM.res.nc'
       else
-        fname = trim(outputdir)//trim(timestring)//'.MOM.res_'//trim(suffix)//'nc'
+        fname = trim(restartdir)//trim(timestr)//'.MOM.res_'//trim(suffix)//'nc'
       endif
 
+      ! check if file is written
       inquire(file=fname, exist=existflag)
       if (existflag) then
-        !open and inquire unlimdim
         call nf90_err(nf90_open(fname, nf90_nowrite, ncid), 'nf90_open: '//fname)
         call nf90_err(nf90_inquire(ncid, unlimiteddimid=dimid), 'inquire unlimiteddimid')
         call nf90_err(nf90_inquire_dimension(ncid, dimid, len=nlen), 'inquire unlimited dimension')
         call nf90_err(nf90_close(ncid), 'close: '//fname)
         if (nlen > 0) allDone(n) = .true.
-        ! if (nlen > 0) then
-        !   allDone(n) = .true.
-        !   if(is_root_pe())print '(A)','XX '//trim(fname)//' exists  '//trim(import_timestr)//'  '//trim(export_timestr)//' complete'
-        ! else
-        !   if(is_root_pe())print '(A)','XX '//trim(fname)//' exists  '//trim(import_timestr)//'  '//trim(export_timestr)//' still 0'
+        if (is_root_pe())print *,'allDone= ',allDone
+
+        if (debug .and. is_root_pe()) then
+          if (nlen > 0) then
+            print '(A)',trim(subname)//' restart '//trim(fname)//'  '//trim(importexport)//' complete'
+          else
+            print '(A)',trim(subname)//' restart '//trim(fname)//'  '//trim(importexport)//' still 0'
+          end if
+        end if
       end if
-    end do
+    end do ! num_rest_files
 
     if (any(allDone) == .false.) then
-      !abort
+      !call MOM_error(FATAL, 'not all Restart files are complete')
     else
+      lastrestart = nextTime
       if (is_root_pe()) then
-        call log_restart_fh(MyTime, startTime, 'mom6.res', prefixtime=.true., rc=rc)
+        call log_restart_fh(nextTime, startTime, 'mom6.res', prefixtime=.true., rc=rc)
         if (ChkErr(rc,__LINE__,u_FILE_u)) return
       endif
     endif
+
   end subroutine outputlog_restart
   !> Handle netcdf errors
   !!
   !! @param[in]  ierr        the error code
   !! @param[in]  string      the error message
-  !!
   subroutine nf90_err(ierr, string)
 
     integer ,         intent(in) :: ierr
@@ -323,13 +450,14 @@ contains
     !----------------------------------------------------------------------------
 
     if (ierr /= nf90_noerr) then
-      write(0, '(a)') 'FATAL ERROR: ' // trim(string)// ' : ' // trim(nf90_strerror(ierr))
+      write(0, '(A)') 'FATAL ERROR: ' // trim(string)// ' : ' // trim(nf90_strerror(ierr))
       ! This fails on WCOSS2 with Intel 19 compiler. See
       ! https://community.intel.com/t5/Intel-Fortran-Compiler/STOP-and-ERROR-STOP-with-variable-stop-codes/m-p/1182521#M149254
       ! When WCOSS2 moves to Intel 2020+, uncomment the next line and remove stop 99
       !stop ierr
       stop 99
     end if
+
   end subroutine nf90_err
 #endif
 end module MOM_cap_outputlog

--- a/config_src/drivers/nuopc_cap/mom_cap_outputlog.F90
+++ b/config_src/drivers/nuopc_cap/mom_cap_outputlog.F90
@@ -36,7 +36,7 @@ contains
   use ESMF                  , only : ESMF_Time, ESMF_Clock, ESMF_ClockGet, ESMF_Alarm, ESMF_AlarmSet
   use ESMF                  , only : ESMF_ClockGetAlarm, ESMF_AlarmIsRinging, ESMF_AlarmRingerOff
   use ESMF                  , only : ESMF_ClockGetNextTime, ESMF_TimeGet, ESMF_TimeInterval
-  use ESMF                  , only : ESMF_TimeIntervalSet, ESMF_TimeIntervalPrint, ESMF_TimePrint
+  use ESMF                  , only : ESMF_TimeIntervalSet, ESMF_TimeIntervalPrint
   use ESMF                  , only : ESMF_SUCCESS, ESMF_LogWrite, ESMF_LOGMSG_INFO
   use ESMF                  , only : ESMF_LogSetError, ESMF_LogFoundError, ESMF_LOGERR_PASSTHRU
   use ESMF                  , only : operator(*), operator(+), operator(-), operator(>), operator(==)
@@ -44,6 +44,9 @@ contains
   use MOM_cap_time          , only : AlarmInit
   use shr_is_restart_fh_mod , only : log_restart_fh
   use netcdf
+  ! debug
+  use ESMF, only : ESMF_TimePrint
+  !use ESMF, only : ESMF_AlarmWasPrevRinging
 
   implicit none; private
 
@@ -56,9 +59,11 @@ contains
   integer, parameter :: n_freq  = 3
   integer, parameter, dimension(n_freq) :: freq = (/3, 6, 24/)
 
-  ! the timeoffset interval is used only to construct the file name.
-  ! the file name must be set as the mid-point of the averaging period.
-  ! filenames will be given by
+  ! the timeoffset interval (defined in minutes) is used to construct
+  ! the file name of the output
+  ! the file name must be set as the mid-point of the averaging period
+  ! via the diagtable
+  ! output filename timestrings are given by
   !      T - (interval * offset + interval/2 * offset)
   ! where interval is the averaging interval in minutes
   !
@@ -74,6 +79,26 @@ contains
   !       12 = 48 - (24 + 12)
   !                 36 = 72 - (24 + 12)
   !
+  ! when the model reaches the stop time, any 'pending' output
+  ! file is closed, and the final interval output is also closed
+  !
+  !                   stop
+  !  18   .   24   .   30
+  !      21 = 30 - (12 + 3)
+  !                03 = 30 - (3)
+  !
+  ! since both the final interval and the next-to-final interval are
+  ! closed at the stop time, a different log file name is required for
+  ! the final log file, otherwise we over-write the next-to-final log
+  !
+  ! an output file is declared closed when the unlimited dimension in
+  ! the file is > 0
+  !
+  ! each closed output file is recorded in a logfile at the associated
+  ! forecast hour. The name of the logfile is given by
+  !     T - (interval * offset)
+  ! where T is the currTime when the file is closed
+
   type(ESMF_TimeInterval) :: timeoffset
   type(ESMF_Time)         :: lastrestart
 
@@ -173,14 +198,17 @@ contains
     call ESMF_TimeIntervalSet(timeoffset, m=1, rc=rc)
     if (ChkErr(rc,__LINE__,u_FILE_u)) return
 
+    ! initialize
+    lastrestart = startTime
+
     do n = 1,n_freq
       write(chour,'(I2.2,A)')freq(n),'h'
       olog(n)%alarm_name = 'output_alarm'//trim(chour)
       olog(n)%opt_n = freq(n)
       olog(n)%filename_timeoffset = 90*freq(n)*timeoffset
-      olog(n)%chkfile_nextAdvance = .false.
+      olog(n)%chkfile_nextAdvance = .false.               ! alarms ring at the ouput freq, but files close on next advance
       olog(n)%filename = ''
-      olog(n)%time_lastrestart = startTime
+      olog(n)%time_lastrestart = lastrestart
 
       call AlarmInit(mclock,         &
            alarm   = olog(n)%alarm,  &
@@ -248,20 +276,16 @@ contains
         ! when the alarm rings, set file check on next advance and construct the filename
         if (ESMF_AlarmIsRinging(olog(n)%alarm, rc=rc)) then
           if (ChkErr(rc,__LINE__,u_FILE_u)) return
-          olog(n)%chkfile_nextAdvance = .true.
           call ESMF_AlarmRingerOff(olog(n)%alarm, rc=rc )
           if (ChkErr(rc,__LINE__,u_FILE_u)) return
+          olog(n)%chkfile_nextAdvance = .true.
+
           call ESMF_ClockGetNextTime(mclock, nextTime, rc=rc)
           if (ChkErr(rc,__LINE__,u_FILE_u)) return
-          !if (freq(n) < 6) then
           call ESMF_TimeGet (nextTime-olog(n)%filename_timeoffset, yy=year, mm=month, dd=day, h=hour, m=minute, rc=rc )
           if (ChkErr(rc,__LINE__,u_FILE_u)) return
           write(olog(n)%filename,'(A,I4.4,4(A,I2.2),A)')trim(outputdir)//'ocn_',year,'_',month,'_',day,'_',hour,'_',minute,'.nc'
-          !else
-          !  call ESMF_TimeGet (nextTime-olog(n)%filename_timeoffset, yy=year, mm=month, dd=day, h=hour, rc=rc )
-          !  if (ChkErr(rc,__LINE__,u_FILE_u)) return
-          !  write(olog(n)%filename,'(A,I4.4,3(A,I2.2),A)')trim(outputdir)//'ocn_',year,'_',month,'_',day,'_',hour,'.nc'
-          !end if
+
           if (debug .and. is_root_pe()) then
             print '(A)',trim(subname)//' fname '//trim(olog(n)%filename)//'  '//trim(importexport)
           end if
@@ -279,29 +303,21 @@ contains
               olog(n)%chkfile_nextAdvance = .false.
               olog(n)%time_lastrestart = lastrestart
               if (is_root_pe()) then
-                ! the file check is taking place one advance after the end of the interval *after* the averaging
-                ! interval in the file (eg, 06 average file is checked for at hour=12+1), so the time
-                ! needed for logging the file completion is one full averaging interval prior to the current time
-                call ESMF_ClockGet(mclock, currTime=currTime, rc=rc)
+                call log_restart_fh(currTime-60*freq(n)*timeoffset, startTime, 'mom6.'//chour, prefixtime=.true., &
+                     lastrestart=olog(n)%time_lastrestart, lastwritten=olog(n)%filename, rc=rc)
                 if (ChkErr(rc,__LINE__,u_FILE_u)) return
-                if (olog(n)%time_lastrestart > startTime) then
-                  call log_restart_fh(currTime-60*freq(n)*timeoffset, startTime, 'mom6.'//chour, prefixtime=.true., appendtime=olog(n)%time_lastrestart, rc=rc)
-                  if (ChkErr(rc,__LINE__,u_FILE_u)) return
-                else
-                  call log_restart_fh(currTime-60*freq(n)*timeoffset, startTime, 'mom6.'//chour, prefixtime=.true., rc=rc)
-                  if (ChkErr(rc,__LINE__,u_FILE_u)) return
-                end if
               endif
             end if
           end if ! existflag
         end if
 
         if (lstop) then
+          !this doesn't work if stoptime is not on an averaging interval!
           call ESMF_TimeGet (currTime-30*freq(n)*timeoffset, yy=year, mm=month, dd=day, h=hour, m=minute, rc=rc )
           if (ChkErr(rc,__LINE__,u_FILE_u)) return
           write(olog(n)%filename,'(A,I4.4,4(A,I2.2),A)')trim(outputdir)//'ocn_',year,'_',month,'_',day,'_',hour,'_',minute,'.nc'
           if (debug .and. is_root_pe()) then
-            print '(A)',trim(subname)//' fname XX '//trim(olog(n)%filename)//'  '//trim(importexport)
+            print '(A)',trim(subname)//' fname at lstop '//trim(olog(n)%filename)//'  '//trim(importexport)
           end if
 
           fname = trim(olog(n)%filename)
@@ -314,17 +330,12 @@ contains
             if (nlen > 0) then
               olog(n)%chkfile_nextAdvance = .false.
               olog(n)%time_lastrestart = lastrestart
+              call ESMF_ClockGet(mclock, currTime=currTime, rc=rc)
+              if (ChkErr(rc,__LINE__,u_FILE_u)) return
               if (is_root_pe()) then
-                ! the file check is taking place at the stopTime (==currTime)
-                call ESMF_ClockGet(mclock, currTime=currTime, rc=rc)
+                call log_restart_fh(currTime-60*freq(n)*timeoffset, startTime, 'mom6.stop.'//chour, prefixtime=.true., &
+                     lastrestart=olog(n)%time_lastrestart, lastwritten=olog(n)%filename, rc=rc)
                 if (ChkErr(rc,__LINE__,u_FILE_u)) return
-                if (olog(n)%time_lastrestart > startTime) then
-                  call log_restart_fh(currTime, startTime, 'mom6.'//chour, prefixtime=.true., appendtime=olog(n)%time_lastrestart, rc=rc)
-                  if (ChkErr(rc,__LINE__,u_FILE_u)) return
-                else
-                  call log_restart_fh(currTime, startTime, 'mom6.'//chour, prefixtime=.true., rc=rc)
-                  if (ChkErr(rc,__LINE__,u_FILE_u)) return
-                end if
               end if
             end if
           end if
@@ -409,14 +420,13 @@ contains
       endif
 
       ! check if file is written
-      inquire(file=fname, exist=existflag)
+      inquire(file=trim(fname), exist=existflag)
       if (existflag) then
         call nf90_err(nf90_open(fname, nf90_nowrite, ncid), 'nf90_open: '//fname)
         call nf90_err(nf90_inquire(ncid, unlimiteddimid=dimid), 'inquire unlimiteddimid')
         call nf90_err(nf90_inquire_dimension(ncid, dimid, len=nlen), 'inquire unlimited dimension')
         call nf90_err(nf90_close(ncid), 'close: '//fname)
         if (nlen > 0) allDone(n) = .true.
-        if (is_root_pe())print *,'allDone= ',allDone
 
         if (debug .and. is_root_pe()) then
           if (nlen > 0) then
@@ -428,15 +438,14 @@ contains
       end if
     end do ! num_rest_files
 
-    if (any(allDone) == .false.) then
-      !call MOM_error(FATAL, 'not all Restart files are complete')
-    else
-      lastrestart = nextTime
-      if (is_root_pe()) then
+    ! Layout(1,1), only rootPE writes restarts
+    if (is_root_pe()) then
+      if (all(allDone) .eqv. .true.) then
+        lastrestart = nextTime
         call log_restart_fh(nextTime, startTime, 'mom6.res', prefixtime=.true., rc=rc)
         if (ChkErr(rc,__LINE__,u_FILE_u)) return
       endif
-    endif
+    end if
 
   end subroutine outputlog_restart
   !> Handle netcdf errors

--- a/config_src/drivers/nuopc_cap/mom_cap_outputlog.F90
+++ b/config_src/drivers/nuopc_cap/mom_cap_outputlog.F90
@@ -619,8 +619,8 @@ contains
 
     if (ierr /= nf90_noerr) then
       write(0, '(A)') 'FATAL ERROR: ' // trim(string)// ' : ' // trim(nf90_strerror(ierr))
-      ! This fails on WCOSS2 with Intel 19 compiler. See
-      ! https://community.intel.com/t5/Intel-Fortran-Compiler/STOP-and-ERROR-STOP-with-variable-stop-codes/m-p/1182521#M149254
+      ! This fails on WCOSS2 with Intel 19 compiler. See https://community.intel.com/
+      ! Search term "STOP and ERROR STOP with variable stop codes"
       ! When WCOSS2 moves to Intel 2020+, uncomment the next line and remove stop 99
       !stop ierr
       stop 99

--- a/config_src/drivers/nuopc_cap/mom_cap_outputlog.F90
+++ b/config_src/drivers/nuopc_cap/mom_cap_outputlog.F90
@@ -1,8 +1,7 @@
-!> This module contains a set of subroutines that check if MOM
-!! history files have been written and closed. This file is
-!! specific to UWM operational requirements and configurations
-!! (eg specific output frequencys in hours) and may break if
-!! used outside the scope of intended use.
+!> This module contains a set of subroutines that check if MOM restart
+!! and history files have been written and closed. This file is specific
+!! to UWM operational requirements and configurations (eg specific output
+!! frequencys in hours) and may break if used outside the scope of intended use.
 !! This module a stub when CESMCOUPLED is defined
 module MOM_cap_outputlog
 
@@ -10,7 +9,7 @@ module MOM_cap_outputlog
   use ESMF                  , only : ESMF_Clock, ESMF_SUCCESS
   implicit none; private
 
-  public :: outputlog_init, outputlog_run
+  public :: outputlog_init, outputlog_run, outputlog_restart
 contains
   subroutine outputlog_init(gcomp, mclock, rc)
 
@@ -24,7 +23,12 @@ contains
     integer, intent(out) :: rc     !< return code
     rc = ESMF_SUCCESS
   end subroutine outputlog_run
-end module MOM_cap_outputlog
+  subroutine outputlog_restart(mclock, num_rest_files, rc=rc)
+    type(ESMF_Clock)     :: mclock         !< the ESMF_clock for the model
+    integer, intent(in)  :: num_rest_files !< the number of restart files
+    integer, intent(out) :: rc             !< return code
+    rc = ESMF_SUCCESS
+  end subroutine outputlog_restart
 #else
   use MOM_error_handler,      only : is_root_pe
   use ESMF                  , only : ESMF_Time, ESMF_Clock, ESMF_ClockGet, ESMF_Alarm, ESMF_AlarmSet
@@ -70,6 +74,7 @@ end module MOM_cap_outputlog
 
   type(outputlog_type) :: olog(n_freq)
 
+  character(len=256) :: restartdir
   character(len=256) :: outputdir
   character(len=2)   :: output_fh
   character(len=3)   :: chour
@@ -77,11 +82,11 @@ end module MOM_cap_outputlog
        __FILE__
 
 contains
-
-!> Initialize a set of Alarms at the allowed output frequencies
-!!
-!! @param clock an ESMF_Clock object
-!! @param rc return code
+  !> Initialize a set of Alarms at the allowed output frequencies
+  !!
+  !! @param gcomp an ESMF_GridComp object
+  !! @param clock an ESMF_Clock object
+  !! @param rc    return code
   subroutine outputlog_init(gcomp, mclock, rc)
 
     type(ESMF_GridComp)  :: gcomp  !< an ESMF_GridComp object
@@ -97,6 +102,16 @@ contains
     !--------------------------------
 
     rc = ESMF_SUCCESS
+
+    call NUOPC_CompAttributeGet(gcomp, name="mom6_restartdir", value=value, &
+         isPresent=isPresent, isSet=isSet, rc=rc)
+    if (ChkErr(rc,__LINE__,u_FILE_u)) return
+    if (isPresent .and. isSet) then
+      restartdir = trim(value)
+    else
+      restartdir = './'
+    end if
+    call ESMF_LogWrite('MOM_cap:MOM6 restart directory = '//trim(restartdir), ESMF_LOGMSG_INFO)
 
     call NUOPC_CompAttributeGet(gcomp, name="mom6_outputdir", value=value, &
          isPresent=isPresent, isSet=isSet, rc=rc)
@@ -150,7 +165,7 @@ contains
   !! completed
   !!
   !! @param clock an ESMF_Clock object
-  !! @param rc return code
+  !! @param rc    return code
   subroutine outputlog_run(mclock, rc)
 
     type(ESMF_Clock)     :: mclock !< the ESMF_clock for the model
@@ -162,7 +177,7 @@ contains
     logical                 :: existflag
     integer                 :: n, ncid, dimid, nlen
     integer                 :: year, month, day, hour, minute
-    character(256)          :: import_timestr, export_timestr, fname
+    character(len=256)      :: import_timestr, export_timestr, fname
     character(len=256)      :: subname='MOM_cap:(outputlog_run) '
     !--------------------------------
 
@@ -177,7 +192,7 @@ contains
 
     do n = 1,n_freq
       write(chour,'(i2.2,a)')freq(n),'h'
-      if (chour == outputfh(1:2)) then
+      if (chour == output_fh(1:2)) then
         call ESMF_ClockGetAlarm(mclock, alarmname=trim(olog(n)%alarm_name), alarm=olog(n)%alarm, rc=rc)
         if (ChkErr(rc,__LINE__,u_FILE_u)) return
         if (ESMF_AlarmIsRinging(olog(n)%alarm, rc=rc)) then
@@ -190,13 +205,13 @@ contains
           call ESMF_ClockGetNextTime(mclock, nextTime, rc=rc)
           if (ChkErr(rc,__LINE__,u_FILE_u)) return
           if (freq(n) < 6) then
-             call ESMF_TimeGet (nextTime-olog(n)%filename_timeoffset, yy=year, mm=month, dd=day, h=hour, m=minute, rc=rc )
-             if (ChkErr(rc,__LINE__,u_FILE_u)) return
-             write(olog(n)%filename,'(a,i4.4,4(a,i2.2),a)')trim(outputdir)//'ocn_',year,'_',month,'_',day,'_',hour,'_',minute,'.nc'
+            call ESMF_TimeGet (nextTime-olog(n)%filename_timeoffset, yy=year, mm=month, dd=day, h=hour, m=minute, rc=rc )
+            if (ChkErr(rc,__LINE__,u_FILE_u)) return
+            write(olog(n)%filename,'(a,i4.4,4(a,i2.2),a)')trim(outputdir)//'ocn_',year,'_',month,'_',day,'_',hour,'_',minute,'.nc'
           else
-             call ESMF_TimeGet (nextTime-olog(n)%filename_timeoffset, yy=year, mm=month, dd=day, h=hour, rc=rc )
-             if (ChkErr(rc,__LINE__,u_FILE_u)) return
-             write(olog(n)%filename,'(a,i4.4,3(a,i2.2),a)')trim(outputdir)//'ocn_',year,'_',month,'_',day,'_',hour,'.nc'
+            call ESMF_TimeGet (nextTime-olog(n)%filename_timeoffset, yy=year, mm=month, dd=day, h=hour, rc=rc )
+            if (ChkErr(rc,__LINE__,u_FILE_u)) return
+            write(olog(n)%filename,'(a,i4.4,3(a,i2.2),a)')trim(outputdir)//'ocn_',year,'_',month,'_',day,'_',hour,'.nc'
           end if
           if(is_root_pe())print *,'XX0 '//trim(olog(n)%filename)//'  '//trim(import_timestr)//'  '//trim(export_timestr)
         end if
@@ -224,39 +239,78 @@ contains
         end if ! chkfile_nextAdvance
       end if ! chour = output_fh
     end do
-#ifdef test
-
-    fname = 'ocn_2011_10_01_10_30.nc'
-    inquire(file=fname, exist=existflag)
-    if (existflag) then
-      !open and inquire unlimdim
-      call nf90_err(nf90_open(fname, nf90_nowrite, ncid), 'nf90_open: '//fname)
-      call nf90_err(nf90_inquire(ncid, unlimiteddimid=dimid), 'inquire unlimiteddimid')
-      call nf90_err(nf90_inquire_dimension(ncid, dimid, len=nlen), 'inquire unlimited dimension')
-      call nf90_err(nf90_close(ncid), 'close: '//fname)
-      if (nlen > 0) then
-        if(is_root_pe())print '(A)','XX '//trim(fname)//' exists  '//trim(import_timestr)//'  '//trim(export_timestr)//' complete'
-      else
-        if(is_root_pe())print '(A)','XX '//trim(fname)//' exists  '//trim(import_timestr)//'  '//trim(export_timestr)//' still 0'
-      end if
-    end if
-
-    fname = 'ocn_2011_10_03_01_30.nc'
-    inquire(file=fname, exist=existflag)
-    if (existflag) then
-      !open and inquire unlimdim
-      call nf90_err(nf90_open(fname, nf90_nowrite, ncid), 'nf90_open: '//fname)
-      call nf90_err(nf90_inquire(ncid, unlimiteddimid=dimid), 'inquire unlimiteddimid')
-      call nf90_err(nf90_inquire_dimension(ncid, dimid, len=nlen), 'inquire unlimited dimension')
-      call nf90_err(nf90_close(ncid), 'close: '//fname)
-      if (nlen > 0) then
-        if(is_root_pe())print '(A)','XX '//trim(fname)//' exists  '//trim(import_timestr)//'  '//trim(export_timestr)//' complete'
-      else
-        if(is_root_pe())print '(A)','XX '//trim(fname)//' exists  '//trim(import_timestr)//'  '//trim(export_timestr)//' still 0'
-      end if
-    end if
-#endif
   end subroutine outputlog_run
+  !> Check all restart files to determine if output has been completed
+  !!
+  !! @param clock          an ESMF_Clock object
+  !! @param num_rest_files the number of restart files
+  !! @param rc             return code
+  subroutine outputlog_restart(mclock, num_rest_files, rc=rc)
+    type(ESMF_Clock)     :: mclock         !< the ESMF_clock for the model
+    integer, intent(in)  :: num_rest_files !< the number of restart files
+    integer, intent(out) :: rc             !< return code
+
+    ! local variables
+    type(ESMF_Time)         :: nextTime
+    integer                 :: n, ncid, dimid, nlen
+    integer                 :: year, month, day, hour, minute, seconds
+    character(len=512)      :: fname
+    character(len=13)       :: timestr
+    logical, allocatable(:) :: allDone
+    character(len=8)        :: suffix
+    character(len=256)      :: subname='MOM_cap:(outputlog_restart) '
+    !--------------------------------
+
+    rc = ESMF_SUCCESS
+
+    call ESMF_ClockGetNextTime(mclock, nextTime, rc=rc)
+    if (ChkErr(rc,__LINE__,u_FILE_u)) return
+    call ESMF_TimeGet (MyTime, yy=year, mm=month, dd=day, h=hour, m=minute, s=seconds, rc=rc )
+    if (ChkErr(rc,__LINE__,u_FILE_u)) return
+    write(timestr,'(i4.4,2(i2.2),A,3(i2.2)') year, month, day,".", hour, minute, seconds
+
+    allocate(allDone(0:num_rest_files-1))
+    allDone = .false.
+
+    do n = 0,num_rest_files-1
+      if (n == 0) then
+        suffix = ''
+      else if (n < 10) then
+        write(suffix,'("_",I1)') n
+      else
+        write(suffix,'("_",I2)') n
+      endif
+      if (len_trim(suffix) == 0) then
+        fname = trim(outputdir)//trim(timestring)//'.MOM.res.nc'
+      else
+        fname = trim(outputdir)//trim(timestring)//'.MOM.res_'//trim(suffix)//'nc'
+      endif
+
+      inquire(file=fname, exist=existflag)
+      if (existflag) then
+        !open and inquire unlimdim
+        call nf90_err(nf90_open(fname, nf90_nowrite, ncid), 'nf90_open: '//fname)
+        call nf90_err(nf90_inquire(ncid, unlimiteddimid=dimid), 'inquire unlimiteddimid')
+        call nf90_err(nf90_inquire_dimension(ncid, dimid, len=nlen), 'inquire unlimited dimension')
+        call nf90_err(nf90_close(ncid), 'close: '//fname)
+        if (nlen > 0) allDone(n) = .true.
+        ! if (nlen > 0) then
+        !   allDone(n) = .true.
+        !   if(is_root_pe())print '(A)','XX '//trim(fname)//' exists  '//trim(import_timestr)//'  '//trim(export_timestr)//' complete'
+        ! else
+        !   if(is_root_pe())print '(A)','XX '//trim(fname)//' exists  '//trim(import_timestr)//'  '//trim(export_timestr)//' still 0'
+      end if
+    end do
+
+    if (any(allDone) == .false.) then
+      !abort
+    else
+      if (is_root_pe()) then
+        call log_restart_fh(MyTime, startTime, 'mom6.res', prefixtime=.true., rc=rc)
+        if (ChkErr(rc,__LINE__,u_FILE_u)) return
+      endif
+    endif
+  end subroutine outputlog_restart
   !> Handle netcdf errors
   !!
   !! @param[in]  ierr        the error code
@@ -277,5 +331,5 @@ contains
       stop 99
     end if
   end subroutine nf90_err
-end module MOM_cap_outputlog
 #endif
+end module MOM_cap_outputlog

--- a/config_src/drivers/nuopc_cap/mom_cap_outputlog.F90
+++ b/config_src/drivers/nuopc_cap/mom_cap_outputlog.F90
@@ -1,7 +1,27 @@
-!> This module contains a set of subroutines that check if MOM diagnostic
-!! output files have been written and closed
-module MOM_cap_logging
+!> This module contains a set of subroutines that check if MOM
+!! history files have been written and closed. It is a stub routine
+!! when CESMCOUPLED is defined
+module MOM_cap_outputlog
 
+#ifdef CESMCOUPLED
+  use ESMF                  , only : ESMF_Clock, ESMF_SUCCESS
+  implicit none; private
+
+  public :: outputlog_init, outputlog_run
+contains
+  subroutine outputlog_init(mclock, rc)
+
+    type(ESMF_Clock)     :: mclock !< the ESMF_clock for the model
+    integer, intent(out) :: rc     !< return code
+    rc = ESMF_SUCCESS
+  end subroutine outputlog_init
+  subroutine outputlog_run(mclock, rc)
+    type(ESMF_Clock)     :: mclock !< the ESMF_clock for the model
+    integer, intent(out) :: rc     !< return code
+    rc = ESMF_SUCCESS
+  end subroutine outputlog_run
+end module MOM_cap_outputlog
+#else
   use MOM_error_handler,      only: is_root_pe
   use ESMF                  , only : ESMF_Time, ESMF_Clock, ESMF_ClockGet, ESMF_Alarm, ESMF_AlarmSet
   use ESMF                  , only : ESMF_ClockGetAlarm, ESMF_AlarmIsRinging, ESMF_AlarmRingerOff
@@ -17,28 +37,36 @@ module MOM_cap_logging
 
   implicit none; private
 
-  public :: outputAlarms_init, outputAlarms_run
+  public :: outputlog_init, outputlog_run
 
-  ! for now, only one type of output we need to log (6hrly)
+  ! the allowable output frequency for MOM6 history, in hours only
+  !integer, parameter :: n_freq  = 3
+  !integer, parameter, dimension(n_freq) :: freq = (/3, 6, 24/)
+
   integer, parameter :: n_freq  = 1
-  integer, parameter, dimension(n_freq) :: freq = (/6/)
+  integer, parameter, dimension(n_freq) :: freq = (/24/)
 
-  ! for generic cases, it will be convienent to use a standard 30min output
-  ! interval type to account for eg 1 or 3 hrly output
-  ! for now, use only 1 hour for 6-hrly case
-  type(ESMF_TimeInterval) :: outputInterval
+  ! the timeoffset interval is used only to construct the file name.
+  ! filenames will be given by T - (interval * offset + interval/2 * offset)
+  ! where interval is the averaging interval in minutes
+  !   00   .     06   .   12   .  18
+  !        03 = 12 - (6 + 3)
+  !                  09 = 18 - (6 + 3)
+  !! the timeoffset must be defined in minutes to allow sub-6hrly output
+  type(ESMF_TimeInterval) :: timeoffset
 
-  type :: ologfile_type
-    character(len=256) :: alarm_name
-    integer            :: opt_n
-    integer            :: interval_factor     !num of intervals between output files, for a given output freq
-    logical            :: chkfile_nextAdvance
-    character(len=256) :: filename
-    type(ESMF_Alarm)   :: alarm
-  end type ologfile_type
+  type :: outputlog_type
+    character(len=256)      :: alarm_name
+    integer                 :: opt_n
+    logical                 :: chkfile_nextAdvance
+    character(len=256)      :: filename
+    type(ESMF_Alarm)        :: alarm
+    type(ESMF_TimeInterval) :: filename_timeoffset
+  end type outputlog_type
 
-  type(ologfile_type) :: olog(n_freq)
+  type(outputlog_type) :: olog(n_freq)
 
+  character(len=3) :: chour
   character(len=*), parameter :: u_FILE_u = &
        __FILE__
 
@@ -48,7 +76,7 @@ contains
 !!
 !! @param clock an ESMF_Clock object
 !! @param rc return code
-  subroutine outputAlarms_init(mclock, rc)
+  subroutine outputlog_init(mclock, rc)
 
     type(ESMF_Clock)     :: mclock !< the ESMF_clock for the model
     integer, intent(out) :: rc     !< return code
@@ -56,9 +84,8 @@ contains
     ! local variables
     type(ESMF_Time)         :: mcurrtime
     type(ESMF_TimeInterval) :: timestep
-    character(len=3)        :: chour
     integer                 :: n
-    character(len=256)      :: subname='MOM_cap:(outputAlarms_init) '
+    character(len=256)      :: subname='MOM_cap:(outputlog_init) '
     !--------------------------------
 
     rc = ESMF_SUCCESS
@@ -66,15 +93,14 @@ contains
     call ESMF_ClockGet(mclock, currTime=mcurrtime, rc=rc)
     if (ChkErr(rc,__LINE__,u_FILE_u)) return
 
-    call ESMF_TimeIntervalSet(outputInterval, h=1, rc=rc)
+    call ESMF_TimeIntervalSet(timeoffset, m=1, rc=rc)
     if (ChkErr(rc,__LINE__,u_FILE_u)) return
 
     do n = 1,n_freq
       write(chour,'(i2.2,a)')freq(n),'h'
       olog(n)%alarm_name = 'output_alarm'//trim(chour)
       olog(n)%opt_n = freq(n)
-      ! for 6hr, factor = 6 + 3
-      olog(n)%interval_factor = olog(n)%opt_n + olog(n)%opt_n/2
+      olog(n)%filename_timeoffset = 90*freq(n)*timeoffset
       olog(n)%chkfile_nextAdvance = .false.
       olog(n)%filename = ''
 
@@ -91,37 +117,38 @@ contains
       if (ChkErr(rc,__LINE__,u_FILE_u)) return
       call ESMF_LogWrite(subname//" Output alarm "//trim(olog(n)%alarm_name)//" is Created and Set", ESMF_LOGMSG_INFO)
     end do
-  end subroutine outputAlarms_init
+  end subroutine outputlog_init
   !> Use Alarms at the diagnostic output frequency to determine if output has been
   !! completed
   !!
   !! @param clock an ESMF_Clock object
   !! @param rc return code
-  subroutine outputAlarms_run(mclock, rc)
+  subroutine outputlog_run(mclock, rc)
 
     type(ESMF_Clock)     :: mclock !< the ESMF_clock for the model
     integer, intent(out) :: rc     !< return code
 
     ! local variables
-    type(ESMF_Time)         :: nextTime, mcurrTime
+    type(ESMF_Time)         :: nextTime, currTime, startTime
     type(ESMF_TimeInterval) :: timeStep
     logical                 :: existflag
     integer                 :: n, ncid, dimid, nlen
-    integer                 :: year, month, day, hour
+    integer                 :: year, month, day, hour, minute
     character(256)          :: import_timestr, export_timestr, fname
-    character(len=256)      :: subname='MOM_cap:(outputAlarms_run) '
+    character(len=256)      :: subname='MOM_cap:(outputlog_run) '
     !--------------------------------
 
     rc = ESMF_SUCCESS
 
-    call ESMF_ClockGet(mclock, currTime=mcurrTime, timeStep=timeStep, rc=rc)
+    call ESMF_ClockGet(mclock, startTime=startTime, currTime=currTime, timeStep=timeStep, rc=rc)
     if (ChkErr(rc,__LINE__,u_FILE_u)) return
-    call ESMF_TimeGet(mcurrTime,          timestring=import_timestr, rc=rc)
+    call ESMF_TimeGet(currTime,          timestring=import_timestr, rc=rc)
     if (ChkErr(rc,__LINE__,u_FILE_u)) return
-    call ESMF_TimeGet(mcurrTime+timestep, timestring=export_timestr, rc=rc)
+    call ESMF_TimeGet(currTime+timestep, timestring=export_timestr, rc=rc)
     if (ChkErr(rc,__LINE__,u_FILE_u)) return
-
+!#ifdef test
     do n = 1,n_freq
+      write(chour,'(i2.2,a)')freq(n),'h'
       call ESMF_ClockGetAlarm(mclock, alarmname=trim(olog(n)%alarm_name), alarm=olog(n)%alarm, rc=rc)
       if (ChkErr(rc,__LINE__,u_FILE_u)) return
       if (ESMF_AlarmIsRinging(olog(n)%alarm, rc=rc)) then
@@ -133,9 +160,9 @@ contains
         ! set filename
         call ESMF_ClockGetNextTime(mclock, nextTime, rc=rc)
         if (ChkErr(rc,__LINE__,u_FILE_u)) return
-        call ESMF_TimeGet (nextTime-olog(n)%interval_factor*outputInterval, yy=year, mm=month, dd=day, h=hour, rc=rc )
+        call ESMF_TimeGet (nextTime-olog(n)%filename_timeoffset, yy=year, mm=month, dd=day, h=hour, m=minute, rc=rc )
         if (ChkErr(rc,__LINE__,u_FILE_u)) return
-        write(olog(n)%filename,'(a,i4.4,3(a,i2.2),a)')'ocn_',year,'_',month,'_',day,'_',hour,'.nc'
+        write(olog(n)%filename,'(a,i4.4,4(a,i2.2),a)')'ocn_',year,'_',month,'_',day,'_',hour,'_',minute,'.nc'
         if(is_root_pe())print *,'XX0 '//trim(olog(n)%filename)//'  '//trim(import_timestr)//'  '//trim(export_timestr)
       end if
 
@@ -144,13 +171,16 @@ contains
         fname = trim(olog(n)%filename)
         inquire(file=fname, exist=existflag)
         if (existflag) then
-          !open and inquire unlimdim
           call nf90_err(nf90_open(fname, nf90_nowrite, ncid), 'nf90_open: '//fname)
           call nf90_err(nf90_inquire(ncid, unlimiteddimid=dimid), 'inquire unlimiteddimid')
           call nf90_err(nf90_inquire_dimension(ncid, dimid, len=nlen), 'inquire unlimited dimension')
           call nf90_err(nf90_close(ncid), 'close: '//fname)
           if (nlen > 0) then
             olog(n)%chkfile_nextAdvance = .false.
+            if (is_root_pe()) then
+              call log_restart_fh(currTime+timestep, startTime, 'mom6.'//chour, prefixtime=.true., rc=rc)
+              if (ChkErr(rc,__LINE__,u_FILE_u)) return
+            endif
             if(is_root_pe())print *,'XX '//trim(olog(n)%filename)//'  '//trim(import_timestr)//'  '//trim(export_timestr)//' complete'
           else
             if(is_root_pe())print *,'XX '//trim(olog(n)%filename)//'  '//trim(import_timestr)//'  '//trim(export_timestr)//' still 0'
@@ -158,7 +188,40 @@ contains
         end if
       end if
     end do
-  end subroutine outputAlarms_run
+!#endif
+#ifdef test
+
+    fname = 'ocn_2011_10_01_10_30.nc'
+    inquire(file=fname, exist=existflag)
+    if (existflag) then
+      !open and inquire unlimdim
+      call nf90_err(nf90_open(fname, nf90_nowrite, ncid), 'nf90_open: '//fname)
+      call nf90_err(nf90_inquire(ncid, unlimiteddimid=dimid), 'inquire unlimiteddimid')
+      call nf90_err(nf90_inquire_dimension(ncid, dimid, len=nlen), 'inquire unlimited dimension')
+      call nf90_err(nf90_close(ncid), 'close: '//fname)
+      if (nlen > 0) then
+        if(is_root_pe())print '(A)','XX '//trim(fname)//' exists  '//trim(import_timestr)//'  '//trim(export_timestr)//' complete'
+      else
+        if(is_root_pe())print '(A)','XX '//trim(fname)//' exists  '//trim(import_timestr)//'  '//trim(export_timestr)//' still 0'
+      end if
+    end if
+
+    fname = 'ocn_2011_10_03_01_30.nc'
+    inquire(file=fname, exist=existflag)
+    if (existflag) then
+      !open and inquire unlimdim
+      call nf90_err(nf90_open(fname, nf90_nowrite, ncid), 'nf90_open: '//fname)
+      call nf90_err(nf90_inquire(ncid, unlimiteddimid=dimid), 'inquire unlimiteddimid')
+      call nf90_err(nf90_inquire_dimension(ncid, dimid, len=nlen), 'inquire unlimited dimension')
+      call nf90_err(nf90_close(ncid), 'close: '//fname)
+      if (nlen > 0) then
+        if(is_root_pe())print '(A)','XX '//trim(fname)//' exists  '//trim(import_timestr)//'  '//trim(export_timestr)//' complete'
+      else
+        if(is_root_pe())print '(A)','XX '//trim(fname)//' exists  '//trim(import_timestr)//'  '//trim(export_timestr)//' still 0'
+      end if
+    end if
+#endif
+  end subroutine outputlog_run
   !> Handle netcdf errors
   !!
   !! @param[in]  ierr        the error code
@@ -179,4 +242,5 @@ contains
       stop 99
     end if
   end subroutine nf90_err
-end module MOM_cap_logging
+end module MOM_cap_outputlog
+#endif

--- a/config_src/drivers/nuopc_cap/mom_cap_outputlog.F90
+++ b/config_src/drivers/nuopc_cap/mom_cap_outputlog.F90
@@ -32,12 +32,12 @@ contains
 #else
   use MOM_error_handler     , only : is_root_pe, MOM_error, FATAL
   use NUOPC                 , only : NUOPC_CompAttributeGet
-  use ESMF                  , only : ESMF_GridComp
+  use ESMF                  , only : ESMF_GridComp, ESMF_GridCompGet, ESMF_VM, ESMF_VMGet
   use ESMF                  , only : ESMF_Time, ESMF_Clock, ESMF_ClockGet, ESMF_Alarm, ESMF_AlarmSet
   use ESMF                  , only : ESMF_ClockGetAlarm, ESMF_AlarmIsRinging, ESMF_AlarmRingerOff
   use ESMF                  , only : ESMF_ClockGetNextTime, ESMF_TimeGet, ESMF_TimeInterval
   use ESMF                  , only : ESMF_AlarmGet, ESMF_TimeIntervalSet, ESMF_TimeIntervalPrint
-  use ESMF                  , only : ESMF_SUCCESS, ESMF_LogWrite, ESMF_LOGMSG_INFO
+  use ESMF                  , only : ESMF_SUCCESS, ESMF_LogWrite, ESMF_LOGMSG_INFO, ESMF_VMBroadCast
   use ESMF                  , only : ESMF_LogSetError, ESMF_LogFoundError, ESMF_LOGERR_PASSTHRU
   use ESMF                  , only : operator(*), operator(+), operator(-), operator(>), operator(==)
   use MOM_cap_methods       , only : ChkErr
@@ -88,6 +88,7 @@ contains
   ! an output file is declared closed when the unlimited dimension in the file is > 0
   ! each closed output file is recorded in a logfile named with the associated forecast hour.
 
+  type(ESMF_VM)           :: vm
   type(ESMF_TimeInterval) :: tincrement
   type(ESMF_Time)         :: lastrestart
 
@@ -141,6 +142,8 @@ contains
     !----------------------------------------------------------------------------
 
     rc = ESMF_SUCCESS
+    call ESMF_GridCompGet(gcomp, vm=vm, rc=rc)
+    if (ChkErr(rc,__LINE__,u_FILE_u)) return
 
     call NUOPC_CompAttributeGet(gcomp, name="mom6_restart_dir", value=value, &
          isPresent=isPresent, isSet=isSet, rc=rc)
@@ -227,7 +230,7 @@ contains
       if (freq(n) .eq. 6) then
         olog(n)%fh_iauoffset      = iau_offset*30*tincrement
       else
-        olog(n)%fh_iauoffset      = 0
+        olog(n)%fh_iauoffset      = 0*tincrement
       end if
 
       call AlarmInit(mclock,                           &
@@ -265,7 +268,7 @@ contains
     type(ESMF_Time)         :: nextTime, currTime, startTime, prevRing
     type(ESMF_TimeInterval) :: timeStep
     logical                 :: lstop
-    integer                 :: n, ncid, dimid, nlen
+  integer                 :: n, ncid, dimid, nlen(1)
     integer                 :: year, month, day, hour, minute
     character(len=512)      :: import_timestr, export_timestr, importexport !debugging only
     character(len=16)       :: timestr
@@ -319,11 +322,12 @@ contains
           fname = trim(olog(n)%filename)
           inquire(file=fname, exist=existflag)
           if (existflag) then
-            call nf90_err(nf90_open(fname, nf90_nowrite, ncid), 'nf90_open: '//fname)
-            call nf90_err(nf90_inquire(ncid, unlimiteddimid=dimid), 'inquire unlimiteddimid')
-            call nf90_err(nf90_inquire_dimension(ncid, dimid, len=nlen), 'inquire unlimited dimension')
-            call nf90_err(nf90_close(ncid), 'close: '//fname)
-            if (nlen > 0) then
+            if (is_root_pe()) then
+              nlen(1) = get_unlimited_len(trim(fname))
+            end if
+            call ESMF_VMBroadCast(vm, nlen, 1, 0, rc=rc)
+            if (ChkErr(rc,__LINE__,u_FILE_u)) return
+            if (nlen(1) > 0) then
               olog(n)%chkfile_nextAdvance = .false.
               olog(n)%time_lastrestart = lastrestart
               if (is_root_pe()) then
@@ -336,8 +340,8 @@ contains
         end if
 
         if (lstop) then
-          ! use prevRing in place of currTime to allow for stopping between averaging
-          ! intervals; prevring == currTime if stopping on intervals
+          ! use prevRing in place of currTime to allow for stopping between averaging intervals
+          ! prevring == currTime if stopping on intervals
           call ESMF_AlarmGet(olog(n)%alarm, prevRingTime=prevring, rc=rc)
           if (ChkErr(rc,__LINE__,u_FILE_u)) return
           if (debug .and. is_root_pe()) then
@@ -358,11 +362,12 @@ contains
           fname = trim(olog(n)%filename)
           inquire(file=fname, exist=existflag)
           if (existflag) then
-            call nf90_err(nf90_open(fname, nf90_nowrite, ncid), 'nf90_open: '//fname)
-            call nf90_err(nf90_inquire(ncid, unlimiteddimid=dimid), 'inquire unlimiteddimid')
-            call nf90_err(nf90_inquire_dimension(ncid, dimid, len=nlen), 'inquire unlimited dimension')
-            call nf90_err(nf90_close(ncid), 'close: '//fname)
-            if (nlen > 0) then
+            if (is_root_pe()) then
+              nlen(1) = get_unlimited_len(fname)
+            end if
+            call ESMF_VMBroadCast(vm, nlen, 1, 0, rc=rc)
+            if (ChkErr(rc,__LINE__,u_FILE_u)) return
+            if (nlen(1) > 0) then
               olog(n)%chkfile_nextAdvance = .false.
               olog(n)%time_lastrestart = lastrestart
               call ESMF_ClockGet(mclock, currTime=currTime, rc=rc)
@@ -376,21 +381,16 @@ contains
           end if
         end if ! lstop
 
-        if (debug) then
+        if (debug .and. is_root_pe()) then
           fname = trim(olog(n)%filename)
           inquire(file=fname, exist=existflag)
           if (existflag) then
-           call nf90_err(nf90_open(fname, nf90_nowrite, ncid), 'nf90_open: '//fname)
-           call nf90_err(nf90_inquire(ncid, unlimiteddimid=dimid), 'inquire unlimiteddimid')
-           call nf90_err(nf90_inquire_dimension(ncid, dimid, len=nlen), 'inquire unlimited dimension')
-           call nf90_err(nf90_close(ncid), 'close: '//fname)
-            if (is_root_pe()) then
-              write(msgString,'(A)')trim(subname)//trim(fname)//' exists '//trim(importexport)
-              if (nlen > 0) then
-                print '(A,L)',trim(msgString)//' complete ',olog(n)%chkfile_nextAdvance
-              else
-                print '(A,L)',trim(msgString)//' still  0 ',olog(n)%chkfile_nextAdvance
-              end if
+            nlen(1) = get_unlimited_len(fname)
+            write(msgString,'(A)')trim(subname)//trim(fname)//' exists '//trim(importexport)
+            if (nlen(1) > 0) then
+              print '(A,L)',trim(msgString)//' complete ',olog(n)%chkfile_nextAdvance
+            else
+              print '(A,L)',trim(msgString)//' still  0 ',olog(n)%chkfile_nextAdvance
             end if
           end if
         end if
@@ -412,7 +412,7 @@ contains
     ! local variables
     type(ESMF_Time)         :: startTime, currTime, nextTime
     type(ESMF_TimeInterval) :: timestep
-    integer                 :: n, ncid, dimid, nlen
+  integer                 :: n, ncid, dimid, nlen(1)
     integer                 :: year, month, day, hour, minute, seconds
     character(len=512)      :: fname
     character(len=15)       :: timestr
@@ -458,14 +458,16 @@ contains
       ! check if file is written
       inquire(file=trim(fname), exist=existflag)
       if (existflag) then
-        call nf90_err(nf90_open(trim(fname), nf90_nowrite, ncid), 'nf90_open: '//trim(fname))
-        call nf90_err(nf90_inquire(ncid, unlimiteddimid=dimid), 'inquire unlimiteddimid')
-        call nf90_err(nf90_inquire_dimension(ncid, dimid, len=nlen), 'inquire unlimited dimension')
-        call nf90_err(nf90_close(ncid), 'close: '//trim(fname))
-        if (nlen > 0) allDone(n) = .true.
+        if (is_root_pe())then
+          nlen(1) = get_unlimited_len(trim(fname))
+        end if
+        call ESMF_VMBroadCast(vm, nlen, 1, 0, rc=rc)
+        if (ChkErr(rc,__LINE__,u_FILE_u)) return
+
+        if (nlen(1) > 0) allDone(n) = .true.
 
         if (debug .and. is_root_pe()) then
-          if (nlen > 0) then
+          if (nlen(1) > 0) then
             print '(A)',trim(subname)//' restart '//trim(fname)//'  '//trim(importexport)//' complete'
           else
             print '(A)',trim(subname)//' restart '//trim(fname)//'  '//trim(importexport)//' still 0'
@@ -474,16 +476,35 @@ contains
       end if
     end do ! num_rest_files
 
-    ! Layout(1,1), only rootPE writes restarts
-    if (is_root_pe()) then
-      if (all(allDone) .eqv. .true.) then
-        lastrestart = nextTime
+    if (all(allDone) .eqv. .true.) then
+      lastrestart = nextTime
+      if (is_root_pe()) then
         call log_restart_fh(nextTime, startTime, 'mom6.res', prefixtime=.true., rc=rc)
         if (ChkErr(rc,__LINE__,u_FILE_u)) return
       endif
     end if
 
   end subroutine outputlog_restart
+
+  !> Return the length of the unlimited dimension
+  !!
+  !! @param[in]  fname   the file name
+  !! @return             unlimited dimension length
+  integer function get_unlimited_len(fname) result(unlen)
+
+    character(len=*), intent(in) :: fname
+
+    integer :: ncid, dimid
+    !----------------------------------------------------------------------------
+
+    unlen = 0
+    call nf90_err(nf90_open(trim(fname), nf90_nowrite, ncid), 'nf90_open: '//trim(fname))
+    call nf90_err(nf90_inquire(ncid, unlimiteddimid=dimid), 'inquire unlimiteddimid')
+    call nf90_err(nf90_inquire_dimension(ncid, dimid, len=unlen), 'inquire unlimited dimension')
+    call nf90_err(nf90_close(ncid), 'close: '//trim(fname))
+
+  end function get_unlimited_len
+
   !> Handle netcdf errors
   !!
   !! @param[in]  ierr        the error code

--- a/config_src/drivers/nuopc_cap/mom_cap_outputlog.F90
+++ b/config_src/drivers/nuopc_cap/mom_cap_outputlog.F90
@@ -36,7 +36,7 @@ contains
   use ESMF                  , only : ESMF_Time, ESMF_Clock, ESMF_ClockGet, ESMF_Alarm, ESMF_AlarmSet
   use ESMF                  , only : ESMF_ClockGetAlarm, ESMF_AlarmIsRinging, ESMF_AlarmRingerOff
   use ESMF                  , only : ESMF_ClockGetNextTime, ESMF_TimeGet, ESMF_TimeInterval
-  use ESMF                  , only : ESMF_TimeIntervalSet, ESMF_TimeIntervalPrint
+  use ESMF                  , only : ESMF_AlarmGet, ESMF_TimeIntervalSet, ESMF_TimeIntervalPrint
   use ESMF                  , only : ESMF_SUCCESS, ESMF_LogWrite, ESMF_LOGMSG_INFO
   use ESMF                  , only : ESMF_LogSetError, ESMF_LogFoundError, ESMF_LOGERR_PASSTHRU
   use ESMF                  , only : operator(*), operator(+), operator(-), operator(>), operator(==)
@@ -44,28 +44,22 @@ contains
   use MOM_cap_time          , only : AlarmInit
   use shr_is_restart_fh_mod , only : log_restart_fh
   use netcdf
-  ! debug
-  use ESMF, only : ESMF_TimePrint
-  !use ESMF, only : ESMF_AlarmWasPrevRinging
 
   implicit none; private
 
   public :: outputlog_init, outputlog_run, outputlog_restart
 
   ! the allowable output frequency for MOM6 history, in hours only
-  ! TODO: 3hrly output reqs filename with minutes field
-  ! TODO: check multiple output freq for same run, reqs different
-  ! known filename root for different freqs
   integer, parameter :: n_freq  = 3
   integer, parameter, dimension(n_freq) :: freq = (/3, 6, 24/)
+  ! TODO: check multiple output freq for same run, reqs different  known filename
+  ! root for different freqs
 
-  ! the timeoffset interval (defined in minutes) is used to construct
-  ! the file name of the output
-  ! the file name must be set as the mid-point of the averaging period
-  ! via the diagtable
-  ! output filename timestrings are given by
-  !      T - (interval * offset + interval/2 * offset)
-  ! where interval is the averaging interval in minutes
+  ! the tincrement interval (defined in minutes) is used to construct the output filename
+  ! the file name must be set as the mid-point of the averaging period via the diagtable
+  ! and the output filename timestrings are given by
+  !      T - (interval * 60 * increment + interval/2 * 60 * increment )
+  ! where T is the time that the currTime when the file is closed
   !
   !   00   .   03   .   06   .   09
   !       1:30 = 6 - (3 + 1:30)
@@ -79,27 +73,22 @@ contains
   !       12 = 48 - (24 + 12)
   !                 36 = 72 - (24 + 12)
   !
-  ! when the model reaches the stop time, any 'pending' output
-  ! file is closed, and the final interval output is also closed
+  ! when the model reaches the stop time, any 'pending' output file is closed, and the final
+  ! interval output is also closed
   !
   !                   stop
   !  18   .   24   .   30
   !      21 = 30 - (12 + 3)
   !                03 = 30 - (3)
   !
-  ! since both the final interval and the next-to-final interval are
-  ! closed at the stop time, a different log file name is required for
-  ! the final log file, otherwise we over-write the next-to-final log
+  ! since both the final interval and the next-to-final interval are closed at the stop time,
+  ! a different log file name is required for  the final log file, otherwise the next-to-final
+  ! log is overwritten
   !
-  ! an output file is declared closed when the unlimited dimension in
-  ! the file is > 0
-  !
-  ! each closed output file is recorded in a logfile at the associated
-  ! forecast hour. The name of the logfile is given by
-  !     T - (interval * offset)
-  ! where T is the currTime when the file is closed
+  ! an output file is declared closed when the unlimited dimension in the file is > 0
+  ! each closed output file is recorded in a logfile at the associated forecast hour.
 
-  type(ESMF_TimeInterval) :: timeoffset
+  type(ESMF_TimeInterval) :: tincrement
   type(ESMF_Time)         :: lastrestart
 
   type :: outputlog_type
@@ -108,7 +97,8 @@ contains
     logical                 :: chkfile_nextAdvance
     character(len=1024)     :: filename
     type(ESMF_Alarm)        :: alarm
-    type(ESMF_TimeInterval) :: filename_timeoffset
+    type(ESMF_TimeInterval) :: fhoffset
+    type(ESMF_TimeInterval) :: filename_fhoffset
     type(ESMF_Time)         :: time_lastrestart
   end type outputlog_type
 
@@ -195,7 +185,7 @@ contains
 
     call ESMF_ClockGet(mclock, currTime=mcurrTime, startTime=startTime, rc=rc)
     if (ChkErr(rc,__LINE__,u_FILE_u)) return
-    call ESMF_TimeIntervalSet(timeoffset, m=1, rc=rc)
+    call ESMF_TimeIntervalSet(tincrement, m=1, rc=rc)
     if (ChkErr(rc,__LINE__,u_FILE_u)) return
 
     ! initialize
@@ -203,19 +193,20 @@ contains
 
     do n = 1,n_freq
       write(chour,'(I2.2,A)')freq(n),'h'
-      olog(n)%alarm_name = 'output_alarm'//trim(chour)
-      olog(n)%opt_n = freq(n)
-      olog(n)%filename_timeoffset = 90*freq(n)*timeoffset
+      olog(n)%alarm_name          = 'output_alarm'//trim(chour)
+      olog(n)%opt_n               = freq(n)
+      olog(n)%fhoffset            = 60*freq(n)*tincrement
+      olog(n)%filename_fhoffset   = 90*freq(n)*tincrement
       olog(n)%chkfile_nextAdvance = .false.               ! alarms ring at the ouput freq, but files close on next advance
-      olog(n)%filename = ''
-      olog(n)%time_lastrestart = lastrestart
+      olog(n)%filename            = ''
+      olog(n)%time_lastrestart    = lastrestart
 
-      call AlarmInit(mclock,         &
-           alarm   = olog(n)%alarm,  &
-           option  = 'nhours',       &
-           opt_n   = olog(n)%opt_n,  &
-           opt_ymd = -999,           &
-           RefTime = mcurrTime,      &
+      call AlarmInit(mclock,           &
+           alarm     = olog(n)%alarm,  &
+           option    = 'nhours',       &
+           opt_n     = olog(n)%opt_n,  &
+           opt_ymd   = -999,           &
+           RefTime   = mcurrTime,      &
            alarmname = olog(n)%alarm_name, rc=rc)
       if (ChkErr(rc,__LINE__,u_FILE_u)) return
 
@@ -223,7 +214,7 @@ contains
       if (ChkErr(rc,__LINE__,u_FILE_u)) return
       call ESMF_LogWrite(trim(subname)//" Output alarm "//trim(olog(n)%alarm_name)//" is Created and Set", ESMF_LOGMSG_INFO)
       if (debug .and. is_root_pe()) then
-        call ESMF_TimeIntervalPrint(olog(n)%filename_timeoffset, options="string", rc=rc)
+        call ESMF_TimeIntervalPrint(olog(n)%filename_fhoffset, options="string", rc=rc)
         if (ChkErr(rc,__LINE__,u_FILE_u)) return
       end if
 
@@ -243,9 +234,9 @@ contains
     integer, intent(out)          :: rc         !< return code
 
     ! local variables
-    type(ESMF_Time)         :: nextTime, currTime, startTime
+    type(ESMF_Time)         :: nextTime, currTime, startTime, prevRing
     type(ESMF_TimeInterval) :: timeStep
-    logical                 :: lstop
+    logical                 :: lstop, stop_on_interval
     integer                 :: n, ncid, dimid, nlen
     integer                 :: year, month, day, hour, minute
     character(len=256)      :: import_timestr, export_timestr, importexport !debugging only
@@ -264,6 +255,7 @@ contains
     importexport = trim(import_timestr)//'  '//trim(export_timestr)
 
     lstop = .false.
+    stop_on_interval = .false.
     if (present(atStopTime)) then
       lstop = atStopTime
     end if
@@ -282,7 +274,7 @@ contains
 
           call ESMF_ClockGetNextTime(mclock, nextTime, rc=rc)
           if (ChkErr(rc,__LINE__,u_FILE_u)) return
-          call ESMF_TimeGet (nextTime-olog(n)%filename_timeoffset, yy=year, mm=month, dd=day, h=hour, m=minute, rc=rc )
+          call ESMF_TimeGet (nextTime-olog(n)%filename_fhoffset, yy=year, mm=month, dd=day, h=hour, m=minute, rc=rc )
           if (ChkErr(rc,__LINE__,u_FILE_u)) return
           write(olog(n)%filename,'(A,I4.4,4(A,I2.2),A)')trim(outputdir)//'ocn_',year,'_',month,'_',day,'_',hour,'_',minute,'.nc'
 
@@ -303,8 +295,8 @@ contains
               olog(n)%chkfile_nextAdvance = .false.
               olog(n)%time_lastrestart = lastrestart
               if (is_root_pe()) then
-                call log_restart_fh(currTime-60*freq(n)*timeoffset, startTime, 'mom6.'//chour, prefixtime=.true., &
-                     lastrestart=olog(n)%time_lastrestart, lastwritten=olog(n)%filename, rc=rc)
+                call log_restart_fh(currTime-olog(n)%fhoffset, startTime, 'mom6.'//chour, prefixtime=.true., &
+                     lastrestart=olog(n)%time_lastrestart, lastoutput=olog(n)%filename, rc=rc)
                 if (ChkErr(rc,__LINE__,u_FILE_u)) return
               endif
             end if
@@ -312,9 +304,27 @@ contains
         end if
 
         if (lstop) then
-          !this doesn't work if stoptime is not on an averaging interval!
-          call ESMF_TimeGet (currTime-30*freq(n)*timeoffset, yy=year, mm=month, dd=day, h=hour, m=minute, rc=rc )
+          ! need separate logic for stopping on interval and stopping between intervals
+          call ESMF_AlarmGet(olog(n)%alarm, prevRingTime=prevring, rc=rc)
           if (ChkErr(rc,__LINE__,u_FILE_u)) return
+          if (debug .and. is_root_pe()) then
+            call ESMF_TimeGet(prevring, yy=year, mm=month, dd=day, h=hour, m=minute, rc=rc)
+            if (ChkErr(rc,__LINE__,u_FILE_u)) return
+            print '(A,I4.4,4(A,I2.2))',trim(subname)//' prevring at lstop ',year,'_',month,'_',day,'_',hour,'_',minute
+          end if
+
+          if (prevring == currTime) then
+            stop_on_interval = .true.
+          else
+            stop_on_interval = .false.
+          end if
+          if (stop_on_interval) then
+            call ESMF_TimeGet(currTime-30*freq(n)*tincrement, yy=year, mm=month, dd=day, h=hour, m=minute, rc=rc)
+            if (ChkErr(rc,__LINE__,u_FILE_u)) return
+          else
+            call ESMF_TimeGet(prevring-30*freq(n)*tincrement, yy=year, mm=month, dd=day, h=hour, m=minute, rc=rc)
+            if (ChkErr(rc,__LINE__,u_FILE_u)) return
+          end if
           write(olog(n)%filename,'(A,I4.4,4(A,I2.2),A)')trim(outputdir)//'ocn_',year,'_',month,'_',day,'_',hour,'_',minute,'.nc'
           if (debug .and. is_root_pe()) then
             print '(A)',trim(subname)//' fname at lstop '//trim(olog(n)%filename)//'  '//trim(importexport)
@@ -333,8 +343,13 @@ contains
               call ESMF_ClockGet(mclock, currTime=currTime, rc=rc)
               if (ChkErr(rc,__LINE__,u_FILE_u)) return
               if (is_root_pe()) then
-                call log_restart_fh(currTime-60*freq(n)*timeoffset, startTime, 'mom6.stop.'//chour, prefixtime=.true., &
-                     lastrestart=olog(n)%time_lastrestart, lastwritten=olog(n)%filename, rc=rc)
+                if (stop_on_interval) then
+                  call log_restart_fh(currTime, startTime, 'mom6.stop.'//chour, prefixtime=.true., &
+                       lastrestart=olog(n)%time_lastrestart, lastoutput=olog(n)%filename, rc=rc)
+                else
+                  call log_restart_fh(prevring, startTime, 'mom6.stop.'//chour, prefixtime=.true., &
+                       lastrestart=olog(n)%time_lastrestart, lastoutput=olog(n)%filename, rc=rc)
+                end if
                 if (ChkErr(rc,__LINE__,u_FILE_u)) return
               end if
             end if

--- a/config_src/drivers/nuopc_cap/mom_cap_outputlog.F90
+++ b/config_src/drivers/nuopc_cap/mom_cap_outputlog.F90
@@ -1,8 +1,8 @@
 !> This module contains a set of subroutines that check if MOM restart and history files
 !! have been written and closed. This file is specific to UWM operational requirements
-!! and configurations (eg specific output frequencys in hours) and may break if used outside
+!! and configurations (eg specific output frequencies in hours) and may break if used outside
 !! the scope of intended use.
-!! This module a stub when CESMCOUPLED is defined
+!! This module is a stub when CESMCOUPLED is defined
 module MOM_cap_outputlog
 
 #ifdef CESMCOUPLED
@@ -87,7 +87,7 @@ contains
   !
   ! Depending on configuration, the output file can have an unlimited dimension >0 at creation time.
   ! This necessitates checking for an additional criteria using the filesize at creation. An output file
-  ! is declared complete either when the unlimited dimension in the file is > 0 or when the unlimited
+  ! is declared complete either when the unlimited dimension in the file is >0 or when the unlimited
   ! dimension is >0 and the filesize is larger than the initial size.
 
   ! When a file is determined to be complete, a log file is recorded containing the forecast hour, the valid
@@ -98,11 +98,11 @@ contains
   type(ESMF_Time)         :: lastrestart
 
   type :: outputlog_type
-    character(len=128)      :: alarm_name
+    character(len=14)       :: alarm_name
     integer                 :: opt_n
     logical                 :: chkfile_nextAdvance
     logical                 :: use_filesize
-    character(len=1024)     :: filename
+    character(len=256)      :: filename
     integer                 :: createsize
     type(ESMF_Alarm)        :: alarm
     type(ESMF_TimeInterval) :: fhoffset
@@ -118,8 +118,6 @@ contains
   character(len=256) :: restartdir
   character(len=256) :: outputdir
   character(len=2)   :: output_fh
-  character(len=3)   :: chour
-  character(len=512) :: msgString
   character(len=*), parameter :: u_FILE_u = &
        __FILE__
 
@@ -141,6 +139,8 @@ contains
     logical                 :: isPresent, isSet
     integer                 :: n
     integer                 :: year, month, day, hour
+    character(len=3)        :: chour
+    character(len=256)      :: msgString
     character(len=256)      :: value
     character(len=256)      :: subname='MOM_cap:(outputlog_init)'
     !----------------------------------------------------------------------------
@@ -207,7 +207,7 @@ contains
     ! get start hour time offset (ie, fhrot)
     call ESMF_TimeGet(mcurrTime, yy=year, mm=month, dd=day, h=hour, rc=rc)
     if (ChkErr(rc,__LINE__,u_FILE_u)) return
-    if (mod(hour,6) .ne. 0) then
+    if (mod(hour,6) /= 0) then
       toffset = hour - 6
     else
       toffset = 0
@@ -273,9 +273,10 @@ contains
     logical            :: lstop
     logical            :: filecomplete
     integer            :: n, nlen(1), fsize(1)
+    character(len=3)   :: chour
     character(len=40)  :: importexport
     character(len=16)  :: timestr
-    character(len=512) :: fname
+    character(len=256) :: fname
     character(len=256) :: subname='MOM_cap:(outputlog_run)'
     !----------------------------------------------------------------------------
 
@@ -402,7 +403,7 @@ contains
     type(ESMF_Time)      :: startTime, currTime, nextTime
     integer              :: n, nlen(1)
     integer              :: year, month, day, hour, minute, seconds
-    character(len=512)   :: fname
+    character(len=256)   :: fname
     character(len=15)    :: timestr
     character(len=40)    :: importexport
     logical, allocatable :: allDone(:)
@@ -579,7 +580,6 @@ contains
   !! @param[in]    filesize       the filesize at creation time
   !! @param[in]    chkflag        logical flag for checking next Advance
   !! @param[in]    timestring     a timestring
-  !! @param [out]  rc             return code
   subroutine debug_info(tag,fname,chkflag,filesize,timestring)
 
     character(len=*), intent(in) :: tag
@@ -589,6 +589,7 @@ contains
     character(len=*), intent(in) :: timestring
 
     integer :: fsize
+    character(len=256) :: msgString
     !----------------------------------------------------------------------------
 
     inquire(file=fname, exist=existflag)
@@ -602,6 +603,7 @@ contains
       end if
     else
       write(msgString,'(A)')tag//'  '//fname//' does not exist '//timestring
+      print '(A)')trim(msgString)
     end if
   end subroutine debug_info
 

--- a/config_src/drivers/nuopc_cap/mom_cap_outputlog.F90
+++ b/config_src/drivers/nuopc_cap/mom_cap_outputlog.F90
@@ -603,7 +603,7 @@ contains
       end if
     else
       write(msgString,'(A)')tag//'  '//fname//' does not exist '//timestring
-      print '(A)')trim(msgString)
+      print '(A)',trim(msgString)
     end if
   end subroutine debug_info
 

--- a/config_src/drivers/nuopc_cap/mom_cap_outputlog.F90
+++ b/config_src/drivers/nuopc_cap/mom_cap_outputlog.F90
@@ -100,12 +100,12 @@ contains
     type(ESMF_Alarm)        :: alarm
     type(ESMF_TimeInterval) :: fhoffset
     type(ESMF_TimeInterval) :: filename_fhoffset
-    type(ESMF_TimeInterval) :: fh_iauoffset
     type(ESMF_Time)         :: time_lastrestart
   end type outputlog_type
 
   type(outputlog_type) :: olog(n_freq)
 
+  integer            :: toffset
   logical            :: debug
   logical            :: existflag
   character(len=256) :: restartdir
@@ -130,14 +130,12 @@ contains
 
     ! local variables
     type(ESMF_Time)         :: mcurrTime
-    type(ESMF_TimeInterval) :: timestep
+    type(ESMF_TimeInterval) :: alarmoffset
     logical                 :: isPresent, isSet
-    integer                 :: iau_offset
     integer                 :: n
+    integer                 :: year, month, day, hour
     character(len=256)      :: value
-    character(len=256)      :: subname='MOM_cap:(outputlog_init) '
-    !debug
-    character(len=16) :: timestr
+    character(len=256)      :: subname='MOM_cap:(outputlog_init)'
     !----------------------------------------------------------------------------
 
     rc = ESMF_SUCCESS
@@ -187,16 +185,6 @@ contains
     write(msgString,'(A)')'MOM_cap:MOM6 output frequency = '//trim(output_fh)
     call ESMF_LogWrite(trim(msgString), ESMF_LOGMSG_INFO)
 
-    iau_offset = 0
-    call NUOPC_CompAttributeGet(gcomp, name="iau_offset", value=value, &
-         isPresent=isPresent, isSet=isSet, rc=rc)
-    if (ChkErr(rc,__LINE__,u_FILE_u)) return
-    if (isPresent .and. isSet) then
-      read(value,*)iau_offset
-    end if
-    write(msgString,'(A,i6)')'MOM_cap:MOM6 iau_offset ',iau_offset
-    call ESMF_LogWrite(trim(msgString), ESMF_LOGMSG_INFO)
-
     debug = .false.
     call NUOPC_CompAttributeGet(gcomp, name="debug_outputlog", value=value, &
          isPresent=isPresent, isSet=isSet, rc=rc)
@@ -209,34 +197,43 @@ contains
     call ESMF_TimeIntervalSet(tincrement, m=1, rc=rc)
     if (ChkErr(rc,__LINE__,u_FILE_u)) return
 
+    ! get start hour time offset (ie, fhrot)
+    call ESMF_TimeGet(mcurrTime, yy=year, mm=month, dd=day, h=hour, rc=rc)
+    if (ChkErr(rc,__LINE__,u_FILE_u)) return
+    if (mod(hour,6) .ne. 0) then
+      toffset = hour - 6
+    else
+      toffset = 0
+    end if
+    if (debug .and. is_root_pe()) then
+      print '(A,i8)',trim(subname)//' toffset = ',toffset
+    end if
     ! initialize
     lastrestart = mcurrTime
-
-    timestr = get_timestr(mcurrTime-iau_offset*30*tincrement, rc)
-    if (ChkErr(rc,__LINE__,u_FILE_u)) return
-    if (debug .and. is_root_pe())print *,'XXX ',trim(timestr)
 
     do n = 1,n_freq
       write(chour,'(I2.2,A)')freq(n),'h'
       olog(n)%alarm_name          = 'output_alarm'//trim(chour)
       olog(n)%opt_n               = freq(n)
-      olog(n)%fhoffset            = 60*freq(n)*tincrement
-      olog(n)%filename_fhoffset   = 90*freq(n)*tincrement
       olog(n)%chkfile_nextAdvance = .false.
       olog(n)%filename            = ''
       olog(n)%time_lastrestart    = lastrestart
-      if (freq(n) .eq. 6) then
-        olog(n)%fh_iauoffset      = iau_offset*60*tincrement
+      olog(n)%fhoffset            = 60*freq(n)*tincrement
+      olog(n)%filename_fhoffset   = 90*freq(n)*tincrement
+
+      ! the time offset in hours required to ensure the alarm rings at multiples of 6
+      if (freq(n) >= 6) then
+        alarmoffset = toffset*60*tincrement
       else
-        olog(n)%fh_iauoffset      = 0*tincrement
+        alarmoffset = 0*tincrement
       end if
 
-      call AlarmInit(mclock,                               &
-           alarm     = olog(n)%alarm,                      &
-           option    = 'nhours',                           &
-           opt_n     = olog(n)%opt_n,                      &
-           opt_ymd   = -999,                               &
-           RefTime   = mcurrTime-iau_offset*30*tincrement, &
+      call AlarmInit(mclock,                  &
+           alarm     = olog(n)%alarm,         &
+           option    = 'nhours',              &
+           opt_n     = olog(n)%opt_n,         &
+           opt_ymd   = -999,                  &
+           RefTime   = mcurrTime+alarmoffset, &
            alarmname = olog(n)%alarm_name, rc=rc)
       if (ChkErr(rc,__LINE__,u_FILE_u)) return
 
@@ -249,8 +246,8 @@ contains
         if (ChkErr(rc,__LINE__,u_FILE_u)) return
       end if
     end do
-
   end subroutine outputlog_init
+
   !> Use Alarms at the output frequency to determine if output has been completed
   !!
   !! @param clock        an ESMF_Clock object
@@ -263,25 +260,24 @@ contains
     integer, intent(out)          :: rc         !< return code
 
     ! local variables
-    type(ESMF_Time)         :: nextTime, currTime, startTime, prevRing
-    type(ESMF_TimeInterval) :: timeStep
-    logical                 :: lstop
-    integer                 :: n, ncid, dimid, nlen(1)
-    character(len=512)      :: import_timestr, export_timestr, importexport !debugging only
-    character(len=16)       :: timestr
-    character(len=512)      :: fname
-    character(len=256)      :: subname='MOM_cap:(outputlog_run) '
+    type(ESMF_Time)    :: nextTime, currTime, startTime, prevRing
+    logical            :: lstop
+    integer            :: n, nlen(1)
+    integer            :: filesize
+    character(len=40)  :: importexport
+    character(len=16)  :: timestr
+    character(len=512) :: fname
+    character(len=256) :: subname='MOM_cap:(outputlog_run)'
     !----------------------------------------------------------------------------
 
     rc = ESMF_SUCCESS
 
-    call ESMF_ClockGet(mclock, startTime=startTime, currTime=currTime, timeStep=timeStep, rc=rc)
+    call ESMF_ClockGet(mclock, startTime=startTime, currTime=currTime, rc=rc)
     if (ChkErr(rc,__LINE__,u_FILE_u)) return
-    call ESMF_TimeGet(currTime,          timestring=import_timestr, rc=rc)
+    call ESMF_ClockGetNextTime(mclock, nextTime, rc=rc)
     if (ChkErr(rc,__LINE__,u_FILE_u)) return
-    call ESMF_TimeGet(currTime+timestep, timestring=export_timestr, rc=rc)
+    importexport = get_importexport(currTime, nextTime, rc=rc)
     if (ChkErr(rc,__LINE__,u_FILE_u)) return
-    importexport = trim(import_timestr)//'  '//trim(export_timestr)
 
     lstop = .false.
     if (present(atStopTime)) then
@@ -296,19 +292,13 @@ contains
         ! when the alarm rings, set file check on next advance and construct the filename
         if (ESMF_AlarmIsRinging(olog(n)%alarm, rc=rc)) then
           if (ChkErr(rc,__LINE__,u_FILE_u)) return
-          ! if (debug .and. is_root_pe()) then
-          !   print *,'XXXX alarm is ringing '//trim(importexport)
-          ! end if
           call ESMF_AlarmRingerOff(olog(n)%alarm, rc=rc )
           if (ChkErr(rc,__LINE__,u_FILE_u)) return
           olog(n)%chkfile_nextAdvance = .true.
 
-          call ESMF_ClockGetNextTime(mclock, nextTime, rc=rc)
-          if (ChkErr(rc,__LINE__,u_FILE_u)) return
-          timestr = get_timestr(nextTime-olog(n)%filename_fhoffset+olog(n)%fh_iauoffset, rc)
+          timestr = get_timestr(nextTime-olog(n)%filename_fhoffset, rc=rc)
           if (ChkErr(rc,__LINE__,u_FILE_u)) return
           write(olog(n)%filename,'(A)')trim(outputdir)//'ocn_'//trim(timestr)//'.nc'
-
           if (debug .and. is_root_pe()) then
              print '(A,L)',trim(subname)//' fname '//trim(olog(n)%filename)//'  '//trim(importexport) &
                   //' checkflag ',olog(n)%chkfile_nextAdvance
@@ -320,35 +310,39 @@ contains
           inquire(file=fname, exist=existflag)
           if (existflag) then
             if (is_root_pe()) then
-              nlen(1) = get_unlimited_len(trim(fname), trim(importexport))
+              nlen(1) = get_unlimited_len(trim(fname))
             end if
             call ESMF_VMBroadCast(vm, nlen, 1, 0, rc=rc)
             if (ChkErr(rc,__LINE__,u_FILE_u)) return
+
             if (nlen(1) > 0) then
               olog(n)%chkfile_nextAdvance = .false.
               olog(n)%time_lastrestart = lastrestart
               if (is_root_pe()) then
-                call log_restart_fh(currTime-olog(n)%fhoffset+olog(n)%fh_iauoffset, startTime, &
-                     'mom6.'//chour, prefixtime=.true., &
-                     lastrestart=olog(n)%time_lastrestart, lastoutput=olog(n)%filename, rc=rc)
-                if (ChkErr(rc,__LINE__,u_FILE_u)) return
+                if (toffset > 0) then
+                  call log_restart_fh(nextTime-olog(n)%fhoffset, startTime, 'mom6.'//chour, prefixtime=.true., &
+                       lastrestart=olog(n)%time_lastrestart, lastoutput=olog(n)%filename, rc=rc)
+                  if (ChkErr(rc,__LINE__,u_FILE_u)) return
+                else
+                  call log_restart_fh(currTime-olog(n)%fhoffset, startTime, 'mom6.'//chour, prefixtime=.true., &
+                       lastrestart=olog(n)%time_lastrestart, lastoutput=olog(n)%filename, rc=rc)
+                  if (ChkErr(rc,__LINE__,u_FILE_u)) return
+                end if
               endif
             end if
           end if ! existflag
         end if
+
+        if (debug .and. is_root_pe()) call debug_info(trim(subname)//'  ',trim(fname), &
+             olog(n)%chkfile_nextAdvance, importexport)
 
         if (lstop) then
           ! use prevRing in place of currTime to allow for stopping between averaging intervals
           ! prevring == currTime if stopping on intervals
           call ESMF_AlarmGet(olog(n)%alarm, prevRingTime=prevring, rc=rc)
           if (ChkErr(rc,__LINE__,u_FILE_u)) return
-          if (debug .and. is_root_pe()) then
-            timestr = get_timestr(prevring, rc)
-            if (ChkErr(rc,__LINE__,u_FILE_u)) return
-            print '(A)',trim(subname)//' prevring at lstop '//trim(timestr)
-          end if
 
-          timestr = get_timestr(prevring-30*freq(n)*tincrement, rc)
+          timestr = get_timestr(prevring-30*freq(n)*tincrement, rc=rc)
           if (ChkErr(rc,__LINE__,u_FILE_u)) return
           write(olog(n)%filename,'(A)')trim(outputdir)//'ocn_'//trim(timestr)//'.nc'
           if (debug .and. is_root_pe()) then
@@ -359,15 +353,14 @@ contains
           inquire(file=fname, exist=existflag)
           if (existflag) then
             if (is_root_pe()) then
-              nlen(1) = get_unlimited_len(fname,trim(importexport))
+              nlen(1) = get_unlimited_len(fname)
             end if
             call ESMF_VMBroadCast(vm, nlen, 1, 0, rc=rc)
             if (ChkErr(rc,__LINE__,u_FILE_u)) return
+
             if (nlen(1) > 0) then
               olog(n)%chkfile_nextAdvance = .false.
               olog(n)%time_lastrestart = lastrestart
-              call ESMF_ClockGet(mclock, currTime=currTime, rc=rc)
-              if (ChkErr(rc,__LINE__,u_FILE_u)) return
               if (is_root_pe()) then
                 call log_restart_fh(prevring, startTime, 'mom6.stop.'//chour, prefixtime=.true., &
                      lastrestart=olog(n)%time_lastrestart, lastoutput=olog(n)%filename, rc=rc)
@@ -375,26 +368,14 @@ contains
               end if
             end if
           end if
+
+          if (debug .and. is_root_pe()) call debug_info(trim(subname)//' lstop ',trim(fname), &
+              olog(n)%chkfile_nextAdvance, importexport)
         end if ! lstop
-
-        if (debug .and. is_root_pe()) then
-          fname = trim(olog(n)%filename)
-          inquire(file=fname, exist=existflag)
-          if (existflag) then
-            nlen(1) = get_unlimited_len(fname,' ')
-            write(msgString,'(A)')trim(subname)//trim(fname)//' exists '//trim(importexport)
-            if (nlen(1) > 0) then
-              print '(A,L)',trim(msgString)//' complete ',olog(n)%chkfile_nextAdvance
-            else
-              print '(A,L)',trim(msgString)//' still  0 ',olog(n)%chkfile_nextAdvance
-            end if
-          end if
-        end if
-
       end if ! chour = output_fh
     end do
-
   end subroutine outputlog_run
+
   !> Check all restart files to determine if output has been completed
   !!
   !! @param clock          an ESMF_Clock object
@@ -406,30 +387,26 @@ contains
     integer, intent(out) :: rc             !< return code
 
     ! local variables
-    type(ESMF_Time)         :: startTime, currTime, nextTime
-    type(ESMF_TimeInterval) :: timestep
-    integer                 :: n, ncid, dimid, nlen(1)
-    integer                 :: year, month, day, hour, minute, seconds
-    character(len=512)      :: fname
-    character(len=15)       :: timestr
-    character(len=256)      :: import_timestr, export_timestr, importexport !debugging only
-    logical, allocatable    :: allDone(:)
-    character(len=8)        :: suffix
-    character(len=256)      :: subname='MOM_cap:(outputlog_restart) '
+    type(ESMF_Time)      :: startTime, currTime, nextTime
+    integer              :: n, nlen(1)
+    integer              :: year, month, day, hour, minute, seconds
+    character(len=512)   :: fname
+    character(len=15)    :: timestr
+    character(len=40)    :: importexport
+    logical, allocatable :: allDone(:)
+    character(len=8)     :: suffix
+    character(len=256)   :: subname='MOM_cap:(outputlog_restart)'
     !----------------------------------------------------------------------------
 
     rc = ESMF_SUCCESS
 
-    call ESMF_ClockGet(mclock, startTime=startTime, currTime=currTime, timeStep=timeStep, rc=rc)
+    call ESMF_ClockGet(mclock, startTime=startTime, currTime=currTime, rc=rc)
     if (ChkErr(rc,__LINE__,u_FILE_u)) return
-    call ESMF_TimeGet(currTime,          timestring=import_timestr, rc=rc)
-    if (ChkErr(rc,__LINE__,u_FILE_u)) return
-    call ESMF_TimeGet(currTime+timestep, timestring=export_timestr, rc=rc)
-    if (ChkErr(rc,__LINE__,u_FILE_u)) return
-    importexport = trim(import_timestr)//'  '//trim(export_timestr)
-
     call ESMF_ClockGetNextTime(mclock, nextTime, rc=rc)
     if (ChkErr(rc,__LINE__,u_FILE_u)) return
+    importexport = get_importexport(currTime, nextTime, rc=rc)
+    if (ChkErr(rc,__LINE__,u_FILE_u)) return
+
     call ESMF_TimeGet (nextTime, yy=year, mm=month, dd=day, h=hour, m=minute, s=seconds, rc=rc )
     if (ChkErr(rc,__LINE__,u_FILE_u)) return
     write(timestr,'(I4.4,2(I2.2),A,3(I2.2))') year, month, day,".", hour, minute, seconds
@@ -448,20 +425,19 @@ contains
       if (len_trim(suffix) == 0) then
         fname = trim(restartdir)//trim(timestr)//'.MOM.res.nc'
       else
-        fname = trim(restartdir)//trim(timestr)//'.MOM.res_'//trim(suffix)//'nc'
+        fname = trim(restartdir)//trim(timestr)//'.MOM.res'//trim(suffix)//'.nc'
       endif
 
       ! check if file is written
       inquire(file=trim(fname), exist=existflag)
       if (existflag) then
         if (is_root_pe())then
-          nlen(1) = get_unlimited_len(trim(fname),' ')
+          nlen(1) = get_unlimited_len(trim(fname))
         end if
         call ESMF_VMBroadCast(vm, nlen, 1, 0, rc=rc)
         if (ChkErr(rc,__LINE__,u_FILE_u)) return
 
         if (nlen(1) > 0) allDone(n) = .true.
-
         if (debug .and. is_root_pe()) then
           if (nlen(1) > 0) then
             print '(A)',trim(subname)//' restart '//trim(fname)//'  '//trim(importexport)//' complete'
@@ -479,62 +455,95 @@ contains
         if (ChkErr(rc,__LINE__,u_FILE_u)) return
       endif
     end if
-
   end subroutine outputlog_restart
-
   !> Return the length of the unlimited dimension
   !!
   !! @param[in]  fname   the file name
   !! @return             unlimited dimension length
-  integer function get_unlimited_len(fname,string) result(unlen)
+  integer function get_unlimited_len(fname) result(unlen)
 
     character(len=*), intent(in) :: fname
-    character(len=*), intent(in) :: string
 
     integer :: ncid, dimid
-    ! debug
-    integer :: varid
-    real(kind=8) :: tval
-    character(len=4) :: dimname
     !----------------------------------------------------------------------------
 
-    tval = 1.0e36
-    dimname = ''
     unlen = 0
     call nf90_err(nf90_open(trim(fname), nf90_nowrite, ncid), 'nf90_open: '//trim(fname))
     call nf90_err(nf90_inquire(ncid, unlimiteddimid=dimid), 'inquire unlimiteddimid')
     call nf90_err(nf90_inquire_dimension(ncid, dimid, len=unlen), 'inquire unlimited dimension')
-    if (unlen > 0) then
-      call nf90_err(nf90_inquire_dimension(ncid, dimid, name=dimname), 'inquire unlimited dimension name')
-      call nf90_err(nf90_inq_varid(ncid, dimname, varid), 'get variable Id: unlimited dimension '//trim(fname))
-      call nf90_err(nf90_get_var(ncid, varid, tval), 'get variable: unlimited dimension value '//trim(fname))
-    end if
     call nf90_err(nf90_close(ncid), 'close: '//trim(fname))
-
-    if (len_trim(string) > 0) then
-      print '(A,g14.7,i8)','checkdim '//trim(string)//' '//trim(dimname)//' =  ',tval,unlen
-    end if
-
   end function get_unlimited_len
-  !> Convert ESMF_Time to a formatted 16-character string
-  !!
-  !! @param[in]  timevalue   an ESMF_Time object
-  !! @param[out] rc          return code
-  !! @return                 16-character formatted time string (YYYY_MM_DD_HH_MM)
-  character(len=16) function get_timestr(timevalue, rc) result(timestr)
 
-    type(ESMF_Time), intent(in)  :: timevalue
+  !> Convenience function to return a 16-character time string
+  !!
+  !! @param[in]  MyTime   an ESMF_Time object
+  !! @param[out] rc       return code
+  !! @return              16-character formatted time string (YYYY_MM_DD_HH_MM)
+  character(len=16) function get_timestr(MyTime, rc) result(timestr)
+
+    type(ESMF_Time), intent(in)  :: MyTime
     integer,         intent(out) :: rc
 
     integer :: year, month, day, hour, minute
     !----------------------------------------------------------------------------
-
     rc = ESMF_SUCCESS
-    call ESMF_TimeGet(timevalue, yy=year, mm=month, dd=day, h=hour, m=minute, rc=rc)
+
+    call ESMF_TimeGet(MyTime, yy=year, mm=month, dd=day, h=hour, m=minute, rc=rc)
     if (ChkErr(rc,__LINE__,u_FILE_u)) return
     write(timestr,'(I4.4,4(A,I2.2))')year,'_',month,'_',day,'_',hour,'_',minute
-
   end function get_timestr
+
+  !> Convenience function to return import/export timestring
+  !!
+  !! @param[in]  currTime   an ESMF_Time object
+  !! @param[in]  nextTime   an ESMF_Time object
+  !! @param[out] rc         return code
+  !! @return                40-character string
+  character(len=40) function get_importexport(currTime, nextTime, rc) result(importexport)
+
+    type(ESMF_Time), intent(in)  :: currTime, nextTime
+    integer,         intent(out) :: rc
+
+    character(len=19) :: import_timestr, export_timestr
+    !----------------------------------------------------------------------------
+    rc = ESMF_SUCCESS
+
+    call ESMF_TimeGet(currTime, timestring=import_timestr, rc=rc)
+    if (ChkErr(rc,__LINE__,u_FILE_u)) return
+    call ESMF_TimeGet(nextTime, timestring=export_timestr, rc=rc)
+    if (ChkErr(rc,__LINE__,u_FILE_u)) return
+    importexport = trim(import_timestr)//'  '//trim(export_timestr)
+  end function get_importexport
+
+  !> Write debug info to stdout
+  !!
+  !! @param[in] tag            an information tag
+  !! @param[in] fname          the filename to check
+  !! @param[in] chkflag        logical flag for checking next Advance
+  !! @param[in] timestring     a timestring
+  !! @param [out]rc            return code
+  subroutine debug_info(tag,fname,chkflag,timestring)
+
+    character(len=*), intent(in) :: tag
+    character(len=*), intent(in) :: fname
+    logical,          intent(in) :: chkflag
+    character(len=*), intent(in) :: timestring
+
+    integer :: nlen(1), filesize
+    !----------------------------------------------------------------------------
+
+    inquire(file=fname, exist=existflag, size=filesize)
+    if (existflag) then
+      nlen(1) = get_unlimited_len(fname)
+      write(msgString,'(A)')tag//'  '//fname//' exists '//timestring
+      if (nlen(1) > 0) then
+        print '(A,L,i14)',trim(msgString)//' complete, chkflag ',chkflag,filesize
+      else
+        print '(A,L,i14)',trim(msgString)//' still  0, chkflag ',chkflag,filesize
+      end if
+    end if
+  end subroutine debug_info
+
   !> Handle netcdf errors
   !!
   !! @param[in]  ierr        the error code
@@ -553,7 +562,6 @@ contains
       !stop ierr
       stop 99
     end if
-
   end subroutine nf90_err
 #endif
 end module MOM_cap_outputlog

--- a/config_src/drivers/nuopc_cap/mom_cap_outputlog.F90
+++ b/config_src/drivers/nuopc_cap/mom_cap_outputlog.F90
@@ -52,8 +52,8 @@ contains
   ! the allowable output frequency for MOM6 history, in hours only
   integer, parameter :: n_freq  = 3
   integer, parameter, dimension(n_freq) :: freq = (/3, 6, 24/)
-  ! TODO: check multiple output freq for same run, reqs different  known filename
-  ! root for different freqs
+  ! TODO: for multiple output freq in same run, a different known filename
+  ! root for different freqs needs to be read in, consistent with the diag table
 
   ! the tincrement interval (defined in minutes) is used to construct the output filename
   ! the file name must be set as the mid-point of the averaging period via the diagtable
@@ -85,9 +85,13 @@ contains
   ! a different log file name is required for the final log file, otherwise the next-to-final
   ! log is overwritten
   !
-  ! TODO: explain why filesize is also a criteria
-  ! an output file is declared closed when the unlimited dimension in the file is > 0
-  ! each closed output file is recorded in a logfile named with the associated forecast hour.
+  ! Depending on configuration, the output file can have an unlimited dimension >0 at creation time.
+  ! This necessitates checking for an additional criteria using the filesize at creation. An output file
+  ! is declared complete either when the unlimited dimension in the file is > 0 or when the unlimited
+  ! dimension is >0 and the filesize is larger than the initial size.
+
+  ! When a file is determined to be complete, a log file is recorded containing the forecast hour, the valid
+  ! time, the name of the output file and the last completed restart file.
 
   type(ESMF_VM)           :: vm
   type(ESMF_TimeInterval) :: tincrement
@@ -253,7 +257,7 @@ contains
     end do
   end subroutine outputlog_init
 
-  !> Use Alarms at the output frequency to determine if output has been completed
+  !> Write a log file denoting that an output file is complete
   !!
   !! @param clock        an ESMF_Clock object
   !! @param atStopTime   when present, checks for final output file
@@ -267,7 +271,7 @@ contains
     ! local variables
     type(ESMF_Time)    :: nextTime, currTime, startTime, prevRing
     logical            :: lstop
-    logical            :: filetest
+    logical            :: filecomplete
     integer            :: n, nlen(1), fsize(1)
     character(len=40)  :: importexport
     character(len=16)  :: timestr
@@ -289,7 +293,7 @@ contains
       lstop = atStopTime
     end if
 
-    filetest = .false.
+    filecomplete = .false.
     fsize(1) = nf90_fill_int
     nlen(1)  = nf90_fill_int
 
@@ -337,10 +341,10 @@ contains
 
         if (olog(n)%chkfile_nextAdvance) then
           fname = trim(olog(n)%filename)
-          filetest = file_is_complete(fname, olog(n)%use_filesize, olog(n)%createsize, rc)
+          filecomplete = file_is_complete(fname, olog(n)%use_filesize, olog(n)%createsize, rc)
           if (ChkErr(rc,__LINE__,u_FILE_u)) return
 
-          if (filetest) then
+          if (filecomplete) then
             olog(n)%chkfile_nextAdvance = .false.
             olog(n)%time_lastrestart = lastrestart
             if (is_root_pe()) then
@@ -364,10 +368,10 @@ contains
           write(olog(n)%filename,'(A)')trim(outputdir)//'ocn_'//trim(timestr)//'.nc'
 
           fname = trim(olog(n)%filename)
-          filetest = file_is_complete(fname, olog(n)%use_filesize, olog(n)%createsize, rc)
+          filecomplete = file_is_complete(fname, olog(n)%use_filesize, olog(n)%createsize, rc)
           if (ChkErr(rc,__LINE__,u_FILE_u)) return
 
-          if (filetest) then
+          if (filecomplete) then
             olog(n)%chkfile_nextAdvance = .false.
             olog(n)%time_lastrestart = lastrestart
             if (is_root_pe()) then
@@ -471,7 +475,8 @@ contains
   !! @param[in]   chk4size      logical flag for check method in use
   !! @param[in]   createsize    the filesize at creation
   !! @param[out]  rc            return code
-  logical function file_is_complete(fname, chk4size, createsize, rc) result(filetest)
+  !! @return                    logical flag, true if the file is complete
+  logical function file_is_complete(fname, chk4size, createsize, rc) result(filecomplete)
 
     character(len=*), intent(in)  :: fname
     logical,          intent(in)  :: chk4size
@@ -483,7 +488,7 @@ contains
 
     rc = ESMF_SUCCESS
 
-    filetest = .false.
+    filecomplete = .false.
     nlen(1) = nf90_fill_int
     fsize(1) = nf90_fill_int
 
@@ -500,9 +505,9 @@ contains
     end if
 
     if (chk4size) then
-      filetest = (nlen(1) > 0 .and. fsize(1) > createsize)
+      filecomplete = (nlen(1) > 0 .and. fsize(1) > createsize)
     else
-      filetest = (nlen(1) > 0)
+      filecomplete = (nlen(1) > 0)
     end if
   end function file_is_complete
 
@@ -569,12 +574,12 @@ contains
 
   !> Write debug info to stdout, only called on root pe
   !!
-  !! @param[in] tag            an information tag
-  !! @param[in] fname          the filename to check
-  !! @param[in] filesize       the filesize at creation time
-  !! @param[in] chkflag        logical flag for checking next Advance
-  !! @param[in] timestring     a timestring
-  !! @param [out]rc            return code
+  !! @param[in]    tag            an information tag
+  !! @param[in]    fname          the filename to check
+  !! @param[in]    filesize       the filesize at creation time
+  !! @param[in]    chkflag        logical flag for checking next Advance
+  !! @param[in]    timestring     a timestring
+  !! @param [out]  rc             return code
   subroutine debug_info(tag,fname,chkflag,filesize,timestring)
 
     character(len=*), intent(in) :: tag

--- a/config_src/drivers/nuopc_cap/mom_cap_outputlog.F90
+++ b/config_src/drivers/nuopc_cap/mom_cap_outputlog.F90
@@ -213,9 +213,8 @@ contains
     ! initialize
     lastrestart = startTime
 
-    call ESMF_TimeGet (mcurrTime-iau_offset*30*tincrement, yy=year, mm=month, dd=day, h=hour, m=minute, rc=rc )
+    timestr = get_timestr(mcurrTime-iau_offset*30*tincrement, rc)
     if (ChkErr(rc,__LINE__,u_FILE_u)) return
-    write(timestr,'(I4.4,4(A,I2.2))')year,'_',month,'_',day,'_',hour,'_',minute
     if (debug .and. is_root_pe())print *,'XXX ',trim(timestr)
 
     do n = 1,n_freq
@@ -268,7 +267,7 @@ contains
     type(ESMF_Time)         :: nextTime, currTime, startTime, prevRing
     type(ESMF_TimeInterval) :: timeStep
     logical                 :: lstop
-  integer                 :: n, ncid, dimid, nlen(1)
+    integer                 :: n, ncid, dimid, nlen(1)
     integer                 :: year, month, day, hour, minute
     character(len=512)      :: import_timestr, export_timestr, importexport !debugging only
     character(len=16)       :: timestr
@@ -308,9 +307,8 @@ contains
 
           call ESMF_ClockGetNextTime(mclock, nextTime, rc=rc)
           if (ChkErr(rc,__LINE__,u_FILE_u)) return
-          call ESMF_TimeGet (nextTime-olog(n)%filename_fhoffset, yy=year, mm=month, dd=day, h=hour, m=minute, rc=rc )
+          timestr = get_timestr(nextTime-olog(n)%filename_fhoffset, rc)
           if (ChkErr(rc,__LINE__,u_FILE_u)) return
-          write(timestr,'(I4.4,4(A,I2.2))')year,'_',month,'_',day,'_',hour,'_',minute
           write(olog(n)%filename,'(A)')trim(outputdir)//'ocn_'//trim(timestr)//'.nc'
 
           if (debug .and. is_root_pe()) then
@@ -345,15 +343,13 @@ contains
           call ESMF_AlarmGet(olog(n)%alarm, prevRingTime=prevring, rc=rc)
           if (ChkErr(rc,__LINE__,u_FILE_u)) return
           if (debug .and. is_root_pe()) then
-            call ESMF_TimeGet(prevring, yy=year, mm=month, dd=day, h=hour, m=minute, rc=rc)
+            timestr = get_timestr(prevring, rc)
             if (ChkErr(rc,__LINE__,u_FILE_u)) return
-            write(timestr,'(I4.4,4(A,I2.2))')year,'_',month,'_',day,'_',hour,'_',minute
             print '(A)',trim(subname)//' prevring at lstop '//trim(timestr)
           end if
 
-          call ESMF_TimeGet(prevring-30*freq(n)*tincrement, yy=year, mm=month, dd=day, h=hour, m=minute, rc=rc)
+          timestr = get_timestr(prevring-30*freq(n)*tincrement, rc)
           if (ChkErr(rc,__LINE__,u_FILE_u)) return
-          write(timestr,'(I4.4,4(A,I2.2))')year,'_',month,'_',day,'_',hour,'_',minute
           write(olog(n)%filename,'(A)')trim(outputdir)//'ocn_'//trim(timestr)//'.nc'
           if (debug .and. is_root_pe()) then
             print '(A)',trim(subname)//' fname at lstop '//trim(olog(n)%filename)//'  '//trim(importexport)
@@ -504,14 +500,32 @@ contains
     call nf90_err(nf90_close(ncid), 'close: '//trim(fname))
 
   end function get_unlimited_len
+  !> Convert ESMF_Time to a formatted 16-character string
+  !!
+  !! @param[in]  timevalue   an ESMF_Time object
+  !! @param[out] rc          return code
+  !! @return                 16-character formatted time string (YYYY_MM_DD_HH_MM)
+  character(len=16) function get_timestr(timevalue, rc) result(timestr)
 
+    type(ESMF_Time), intent(in)  :: timevalue
+    integer,         intent(out) :: rc
+
+    integer :: year, month, day, hour, minute
+    !----------------------------------------------------------------------------
+
+    rc = ESMF_SUCCESS
+    call ESMF_TimeGet(timevalue, yy=year, mm=month, dd=day, h=hour, m=minute, rc=rc)
+    if (ChkErr(rc,__LINE__,u_FILE_u)) return
+    write(timestr,'(I4.4,4(A,I2.2))')year,'_',month,'_',day,'_',hour,'_',minute
+
+  end function get_timestr
   !> Handle netcdf errors
   !!
   !! @param[in]  ierr        the error code
   !! @param[in]  string      the error message
   subroutine nf90_err(ierr, string)
 
-    integer ,         intent(in) :: ierr
+    integer,          intent(in) :: ierr
     character(len=*), intent(in) :: string
     !----------------------------------------------------------------------------
 

--- a/config_src/drivers/nuopc_cap/mom_cap_outputlog.F90
+++ b/config_src/drivers/nuopc_cap/mom_cap_outputlog.F90
@@ -362,7 +362,7 @@ contains
               olog(n)%chkfile_nextAdvance = .false.
               olog(n)%time_lastrestart = lastrestart
               if (is_root_pe()) then
-                call log_restart_fh(prevring, startTime, 'mom6.stop.'//chour, prefixtime=.true., &
+                call log_restart_fh(prevring, startTime, 'mom6.'//chour, prefixtime=.true., &
                      lastrestart=olog(n)%time_lastrestart, lastoutput=olog(n)%filename, rc=rc)
                 if (ChkErr(rc,__LINE__,u_FILE_u)) return
               end if
@@ -407,7 +407,7 @@ contains
     importexport = get_importexport(currTime, nextTime, rc=rc)
     if (ChkErr(rc,__LINE__,u_FILE_u)) return
 
-    call ESMF_TimeGet (nextTime, yy=year, mm=month, dd=day, h=hour, m=minute, s=seconds, rc=rc )
+    call ESMF_TimeGet(nextTime, yy=year, mm=month, dd=day, h=hour, m=minute, s=seconds, rc=rc )
     if (ChkErr(rc,__LINE__,u_FILE_u)) return
     write(timestr,'(I4.4,2(I2.2),A,3(I2.2))') year, month, day,".", hour, minute, seconds
 

--- a/config_src/drivers/nuopc_cap/mom_cap_outputlog.F90
+++ b/config_src/drivers/nuopc_cap/mom_cap_outputlog.F90
@@ -1,6 +1,9 @@
 !> This module contains a set of subroutines that check if MOM
-!! history files have been written and closed. It is a stub routine
-!! when CESMCOUPLED is defined
+!! history files have been written and closed. This file is
+!! specific to UWM operational requirements and configurations
+!! (eg specific output frequencys in hours) and may break if
+!! used outside the scope of intended use.
+!! This module a stub when CESMCOUPLED is defined
 module MOM_cap_outputlog
 
 #ifdef CESMCOUPLED
@@ -9,8 +12,9 @@ module MOM_cap_outputlog
 
   public :: outputlog_init, outputlog_run
 contains
-  subroutine outputlog_init(mclock, rc)
+  subroutine outputlog_init(gcomp, mclock, rc)
 
+    type(ESMF_GridComp)  :: gcomp  !< an ESMF_GridComp object
     type(ESMF_Clock)     :: mclock !< the ESMF_clock for the model
     integer, intent(out) :: rc     !< return code
     rc = ESMF_SUCCESS
@@ -22,7 +26,7 @@ contains
   end subroutine outputlog_run
 end module MOM_cap_outputlog
 #else
-  use MOM_error_handler,      only: is_root_pe
+  use MOM_error_handler,      only : is_root_pe
   use ESMF                  , only : ESMF_Time, ESMF_Clock, ESMF_ClockGet, ESMF_Alarm, ESMF_AlarmSet
   use ESMF                  , only : ESMF_ClockGetAlarm, ESMF_AlarmIsRinging, ESMF_AlarmRingerOff
   use ESMF                  , only : ESMF_ClockGetNextTime, ESMF_TimeGet, ESMF_TimeInterval
@@ -40,11 +44,11 @@ end module MOM_cap_outputlog
   public :: outputlog_init, outputlog_run
 
   ! the allowable output frequency for MOM6 history, in hours only
-  !integer, parameter :: n_freq  = 3
-  !integer, parameter, dimension(n_freq) :: freq = (/3, 6, 24/)
-
-  integer, parameter :: n_freq  = 1
-  integer, parameter, dimension(n_freq) :: freq = (/24/)
+  ! TODO: 3hrly output reqs filename with minutes field
+  ! TODO: check multiple output freq for same run, reqs different
+  ! known filename root for different freqs
+  integer, parameter :: n_freq  = 3
+  integer, parameter, dimension(n_freq) :: freq = (/3, 6, 24/)
 
   ! the timeoffset interval is used only to construct the file name.
   ! filenames will be given by T - (interval * offset + interval/2 * offset)
@@ -52,32 +56,35 @@ end module MOM_cap_outputlog
   !   00   .     06   .   12   .  18
   !        03 = 12 - (6 + 3)
   !                  09 = 18 - (6 + 3)
-  !! the timeoffset must be defined in minutes to allow sub-6hrly output
+  ! the timeoffset must be defined in minutes to allow sub-6hrly output
   type(ESMF_TimeInterval) :: timeoffset
 
   type :: outputlog_type
-    character(len=256)      :: alarm_name
+    character(len=128)      :: alarm_name
     integer                 :: opt_n
     logical                 :: chkfile_nextAdvance
-    character(len=256)      :: filename
+    character(len=1024)     :: filename
     type(ESMF_Alarm)        :: alarm
     type(ESMF_TimeInterval) :: filename_timeoffset
   end type outputlog_type
 
   type(outputlog_type) :: olog(n_freq)
 
-  character(len=3) :: chour
+  character(len=256) :: outputdir
+  character(len=2)   :: output_fh
+  character(len=3)   :: chour
   character(len=*), parameter :: u_FILE_u = &
        __FILE__
 
 contains
 
-!> Initialize a set of Alarms at the diagnostic output frequency
+!> Initialize a set of Alarms at the allowed output frequencies
 !!
 !! @param clock an ESMF_Clock object
 !! @param rc return code
-  subroutine outputlog_init(mclock, rc)
+  subroutine outputlog_init(gcomp, mclock, rc)
 
+    type(ESMF_GridComp)  :: gcomp  !< an ESMF_GridComp object
     type(ESMF_Clock)     :: mclock !< the ESMF_clock for the model
     integer, intent(out) :: rc     !< return code
 
@@ -85,10 +92,31 @@ contains
     type(ESMF_Time)         :: mcurrtime
     type(ESMF_TimeInterval) :: timestep
     integer                 :: n
+    character(len=256)      :: value
     character(len=256)      :: subname='MOM_cap:(outputlog_init) '
     !--------------------------------
 
     rc = ESMF_SUCCESS
+
+    call NUOPC_CompAttributeGet(gcomp, name="mom6_outputdir", value=value, &
+         isPresent=isPresent, isSet=isSet, rc=rc)
+    if (ChkErr(rc,__LINE__,u_FILE_u)) return
+    if (isPresent .and. isSet) then
+      outputdir = trim(value)
+    else
+      outputdir = './'
+    end if
+    call ESMF_LogWrite('MOM_cap:MOM6 output directory = '//trim(outputdir), ESMF_LOGMSG_INFO)
+
+    call NUOPC_CompAttributeGet(gcomp, name="mom6_output_fh", value=value, &
+         isPresent=isPresent, isSet=isSet, rc=rc)
+    if (ChkErr(rc,__LINE__,u_FILE_u)) return
+    if (isPresent .and. isSet) then
+      write(output_fh, '(a2)')trim(value)
+    else
+      output_fh = '06'
+    end if
+    call ESMF_LogWrite('MOM_cap:MOM6 output frequency = '//trim(output_fh), ESMF_LOGMSG_INFO)
 
     call ESMF_ClockGet(mclock, currTime=mcurrtime, rc=rc)
     if (ChkErr(rc,__LINE__,u_FILE_u)) return
@@ -118,7 +146,7 @@ contains
       call ESMF_LogWrite(subname//" Output alarm "//trim(olog(n)%alarm_name)//" is Created and Set", ESMF_LOGMSG_INFO)
     end do
   end subroutine outputlog_init
-  !> Use Alarms at the diagnostic output frequency to determine if output has been
+  !> Use Alarms at the output frequency to determine if output has been
   !! completed
   !!
   !! @param clock an ESMF_Clock object
@@ -146,49 +174,56 @@ contains
     if (ChkErr(rc,__LINE__,u_FILE_u)) return
     call ESMF_TimeGet(currTime+timestep, timestring=export_timestr, rc=rc)
     if (ChkErr(rc,__LINE__,u_FILE_u)) return
-!#ifdef test
+
     do n = 1,n_freq
       write(chour,'(i2.2,a)')freq(n),'h'
-      call ESMF_ClockGetAlarm(mclock, alarmname=trim(olog(n)%alarm_name), alarm=olog(n)%alarm, rc=rc)
-      if (ChkErr(rc,__LINE__,u_FILE_u)) return
-      if (ESMF_AlarmIsRinging(olog(n)%alarm, rc=rc)) then
+      if (chour == outputfh(1:2)) then
+        call ESMF_ClockGetAlarm(mclock, alarmname=trim(olog(n)%alarm_name), alarm=olog(n)%alarm, rc=rc)
         if (ChkErr(rc,__LINE__,u_FILE_u)) return
-        olog(n)%chkfile_nextAdvance = .true.
-        ! turn off the alarm
-        call ESMF_AlarmRingerOff(olog(n)%alarm, rc=rc )
-        if (ChkErr(rc,__LINE__,u_FILE_u)) return
-        ! set filename
-        call ESMF_ClockGetNextTime(mclock, nextTime, rc=rc)
-        if (ChkErr(rc,__LINE__,u_FILE_u)) return
-        call ESMF_TimeGet (nextTime-olog(n)%filename_timeoffset, yy=year, mm=month, dd=day, h=hour, m=minute, rc=rc )
-        if (ChkErr(rc,__LINE__,u_FILE_u)) return
-        write(olog(n)%filename,'(a,i4.4,4(a,i2.2),a)')'ocn_',year,'_',month,'_',day,'_',hour,'_',minute,'.nc'
-        if(is_root_pe())print *,'XX0 '//trim(olog(n)%filename)//'  '//trim(import_timestr)//'  '//trim(export_timestr)
-      end if
-
-      if (olog(n)%chkfile_nextAdvance) then
-        ! check if file is written
-        fname = trim(olog(n)%filename)
-        inquire(file=fname, exist=existflag)
-        if (existflag) then
-          call nf90_err(nf90_open(fname, nf90_nowrite, ncid), 'nf90_open: '//fname)
-          call nf90_err(nf90_inquire(ncid, unlimiteddimid=dimid), 'inquire unlimiteddimid')
-          call nf90_err(nf90_inquire_dimension(ncid, dimid, len=nlen), 'inquire unlimited dimension')
-          call nf90_err(nf90_close(ncid), 'close: '//fname)
-          if (nlen > 0) then
-            olog(n)%chkfile_nextAdvance = .false.
-            if (is_root_pe()) then
-              call log_restart_fh(currTime+timestep, startTime, 'mom6.'//chour, prefixtime=.true., rc=rc)
-              if (ChkErr(rc,__LINE__,u_FILE_u)) return
-            endif
-            if(is_root_pe())print *,'XX '//trim(olog(n)%filename)//'  '//trim(import_timestr)//'  '//trim(export_timestr)//' complete'
+        if (ESMF_AlarmIsRinging(olog(n)%alarm, rc=rc)) then
+          if (ChkErr(rc,__LINE__,u_FILE_u)) return
+          olog(n)%chkfile_nextAdvance = .true.
+          ! turn off the alarm
+          call ESMF_AlarmRingerOff(olog(n)%alarm, rc=rc )
+          if (ChkErr(rc,__LINE__,u_FILE_u)) return
+          ! set filename
+          call ESMF_ClockGetNextTime(mclock, nextTime, rc=rc)
+          if (ChkErr(rc,__LINE__,u_FILE_u)) return
+          if (freq(n) < 6) then
+             call ESMF_TimeGet (nextTime-olog(n)%filename_timeoffset, yy=year, mm=month, dd=day, h=hour, m=minute, rc=rc )
+             if (ChkErr(rc,__LINE__,u_FILE_u)) return
+             write(olog(n)%filename,'(a,i4.4,4(a,i2.2),a)')trim(outputdir)//'ocn_',year,'_',month,'_',day,'_',hour,'_',minute,'.nc'
           else
-            if(is_root_pe())print *,'XX '//trim(olog(n)%filename)//'  '//trim(import_timestr)//'  '//trim(export_timestr)//' still 0'
+             call ESMF_TimeGet (nextTime-olog(n)%filename_timeoffset, yy=year, mm=month, dd=day, h=hour, rc=rc )
+             if (ChkErr(rc,__LINE__,u_FILE_u)) return
+             write(olog(n)%filename,'(a,i4.4,3(a,i2.2),a)')trim(outputdir)//'ocn_',year,'_',month,'_',day,'_',hour,'.nc'
           end if
+          if(is_root_pe())print *,'XX0 '//trim(olog(n)%filename)//'  '//trim(import_timestr)//'  '//trim(export_timestr)
         end if
-      end if
+
+        if (olog(n)%chkfile_nextAdvance) then
+          ! check if file is written
+          fname = trim(olog(n)%filename)
+          inquire(file=fname, exist=existflag)
+          if (existflag) then
+            call nf90_err(nf90_open(fname, nf90_nowrite, ncid), 'nf90_open: '//fname)
+            call nf90_err(nf90_inquire(ncid, unlimiteddimid=dimid), 'inquire unlimiteddimid')
+            call nf90_err(nf90_inquire_dimension(ncid, dimid, len=nlen), 'inquire unlimited dimension')
+            call nf90_err(nf90_close(ncid), 'close: '//fname)
+            if (nlen > 0) then
+              olog(n)%chkfile_nextAdvance = .false.
+              if (is_root_pe()) then
+                call log_restart_fh(currTime+timestep, startTime, 'mom6.'//chour, prefixtime=.true., rc=rc)
+                if (ChkErr(rc,__LINE__,u_FILE_u)) return
+              endif
+              if(is_root_pe())print *,'XX '//trim(olog(n)%filename)//'  '//trim(import_timestr)//'  '//trim(export_timestr)//' complete'
+            else
+              if(is_root_pe())print *,'XX '//trim(olog(n)%filename)//'  '//trim(import_timestr)//'  '//trim(export_timestr)//' still 0'
+            end if
+          end if ! existflag
+        end if ! chkfile_nextAdvance
+      end if ! chour = output_fh
     end do
-!#endif
 #ifdef test
 
     fname = 'ocn_2011_10_01_10_30.nc'


### PR DESCRIPTION
- fixes #165 

This PR implements adds a new module, ``mom_cap_outputlog.F90`` (a stub for CESMCOUPLED), that will enable output logging diagnostics at a given hourly output frequency of a ModelAdvance via Alarms processing.

It should be remembered that the model clock does not advance until the end of the ModelAdvance, thus each Alarm is referenced to the model's "nextTime". However, the output actually closes one full interval after the end of the averaging period (I don't know why). So the 00-06 average closes at the fh=12 + 1 advance. 

When an output alarm rings, a flag is set to check for file completion on the next ModelAdvance and then write a set of information to a log file. The check flag is then set false. The file is assumed to be complete if the unlimited dimension value is > 0 and (if required) the file size is > than the file size when first created.

The actual behavior of the file creation/closing can be see by setting a MOM6 attribute (``debug_outputlog = true``) which will enable a series of messages written to stdout. The following is a snip, where the field (still 0//complete) gives the status check using the unlimited dimension length and the final field is the state of the ``check_nextAdvance`` flag.

```
438: 40: MOM_cap:(outputlog_run) fname ./ocn_2011_10_01_03_00.nc  2011-10-01T11:00:00  2011-10-01T12:00:00
439: 40: MOM_cap:(outputlog_run)./ocn_2011_10_01_03_00.nc exists 2011-10-01T11:00:00  2011-10-01T12:00:00 still 0  T
445: 40: MOM_cap:(outputlog_run)./ocn_2011_10_01_03_00.nc exists 2011-10-01T12:00:00  2011-10-01T13:00:00 complete  F
446: 40: MOM_cap:(outputlog_run)./ocn_2011_10_01_03_00.nc exists 2011-10-01T13:00:00  2011-10-01T14:00:00 complete  F
449: 40: MOM_cap:(outputlog_run)./ocn_2011_10_01_03_00.nc exists 2011-10-01T14:00:00  2011-10-01T15:00:00 complete  F
450: 40: MOM_cap:(outputlog_run)./ocn_2011_10_01_03_00.nc exists 2011-10-01T15:00:00  2011-10-01T16:00:00 complete  F
451: 40: MOM_cap:(outputlog_run)./ocn_2011_10_01_03_00.nc exists 2011-10-01T16:00:00  2011-10-01T17:00:00 complete  F
457: 40: MOM_cap:(outputlog_run) fname ./ocn_2011_10_01_09_00.nc  2011-10-01T17:00:00  2011-10-01T18:00:00
458: 40: MOM_cap:(outputlog_run)./ocn_2011_10_01_09_00.nc exists 2011-10-01T17:00:00  2011-10-01T18:00:00 still 0  T
464: 40: MOM_cap:(outputlog_run)./ocn_2011_10_01_09_00.nc exists 2011-10-01T18:00:00  2011-10-01T19:00:00 complete  F
```


When the model stop time is reached, any pending output is written, along with the output (if any) for the final interval. This produces two log files; one for the interval prior to the final interval and one at the final interval; the log file for the very final interval will include the tag ``stop`` (eg ``20111002.000000.mom6.stop.06h``)


