### PR TITLE
[production/GFSv17] Add output directory argument for logs

### DIFF
--- a/config_src/drivers/nuopc_cap/mom_cap_outputlog.F90
+++ b/config_src/drivers/nuopc_cap/mom_cap_outputlog.F90
@@ -350,7 +350,7 @@ contains
             olog(n)%time_lastrestart = lastrestart
             if (is_root_pe()) then
               call log_restart_fh(currTime-olog(n)%fhoffset, startTime, 'mom6.'//chour, prefixtime=.true., &
-                   lastrestart=olog(n)%time_lastrestart, lastoutput=olog(n)%filename, rc=rc)
+                   lastrestart=olog(n)%time_lastrestart, lastoutput=olog(n)%filename, output_dir=outputdir, rc=rc)
               if (ChkErr(rc,__LINE__,u_FILE_u)) return
             endif
           end if
@@ -377,7 +377,7 @@ contains
             olog(n)%time_lastrestart = lastrestart
             if (is_root_pe()) then
               call log_restart_fh(prevring, startTime, 'mom6.lstop.'//chour, prefixtime=.true., &
-                   lastrestart=olog(n)%time_lastrestart, lastoutput=olog(n)%filename, rc=rc)
+                   lastrestart=olog(n)%time_lastrestart, lastoutput=olog(n)%filename, output_dir=outputdir, rc=rc)
               if (ChkErr(rc,__LINE__,u_FILE_u)) return
             end if
           end if
@@ -464,7 +464,7 @@ contains
     if (all(allDone) .eqv. .true.) then
       lastrestart = nextTime
       if (is_root_pe()) then
-        call log_restart_fh(nextTime, startTime, 'mom6.res', prefixtime=.true., rc=rc)
+        call log_restart_fh(nextTime, startTime, 'mom6.res', prefixtime=.true., output_dir=outputdir, rc=rc)
         if (ChkErr(rc,__LINE__,u_FILE_u)) return
       endif
     end if


### PR DESCRIPTION
There is a request from NCO to move the MOM6 logs into the ./MOM6_OUTPUT directory. This change will add that argument to the logging function call in MOM6. There will be a user-controlled feature added to develop soon.